### PR TITLE
fix(karmolab): devtools showToast typecheck (TS2554)

### DIFF
--- a/apps/karmolab/src/widgets/devtools.ts
+++ b/apps/karmolab/src/widgets/devtools.ts
@@ -64,7 +64,7 @@
     });
     levelSel.addEventListener('change', () => {
       localStorage.setItem(notifyLevelKey, levelSel.value);
-      if (typeof Toolbox !== 'undefined') Toolbox.showToast('알림 설정이 저장되었습니다.', 'success');
+      if (typeof Toolbox !== 'undefined') Toolbox.showToast('알림 설정이 저장되었습니다.', 'success', undefined);
     });
     pLevel.appendChild(levelSel);
 


### PR DESCRIPTION
## Summary
CI typecheck (karmolab-ts.yml) 가 계속 실패하던 TS2554 픽스.

src/widgets/devtools.ts:67 의 Toolbox.showToast(msg, type) 2-인자 호출이 TS2554 (Expected 3 arguments, but got 2) 로 거부됨.

원인: src/toolbox.ts:985 의 function showToast(msg, type = 'success', detail) — detail 인자에 ? 또는 default 값이 없어서 TS가 required로 추론. @ts-nocheck 파일이지만 export 타입 추론에는 영향, 외부 (devtools.ts) 호출 사이트에서 타입 거부.

Fix: devtools.ts 호출에 3rd 인자 undefined 명시.

## Test plan
- [ ] npm run typecheck 통과 확인 (로컬 완료)
- [ ] CI karmolab-ts.yml job 통과 확인

Generated with Claude Code https://claude.ai/claude-code