### PR TITLE
feat(karmolab): sidebar/header nav toggle option

### DIFF
--- a/apps/karmolab/css/toolbox.css
+++ b/apps/karmolab/css/toolbox.css
@@ -1274,6 +1274,178 @@ input[type="range"] { width: 100%; accent-color: var(--accent); cursor: pointer;
     animation: spin 0.7s linear infinite;
 }
 
+/* ═══════════════════════════════════════
+   SIDEBAR NAV (data-nav="sidebar" 모드)
+   ═══════════════════════════════════════ */
+
+.sidebar { display: none; }
+
+html[data-nav="sidebar"] .header-nav { display: none !important; }
+html[data-nav="sidebar"] .header-bar-right { grid-column: 3; }
+
+html[data-nav="sidebar"] .sidebar {
+    display: flex;
+    position: fixed;
+    top: 52px; /* header-bar 높이 */
+    left: 0;
+    bottom: 0;
+    width: var(--sidebar-collapsed-width);
+    background: var(--glass-strong);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: blur(14px);
+    border-right: 1px solid var(--border);
+    flex-direction: column;
+    flex-shrink: 0;
+    overflow: hidden;
+    transition: width var(--transition-slow);
+    z-index: 50;
+}
+
+html[data-nav="sidebar"] .sidebar:hover {
+    width: var(--sidebar-width);
+}
+
+html[data-nav="sidebar"] .main-content {
+    margin-left: var(--sidebar-collapsed-width);
+    transition: margin-left var(--transition-slow);
+}
+
+html[data-nav="sidebar"]:has(.sidebar:hover) .main-content {
+    margin-left: var(--sidebar-width);
+}
+
+.sidebar-nav {
+    padding: var(--space-md) var(--space-sm);
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.sidebar-footer {
+    flex-shrink: 0;
+    padding: var(--space-sm);
+    border-top: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    min-height: 40px;
+    position: relative;
+}
+
+.sidebar-dev-links {
+    font-size: var(--font-size-2xs);
+    color: var(--text-tertiary);
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+    position: absolute;
+    left: 9px;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.sidebar-dev-links:hover { color: var(--accent); }
+
+.sidebar-dev-links-icon {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: var(--bg-tertiary);
+    font-size: 11px;
+    font-weight: 700;
+    font-style: italic;
+    color: var(--text-tertiary);
+}
+
+.sidebar-group { margin-top: var(--space-sm); }
+
+.sidebar-group-trigger {
+    display: flex;
+    gap: 6px;
+    width: 100%;
+    padding: 6px 10px 6px 30px;
+    font-size: var(--font-size-2xs);
+    font-weight: 600;
+    color: var(--text-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    transition: color var(--transition);
+    text-align: left;
+    position: relative;
+    cursor: pointer;
+    background: none;
+    border: none;
+}
+
+.sidebar-group-trigger:hover { color: var(--text-secondary); }
+
+.sidebar-group-trigger .chevron {
+    position: absolute;
+    left: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    transition: transform var(--transition);
+}
+
+.sidebar-group-trigger .chevron::before {
+    content: '';
+    position: absolute;
+    left: 1px;
+    top: 2px;
+    width: 4px;
+    height: 4px;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    transform: rotate(-45deg);
+}
+
+.sidebar-group-trigger.open .chevron { transform: translateY(-50%) rotate(90deg); }
+
+.sidebar-group-body { display: none; overflow: hidden; }
+.sidebar-group-body.open { display: block; }
+
+/* 텍스트는 항상 한 줄 — 사이드바 overflow:hidden 이 클리핑 담당 */
+html[data-nav="sidebar"] .sidebar .nav-item-text,
+html[data-nav="sidebar"] .sidebar .sidebar-group-label {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: clip;
+    flex-shrink: 0;
+    transition: opacity var(--transition-slow);
+}
+
+/* 접힌 상태: opacity로만 숨김 (width 조작 없음 → reflow/줄바꿈 없음) */
+html[data-nav="sidebar"] .sidebar:not(:hover) .sidebar-group-label,
+html[data-nav="sidebar"] .sidebar:not(:hover) .nav-item-text {
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* 펼친 상태: 텍스트 페이드인 */
+html[data-nav="sidebar"] .sidebar:hover .sidebar-group-label,
+html[data-nav="sidebar"] .sidebar:hover .nav-item-text {
+    opacity: 1;
+}
+
+html[data-nav="sidebar"] .sidebar:not(:hover) .sidebar-dev-links-icon { display: flex; }
+html[data-nav="sidebar"] .sidebar:not(:hover) .sidebar-dev-links-text { display: none; }
+html[data-nav="sidebar"] .sidebar:hover .sidebar-dev-links-icon { display: flex; }
+html[data-nav="sidebar"] .sidebar:hover .sidebar-dev-links-text { display: inline; }
+
+@media (max-width: 768px) {
+    html[data-nav="sidebar"] .sidebar { display: none; }
+    html[data-nav="sidebar"] .main-content { margin-left: 0; }
+}
+
 /* ── Scrollbar ── */
 
 ::-webkit-scrollbar { width: 4px; }

--- a/apps/karmolab/index.html
+++ b/apps/karmolab/index.html
@@ -37,8 +37,10 @@ permalink: /karmolab/
 (function(){
   var t=localStorage.getItem('toolbox_theme')||'dark';
   var bg=localStorage.getItem('toolbox_bg_theme')||'blue-magenta';
+  var nav=localStorage.getItem('toolbox_nav_layout')||'header';
   document.documentElement.setAttribute('data-theme',t);
   document.documentElement.setAttribute('data-bg',bg);
+  document.documentElement.setAttribute('data-nav',nav);
   var pt=localStorage.getItem('toolbox_prism_theme');
   var pb='/apps/karmolab/js/vendor/prism/themes-cdn/',pe='/apps/karmolab/js/vendor/prism/themes-ext/';
   var m={tomorrow:pb+'prism-tomorrow.min.css',okaidia:pb+'prism-okaidia.min.css',twilight:pb+'prism-twilight.min.css',prism:pb+'prism.min.css',coy:pb+'prism-coy.min.css',dracula:pe+'prism-dracula.min.css','one-dark':pe+'prism-one-dark.min.css',nord:pe+'prism-nord.min.css','material-dark':pe+'prism-material-dark.min.css','vsc-dark-plus':pe+'prism-vsc-dark-plus.min.css',ghcolors:pe+'prism-ghcolors.min.css','one-light':pe+'prism-one-light.min.css','material-light':pe+'prism-material-light.min.css'};
@@ -78,6 +80,17 @@ permalink: /karmolab/
             </div>
         </header>
         <div class="app-body">
+            <aside class="sidebar" id="sidebar">
+                <nav class="sidebar-nav" role="navigation" aria-label="도구 목록">
+                    <div id="sidebar-nav"></div>
+                </nav>
+                <div class="sidebar-footer">
+                    <a href="#linktree" class="sidebar-dev-links" onclick="if(typeof Toolbox!=='undefined'){Toolbox.switchPage('linktree');return false}" title="개발자 연락처 · 링크" aria-label="누가 만들었나요">
+                        <span class="sidebar-dev-links-icon" aria-hidden="true">i</span>
+                        <span class="sidebar-dev-links-text">누가 만들었나요?</span>
+                    </a>
+                </div>
+            </aside>
             <main class="main-content" role="main">
                 <div class="intro-overlay hidden" id="introOverlay" aria-hidden="true">
                     <h1 class="intro-title">KarmoLab</h1>

--- a/apps/karmolab/package-lock.json
+++ b/apps/karmolab/package-lock.json
@@ -18,7 +18,12 @@
     "../../packages/karmolab-ai": {
       "version": "0.1.0",
       "devDependencies": {
+        "@google/generative-ai": "^0.21.0",
+        "@types/node": "^22.0.0",
         "typescript": "~5.9.0"
+      },
+      "peerDependencies": {
+        "@google/generative-ai": "^0.21.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/apps/karmolab/src/toolbox.ts
+++ b/apps/karmolab/src/toolbox.ts
@@ -55,6 +55,30 @@ const Toolbox = (() => {
         return t ? { category: t.category, desc: t.desc, hidden: t.hidden } : null;
     }
     const LAST_PAGE_KEY = 'toolbox_last_page';
+    const NAV_LAYOUT_KEY = 'toolbox_nav_layout';
+    const SIDEBAR_GROUP_KEY = 'toolbox_sidebar_groups';
+
+    function getNavLayout() {
+        const v = localStorage.getItem(NAV_LAYOUT_KEY);
+        return (v === 'sidebar' || v === 'header') ? v : 'header';
+    }
+
+    function setNavLayout(layout) {
+        document.documentElement.setAttribute('data-nav', layout);
+        try { localStorage.setItem(NAV_LAYOUT_KEY, layout); } catch (_) {}
+    }
+
+    function getSidebarGroupState() {
+        try {
+            const raw = localStorage.getItem(SIDEBAR_GROUP_KEY);
+            if (raw) return JSON.parse(raw);
+        } catch (_) {}
+        return { tool: true, play: false, lab: false, misc: true };
+    }
+
+    function setSidebarGroupState(state) {
+        try { localStorage.setItem(SIDEBAR_GROUP_KEY, JSON.stringify(state)); } catch (_) {}
+    }
 
     let megaMenuCloseTimer = null;
 
@@ -429,6 +453,49 @@ const Toolbox = (() => {
             document.addEventListener('keydown', (e) => {
                 if (e.key === 'Escape') closeAllHeaderNav();
             });
+        }
+
+        // Build sidebar nav groups
+        const sidebarNavEl = document.getElementById('sidebar-nav');
+        if (sidebarNavEl) {
+            function buildSidebarGroup(catId, label, catTools) {
+                if (!catTools.length) return;
+                const isOpen = getSidebarGroupState()[catId] !== undefined
+                    ? getSidebarGroupState()[catId]
+                    : (catId === 'tool');
+                const wrap = document.createElement('div');
+                wrap.className = 'sidebar-group';
+                const trigger = document.createElement('button');
+                trigger.type = 'button';
+                trigger.className = 'sidebar-group-trigger' + (isOpen ? ' open' : '');
+                trigger.setAttribute('aria-expanded', String(isOpen));
+                trigger.innerHTML = '<span class="chevron" aria-hidden="true"></span>'
+                    + '<span class="sidebar-group-label">' + label + '</span>';
+                const body = document.createElement('div');
+                body.className = 'sidebar-group-body' + (isOpen ? ' open' : '');
+                catTools.forEach(tool => addNavItem(body, tool));
+                trigger.onclick = () => {
+                    const open = body.classList.toggle('open');
+                    trigger.classList.toggle('open', open);
+                    trigger.setAttribute('aria-expanded', String(open));
+                    setSidebarGroupState({ ...getSidebarGroupState(), [catId]: open });
+                };
+                wrap.appendChild(trigger);
+                wrap.appendChild(body);
+                sidebarNavEl.appendChild(wrap);
+            }
+
+            CATEGORIES.forEach(cat => {
+                const catTools = tools
+                    .filter(t => !hiddenSet.has(t.id) && t.category === cat.id && (cat.id !== 'desktop' || isDesktopApp()))
+                    .sort((a, b) => (a.title || '').localeCompare(b.title || '', 'ko-KR'));
+                buildSidebarGroup(cat.id, cat.label, catTools);
+            });
+
+            const sidebarUncategorized = tools
+                .filter(t => !hiddenSet.has(t.id) && !t.category)
+                .sort((a, b) => (a.title || '').localeCompare(b.title || '', 'ko-KR'));
+            buildSidebarGroup('misc', '기타', sidebarUncategorized);
         }
 
         // Build landing page
@@ -917,6 +984,7 @@ const Toolbox = (() => {
     function initTheme() {
         setTheme(getTheme());
         setBgTheme(getBgTheme());
+        setNavLayout(getNavLayout());
         const btn = document.getElementById('themeToggle');
         if (btn) btn.onclick = toggleTheme;
         setPrismTheme(getPrismTheme(), true);
@@ -1064,6 +1132,7 @@ const Toolbox = (() => {
         escapeHtml, formatTimestamp, showLightbox,
         recordUsage, getUsageStats,
         getPref, setPref,
+        getNavLayout, setNavLayout,
         getTheme, setTheme, toggleTheme,
         getBgTheme, setBgTheme, getBgThemes,
         getPrismTheme, setPrismTheme, getPrismThemes: () => [...PRISM_THEMES],

--- a/apps/karmolab/src/widgets/servermonitor.ts
+++ b/apps/karmolab/src/widgets/servermonitor.ts
@@ -997,7 +997,8 @@
       } finally {
         if (!skipFinalMergeRefresh) {
           try {
-            await refreshDevTable?.();
+            const doRefresh = refreshDevTable as (() => Promise<void>) | null;
+            if (doRefresh) await doRefresh();
           } catch {
             /* ignore */
           }
@@ -1011,7 +1012,8 @@
     void (async () => {
       if (mergedServicesEl) {
         try {
-          await refreshDevTable?.();
+          const doRefresh = refreshDevTable as (() => Promise<void>) | null;
+          if (doRefresh) await doRefresh();
         } catch {
           /* ignore */
         }

--- a/apps/karmolab/src/widgets/user.ts
+++ b/apps/karmolab/src/widgets/user.ts
@@ -263,6 +263,8 @@
     /** 키별 용도 설명 (Toolbox 관련) */
     const STORAGE_DESC: Record<string, string> = {
         'toolbox_theme': '테마 (라이트/다크)',
+        'toolbox_nav_layout': '네비게이션 레이아웃 (상단/사이드바)',
+        'toolbox_sidebar_groups': '사이드바 그룹 접힘 상태',
         'toolbox_prism_theme': '코드 하이라이트 테마',
         'toolbox_last_page': '마지막 접속 페이지',
         'toolbox_widget_prefs': '위젯별 설정 (모델, 프리셋 등)',
@@ -395,12 +397,20 @@
         const prismThemes = Toolbox.getPrismThemes?.() ?? [];
         const bgTheme = Toolbox.getBgTheme?.() ?? '';
         const bgThemes = Toolbox.getBgThemes?.() ?? [];
+        const navLayout = (Toolbox as any).getNavLayout?.() ?? 'header';
         const apiUI = typeof Gemini !== 'undefined' ? Gemini.buildApiKeyUI('set') : { html: '' };
 
         container.innerHTML = `
             <div class="user-layout">
                 <div class="settings-section">
                     <h3>🎨 표시</h3>
+                    <div class="settings-row">
+                        <label for="setNavLayout">네비게이션</label>
+                        <select id="setNavLayout" class="settings-control">
+                            <option value="header" ${navLayout === 'header' ? 'selected' : ''}>상단 메뉴</option>
+                            <option value="sidebar" ${navLayout === 'sidebar' ? 'selected' : ''}>사이드바</option>
+                        </select>
+                    </div>
                     <div class="settings-row">
                         <label for="setTheme">테마</label>
                         <select id="setTheme" class="settings-control">
@@ -443,6 +453,14 @@
                     </div>
                 </div>
             </div>`;
+
+        container.querySelector<HTMLSelectElement>('#setNavLayout')?.addEventListener('change', (e: Event) => {
+            const target = e.target as HTMLSelectElement | null;
+            if (!target) return;
+            (Toolbox as any).setNavLayout?.(target.value);
+            const label = target.value === 'sidebar' ? '사이드바' : '상단 메뉴';
+            (Toolbox as any).showToast?.('네비게이션: ' + label);
+        });
 
         container.querySelector<HTMLSelectElement>('#setTheme')?.addEventListener('change', (e: Event) => {
             const target = e.target as HTMLSelectElement | null;

--- a/apps/karmolab/tsconfig.json
+++ b/apps/karmolab/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,


### PR DESCRIPTION
## Summary

- 네비게이션 레이아웃 전환 기능 추가: 상단 헤더 메뉴 ↔ 사이드바 (설정에서 선택, `localStorage` 유지)
- 사이드바: 56px 접힘 → hover 시 224px 확장 (CSS transition), `html[data-nav="sidebar"]` 속성으로 제어
- 사이드바 모드에서 헤더 우측 버튼(테마/유저/링크) 우측 정렬 유지 (`grid-column: 3`)
- 사이드바 펼치기 애니메이션 중 위젯 제목 줄바꿈 방지 (`opacity` 전환 + `overflow: hidden` 마스킹)
- TypeScript typecheck CI 실패 수정: `DOM.Iterable` lib 추가, `refreshDevTable` never 타입 내로잉 해결

## Test plan

- [ ] 설정(유저 위젯) → 네비게이션 드롭다운에서 "사이드바" 선택 → 사이드바로 전환되는지 확인
- [ ] 사이드바 hover 시 부드럽게 확장, 위젯 제목이 한 줄 유지되는지 확인
- [ ] 페이지 새로고침 후 설정 유지되는지 확인
- [ ] 헤더 우측 버튼들이 사이드바 모드에서도 우측 정렬인지 확인
- [ ] `npm run typecheck` 통과 확인
- [ ] 모바일(≤768px)에서 사이드바 숨김, 헤더 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)