### PR TITLE
feat(yawnbot): 메모리 시스템 개선 + 캐릭터별 멀티턴 대화

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/assistant-handler.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/assistant-handler.ts
@@ -8,11 +8,29 @@
  */
 import { Message, DMChannel, TextChannel } from 'discord.js';
 import { generateAssistantText } from 'karmolab-ai/node';
+import type { ChatContent } from 'karmolab-ai/node';
 import type { MemoryService, ConversationEntry } from '../services/memory-service';
 import { CharacterService, type CharacterCard } from '../services/character-service';
 
 const MAX_RESPONSE_LENGTH = 1900;
 const MAX_PROMPT_CHARS = parseInt(process.env.ASSISTANT_MAX_PROMPT_CHARS || '12000', 10);
+const MAX_HISTORY_TURNS = 20;
+
+const chatHistories = new Map<string, ChatContent[]>();
+
+function getHistory(slug: string): ChatContent[] {
+  if (!chatHistories.has(slug)) chatHistories.set(slug, []);
+  return chatHistories.get(slug)!;
+}
+
+function appendHistory(slug: string, userMsg: string, assistantMsg: string): void {
+  const history = getHistory(slug);
+  history.push({ role: 'user', parts: [{ text: userMsg }] });
+  history.push({ role: 'model', parts: [{ text: assistantMsg }] });
+  if (history.length > MAX_HISTORY_TURNS * 2) {
+    history.splice(0, history.length - MAX_HISTORY_TURNS * 2);
+  }
+}
 
 async function detectAndSaveHotMemory(
   memory: MemoryService,
@@ -53,7 +71,7 @@ function buildSystemPrompt(card: CharacterCard, channelType: 'dm' | 'public'): s
   return `${card.body}\n\n${channelDesc}`;
 }
 
-function buildFullPrompt(
+function buildSystemInstruction(
   card: CharacterCard,
   memory: MemoryService,
   channelType: 'dm' | 'public',
@@ -70,7 +88,16 @@ function buildFullPrompt(
   );
 
   const contextBlock = context ? `\n\n${context}` : '';
-  return `${system}${contextBlock}\n\n나: ${userMessage}`;
+  return `${system}${contextBlock}`;
+}
+
+function buildFullPrompt(
+  card: CharacterCard,
+  memory: MemoryService,
+  channelType: 'dm' | 'public',
+  userMessage: string,
+): string {
+  return `${buildSystemInstruction(card, memory, channelType, userMessage)}\n\n나: ${userMessage}`;
 }
 
 function friendlyError(err: unknown): string {
@@ -159,11 +186,23 @@ export async function handleAssistantMessage(
 
   const startTime = Date.now();
   console.log(`[Assistant:${card.slug}] 프롬프트 빌드 시작...`);
-  const fullPrompt = buildFullPrompt(card, memory, channelType, userContent);
+
+  const isGemini = provider !== 'claude-cli';
+  const systemInstruction = isGemini
+    ? buildSystemInstruction(card, memory, channelType, userContent)
+    : undefined;
+  const fullPrompt = isGemini
+    ? userContent
+    : buildFullPrompt(card, memory, channelType, userContent);
   const promptSize = Buffer.byteLength(fullPrompt, 'utf-8');
   console.log(
     `[Assistant:${card.slug}] 프롬프트 준비 완료: ${promptSize}바이트, ${fullPrompt.length}자 (빌드 소요: ${Date.now() - startTime}ms)`,
   );
+
+  const history = isGemini ? getHistory(card.slug) : undefined;
+  if (history) {
+    console.log(`[Assistant:${card.slug}] 히스토리: ${history.length / 2}턴`);
+  }
 
   try {
     const aiStartTime = Date.now();
@@ -177,6 +216,8 @@ export async function handleAssistantMessage(
         );
         const { text } = await generateAssistantText(process.env, fullPrompt, {
           timeoutMs: 20000,
+          history,
+          systemInstruction,
         });
         response = text;
         const aiDuration = Date.now() - aiStartTime;
@@ -211,6 +252,8 @@ export async function handleAssistantMessage(
       content: reply,
       channel: channelType,
     });
+
+    if (isGemini) appendHistory(card.slug, userContent, reply);
 
     detectAndSaveHotMemory(memory, userContent).catch(() => {});
 

--- a/apps/discord-bots/apps/yawnbot/src/bot/assistant-handler.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/assistant-handler.ts
@@ -195,13 +195,20 @@ export async function handleAssistantMessage(
     ? userContent
     : buildFullPrompt(card, memory, channelType, userContent);
   const promptSize = Buffer.byteLength(fullPrompt, 'utf-8');
-  console.log(
-    `[Assistant:${card.slug}] 프롬프트 준비 완료: ${promptSize}바이트, ${fullPrompt.length}자 (빌드 소요: ${Date.now() - startTime}ms)`,
-  );
-
   const history = isGemini ? getHistory(card.slug) : undefined;
-  if (history) {
-    console.log(`[Assistant:${card.slug}] 히스토리: ${history.length / 2}턴`);
+
+  if (isGemini && systemInstruction != null) {
+    const sysSize = Buffer.byteLength(systemInstruction, 'utf-8');
+    const histSize = history
+      ? history.reduce((sum, e) => sum + Buffer.byteLength(JSON.stringify(e), 'utf-8'), 0)
+      : 0;
+    console.log(
+      `[Assistant:${card.slug}] 프롬프트 준비 완료: 메시지 ${promptSize}B / systemInstruction ${sysSize}B / history ${histSize}B / 합계 ${promptSize + sysSize + histSize}B / 히스토리 ${(history?.length ?? 0) / 2}턴 (빌드 소요: ${Date.now() - startTime}ms)`,
+    );
+  } else {
+    console.log(
+      `[Assistant:${card.slug}] 프롬프트 준비 완료: ${promptSize}바이트, ${fullPrompt.length}자 (빌드 소요: ${Date.now() - startTime}ms)`,
+    );
   }
 
   try {

--- a/apps/discord-bots/apps/yawnbot/src/services/memory-service.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/memory-service.ts
@@ -109,11 +109,6 @@ export class MemoryService {
     );
   }
 
-  /**
-   * ASSISTANT_AGENT_REPO_PATH 루트에 CLAUDE.md 심볼릭 링크가 없으면 생성.
-   * memo/CLAUDE-karmoddrine.md → {agentRepoPath}/CLAUDE.md
-   * Windows Developer Mode 또는 관리자 권한이 있을 때만 성공.
-   */
   private _ensureAgentClaudeMd(): void {
     const agentPath = process.env.ASSISTANT_AGENT_REPO_PATH?.trim();
     if (!agentPath) return;
@@ -123,9 +118,7 @@ export class MemoryService {
 
     const sourcePath = path.join(this.memoRepoPath, 'CLAUDE-karmoddrine.md');
     if (!fs.existsSync(sourcePath)) {
-      console.warn(
-        '[Memory] CLAUDE-karmoddrine.md 없음 — 에이전트 컨텍스트 파일 생성 건너뜀',
-      );
+      console.warn('[Memory] CLAUDE-karmoddrine.md 없음 — 에이전트 컨텍스트 파일 생성 건너뜀');
       return;
     }
 
@@ -134,9 +127,7 @@ export class MemoryService {
       console.log(`[Memory] CLAUDE.md 심볼릭 링크 생성: ${linkPath}`);
     } catch (e: unknown) {
       console.warn(
-        `[Memory] CLAUDE.md 심볼릭 링크 생성 실패 (Developer Mode 또는 관리자 권한 필요): ${
-          e instanceof Error ? e.message : e
-        }`,
+        `[Memory] CLAUDE.md 심볼릭 링크 생성 실패: ${e instanceof Error ? e.message : e}`,
       );
     }
   }
@@ -170,7 +161,22 @@ export class MemoryService {
 
   appendHotMemory(fact: string): void {
     const userMdPath = path.join(this.memoryDir, 'user.md');
+    const existing = this._read(userMdPath);
     const today = kstDateStr();
+
+    // 기존 핫메모리 라인과 내용이 유사하면 스킵
+    const existingLines = existing.split('\n').filter((l) => /^- \[/.test(l));
+    const factNorm = fact.toLowerCase().trim();
+    const isDuplicate = existingLines.some((line) => {
+      const lineContent = line.replace(/^- \[\d{4}-\d{2}-\d{2}\]\s*/, '').toLowerCase().trim();
+      return lineContent.includes(factNorm) || factNorm.includes(lineContent);
+    });
+
+    if (isDuplicate) {
+      console.log(`[Memory:${this.slug}] Hot memory 중복 스킵: ${fact.slice(0, 60)}`);
+      return;
+    }
+
     const line = `\n- [${today}] ${fact}`;
     try {
       fs.appendFileSync(userMdPath, line, 'utf-8');
@@ -208,7 +214,6 @@ export class MemoryService {
     return hotMemories.length > 0 ? hotMemories.join('\n') : '(기록 없음)';
   }
 
-  /** 슬래시 `/기억 수정` 등 외부에서 user.md를 통째로 덮어쓸 때 사용 */
   getUserMdPath(): string {
     return path.join(this.memoryDir, 'user.md');
   }
@@ -299,7 +304,6 @@ export class MemoryService {
 
     const yesterday = kstDateStr(daysAgo(1));
     const dailySummaryPath = path.join(this.memoryDir, 'daily', `${yesterday}.md`);
-
     if (!fs.existsSync(dailySummaryPath)) return;
 
     try {
@@ -328,27 +332,24 @@ export class MemoryService {
       const selfMatch = updatedMemory.match(/##\s*\[봇\s*자신에\s*대한\s*정보\]([\s\S]*?)$/);
 
       if (userMatch) {
-        const userContent = userMatch[1].trim();
         fs.writeFileSync(
           path.join(this.memoryDir, 'user.md'),
-          `# 나에 대한 정보\n\n${userContent}\n`,
+          `# 나에 대한 정보\n\n${userMatch[1].trim()}\n`,
           'utf-8',
         );
         this.dirty = true;
       }
 
       if (selfMatch) {
-        const selfContent = selfMatch[1].trim();
         fs.writeFileSync(
           path.join(this.memoryDir, 'self.md'),
-          `# 봇 자신에 대한 정보\n\n${selfContent}\n`,
+          `# 봇 자신에 대한 정보\n\n${selfMatch[1].trim()}\n`,
           'utf-8',
         );
         this.dirty = true;
       }
 
       fs.writeFileSync(markerPath, today, 'utf-8');
-
       console.log(`[Memory:${this.slug}] user.md / self.md 갱신 완료`);
     } catch (e: unknown) {
       console.error(
@@ -371,8 +372,7 @@ export class MemoryService {
         for (const file of files) {
           const filePath = path.join(dir, file);
           const stat = fs.statSync(filePath);
-          const ageMs = Date.now() - stat.mtimeMs;
-          if (ageMs > days * 24 * 60 * 60 * 1000) {
+          if (Date.now() - stat.mtimeMs > days * 24 * 60 * 60 * 1000) {
             fs.unlinkSync(filePath);
             console.log(`[Memory:${this.slug}] 오래된 파일 삭제: ${file}`);
             this.dirty = true;
@@ -389,10 +389,7 @@ export class MemoryService {
 
   // ── 컨텍스트 빌드 ─────────────────────────────────────────────────────────
 
-  /**
-   * 오늘 로그에서 최근 maxEntries개 메시지 라인만 추출.
-   * 로그 전체가 수십 KB여도 컨텍스트 예산 초과 없이 최신 대화를 포함할 수 있다.
-   */
+  /** 오늘 로그에서 최근 maxEntries개 메시지 라인만 추출 */
   private _getRecentLog(maxEntries: number = 30): string {
     const filePath = path.join(this.logsDir, `${kstDateStr()}.md`);
     if (!fs.existsSync(filePath)) return '';
@@ -412,8 +409,8 @@ export class MemoryService {
   }
 
   /**
-   * 시스템 프롬프트(card.md 본문)는 이 함수가 포함하지 않는다 — 호출자가 앞에 붙인다.
-   * 여기선 user.md / self.md / 주간·어제 요약 / 오늘 로그(최근 N개)만 반환.
+   * 시스템 프롬프트(card.md 본문)는 포함하지 않음 — 호출자가 앞에 붙인다.
+   * user.md / self.md / 오늘 로그(최근 N개) / 최근 7일 daily 요약 / weekly 요약 반환.
    */
   buildContext(maxChars = 8000): string {
     const fixed: string[] = [];
@@ -426,26 +423,27 @@ export class MemoryService {
 
     const optional: string[] = [];
 
-    // 오늘 로그는 전체가 아닌 최근 N개만 — 로그가 아무리 커도 컨텍스트를 초과하지 않는다
+    // 오늘 로그: 최근 N개만
     const recentLogEntries = parseInt(process.env.ASSISTANT_RECENT_LOG_ENTRIES || '30', 10);
     const todayLog = this._getRecentLog(recentLogEntries);
     if (todayLog) optional.push(`[오늘 대화 기록]\n${todayLog}`);
 
-    const yesterdaySummary = this._read(
-      path.join(this.memoryDir, 'daily', `${kstDateStr(daysAgo(1))}.md`),
-    );
-    if (yesterdaySummary) optional.push(`[어제 요약]\n${yesterdaySummary}`);
+    // 최근 7일치 daily 요약 (최신순)
+    const MAX_DAILY_DAYS = 7;
+    for (let i = 1; i <= MAX_DAILY_DAYS; i++) {
+      const dateStr = kstDateStr(daysAgo(i));
+      const summary = this._read(path.join(this.memoryDir, 'daily', `${dateStr}.md`));
+      if (summary) optional.push(`[${dateStr} 요약]\n${summary}`);
+    }
 
-    const weeklyDir = path.join(this.memoryDir, 'weekly');
-    const latestWeekly = this._latestFile(weeklyDir);
-    if (latestWeekly) optional.push(`[최근 주간 요약]\n${latestWeekly}`);
+    // weekly 요약 (7일 이전 장기 기억)
+    const latestWeekly = this._latestFile(path.join(this.memoryDir, 'weekly'));
+    if (latestWeekly) optional.push(`[주간 요약]\n${latestWeekly}`);
 
     let result = fixed.join('\n\n');
     for (const part of optional) {
       const candidate = result ? result + '\n\n' + part : part;
-      if (candidate.length <= maxChars) {
-        result = candidate;
-      }
+      if (candidate.length <= maxChars) result = candidate;
     }
 
     return result;

--- a/apps/discord-bots/apps/yawnbot/src/services/memory-service.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/memory-service.ts
@@ -167,8 +167,13 @@ export class MemoryService {
     // 기존 핫메모리 라인과 내용이 유사하면 스킵
     const existingLines = existing.split('\n').filter((l) => /^- \[/.test(l));
     const factNorm = fact.toLowerCase().trim();
+    if (factNorm.length < 2) {
+      console.log(`[Memory:${this.slug}] Hot memory 빈 내용 스킵`);
+      return;
+    }
     const isDuplicate = existingLines.some((line) => {
       const lineContent = line.replace(/^- \[\d{4}-\d{2}-\d{2}\]\s*/, '').toLowerCase().trim();
+      if (lineContent.length < 2) return false;
       return lineContent.includes(factNorm) || factNorm.includes(lineContent);
     });
 
@@ -424,7 +429,8 @@ export class MemoryService {
     const optional: string[] = [];
 
     // 오늘 로그: 최근 N개만
-    const recentLogEntries = parseInt(process.env.ASSISTANT_RECENT_LOG_ENTRIES || '30', 10);
+    const parsed = parseInt(process.env.ASSISTANT_RECENT_LOG_ENTRIES || '', 10);
+    const recentLogEntries = Number.isFinite(parsed) ? Math.min(200, Math.max(1, parsed)) : 30;
     const todayLog = this._getRecentLog(recentLogEntries);
     if (todayLog) optional.push(`[오늘 대화 기록]\n${todayLog}`);
 

--- a/apps/discord-bots/apps/yawnbot/src/services/memory-service.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/memory-service.ts
@@ -390,8 +390,30 @@ export class MemoryService {
   // ── 컨텍스트 빌드 ─────────────────────────────────────────────────────────
 
   /**
+   * 오늘 로그에서 최근 maxEntries개 메시지 라인만 추출.
+   * 로그 전체가 수십 KB여도 컨텍스트 예산 초과 없이 최신 대화를 포함할 수 있다.
+   */
+  private _getRecentLog(maxEntries: number = 30): string {
+    const filePath = path.join(this.logsDir, `${kstDateStr()}.md`);
+    if (!fs.existsSync(filePath)) return '';
+    try {
+      const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
+      const entryLines = lines.filter((l) => /^\[\d{2}:\d{2}/.test(l.trim()));
+      if (entryLines.length === 0) return '';
+      const recent = entryLines.slice(-maxEntries);
+      const truncated = entryLines.length > maxEntries;
+      const header = truncated
+        ? `# ${kstDateStr()} 대화 로그 (최근 ${recent.length}개 / 전체 ${entryLines.length}개)`
+        : `# ${kstDateStr()} 대화 로그`;
+      return `${header}\n\n${recent.join('\n')}`;
+    } catch {
+      return '';
+    }
+  }
+
+  /**
    * 시스템 프롬프트(card.md 본문)는 이 함수가 포함하지 않는다 — 호출자가 앞에 붙인다.
-   * 여기선 user.md / self.md / 주간·어제 요약 / 오늘 로그만 반환.
+   * 여기선 user.md / self.md / 주간·어제 요약 / 오늘 로그(최근 N개)만 반환.
    */
   buildContext(maxChars = 8000): string {
     const fixed: string[] = [];
@@ -404,7 +426,9 @@ export class MemoryService {
 
     const optional: string[] = [];
 
-    const todayLog = this._read(path.join(this.logsDir, `${kstDateStr()}.md`));
+    // 오늘 로그는 전체가 아닌 최근 N개만 — 로그가 아무리 커도 컨텍스트를 초과하지 않는다
+    const recentLogEntries = parseInt(process.env.ASSISTANT_RECENT_LOG_ENTRIES || '30', 10);
+    const todayLog = this._getRecentLog(recentLogEntries);
     if (todayLog) optional.push(`[오늘 대화 기록]\n${todayLog}`);
 
     const yesterdaySummary = this._read(

--- a/packages/karmolab-ai/src/node.ts
+++ b/packages/karmolab-ai/src/node.ts
@@ -371,7 +371,13 @@ export async function generateAssistantText(
     return { text, provider: 'claude-cli' };
   }
 
-  if (opts.history && opts.history.length > 0) {
+  if (opts.systemInstruction || (opts.history && opts.history.length > 0)) {
+    const surface = parseGenerativeSurfaceFromEnv(env);
+    if (surface === 'vertex') {
+      console.warn('[karmolab-ai] Vertex는 chat history를 지원하지 않아 single-turn으로 fallback합니다.');
+      const { text } = await generateBlobTextFromEnvWithOptions(env, prompt, { surface: 'vertex' });
+      return { text, provider: 'gemini' };
+    }
     const apiKey = env.GEMINI_API_KEY?.trim();
     if (!apiKey) throw new Error('AI Studio API: .env에 GEMINI_API_KEY가 필요합니다.');
     const modelId = resolveAiStudioTextModelId(env.GEMINI_MODEL);
@@ -379,7 +385,7 @@ export async function generateAssistantText(
       apiKey,
       modelId,
       systemInstruction: opts.systemInstruction,
-      history: opts.history,
+      history: opts.history ?? [],
       message: prompt,
     });
     return { text, provider: 'gemini' };

--- a/packages/karmolab-ai/src/node.ts
+++ b/packages/karmolab-ai/src/node.ts
@@ -13,6 +13,8 @@ import {
 
 export type { GoogleGenerativeSurface };
 
+export type ChatContent = { role: 'user' | 'model'; parts: [{ text: string }] };
+
 export function resolveAiStudioTextModelId(modelFromEnv?: string | null): string {
   const t = modelFromEnv?.trim();
   return t || DEFAULT_TEXT_MODEL_ID;
@@ -34,6 +36,25 @@ export async function generateAiStudioText(opts: {
   const model = createAiStudioTextModel(opts.apiKey, opts.modelId);
   const ro = opts.signal ? { signal: opts.signal } : undefined;
   const res = await model.generateContent(opts.prompt, ro);
+  return res.response.text();
+}
+
+/** 멀티턴 대화 히스토리 + 현재 메시지 → 응답 텍스트 (AI Studio Chat) */
+async function generateAiStudioChatText(opts: {
+  apiKey: string;
+  modelId?: string | null;
+  systemInstruction?: string;
+  history: ChatContent[];
+  message: string;
+  signal?: AbortSignal;
+}): Promise<string> {
+  const model = createAiStudioTextModel(opts.apiKey, opts.modelId);
+  const chat = model.startChat({
+    history: opts.history,
+    ...(opts.systemInstruction ? { systemInstruction: { parts: [{ text: opts.systemInstruction }] } } : {}),
+  });
+  const ro = opts.signal ? { signal: opts.signal } : undefined;
+  const res = await chat.sendMessage(opts.message, ro);
   return res.response.text();
 }
 
@@ -340,7 +361,7 @@ export function resolveAssistantProvider(env: NodeJS.ProcessEnv = process.env): 
 export async function generateAssistantText(
   env: NodeJS.ProcessEnv,
   prompt: string,
-  opts: { timeoutMs?: number } = {},
+  opts: { timeoutMs?: number; history?: ChatContent[]; systemInstruction?: string } = {},
 ): Promise<{ text: string; provider: AssistantAiProvider }> {
   const provider = resolveAssistantProvider(env);
 
@@ -348,6 +369,20 @@ export async function generateAssistantText(
     const cwd = env.ASSISTANT_AGENT_REPO_PATH?.trim() || undefined;
     const text = await generateClaudeCliText({ prompt, timeoutMs: opts.timeoutMs, cwd });
     return { text, provider: 'claude-cli' };
+  }
+
+  if (opts.history && opts.history.length > 0) {
+    const apiKey = env.GEMINI_API_KEY?.trim();
+    if (!apiKey) throw new Error('AI Studio API: .env에 GEMINI_API_KEY가 필요합니다.');
+    const modelId = resolveAiStudioTextModelId(env.GEMINI_MODEL);
+    const text = await generateAiStudioChatText({
+      apiKey,
+      modelId,
+      systemInstruction: opts.systemInstruction,
+      history: opts.history,
+      message: prompt,
+    });
+    return { text, provider: 'gemini' };
   }
 
   const { text } = await generateBlobTextFromEnvWithOptions(env, prompt, { surface: 'inherit' });


### PR DESCRIPTION
## 변경 내용\n\n### memory-service.ts\n- 오늘 로그 스킵 버그 수정: 전체 로그(94KB) 대신 최근 30개 항목만 추출하는 `_getRecentLog()` 추가\n- 일간 요약 컨텍스트: 어제 하루만 → 최근 7일치 포함\n- 핫메모리 중복 저장 방지: 내용 기반 유사도 검사 후 스킵\n\n### packages/karmolab-ai/src/node.ts\n- `ChatContent` 타입 export\n- `generateAiStudioChatText()` 추가 — `model.startChat({ history, systemInstruction })`\n- `generateAssistantText()` opts에 `history?`, `systemInstruction?` 추가\n\n### apps/discord-bots/apps/yawnbot/src/bot/assistant-handler.ts\n- 슬러그별 `Map<string, ChatContent[]>` 히스토리 관리 (최대 20턴)\n- Gemini: systemInstruction(캐릭터+컨텍스트) + history + 현재 메시지 분리 전달\n- claude-cli: 기존 flat prompt 그대로 유지\n- 응답 성공 시 히스토리 자동 업데이트