### PR TITLE
feat(questlog): TASK-KL-017 — QuestLog v2 위젯 체크박스 토글 → memo write-back

### DIFF
--- a/apps/karmolab-tauri/src-tauri/capabilities/default.json
+++ b/apps/karmolab-tauri/src-tauri/capabilities/default.json
@@ -26,6 +26,7 @@
     "allow-activity",
     "allow-karmoddrine-state",
     "allow-quest-index",
+    "allow-quest-writeback",
     "allow-flow-doc",
     "allow-terminal",
     "updater:default"

--- a/apps/karmolab-tauri/src-tauri/permissions/quest-index.toml
+++ b/apps/karmolab-tauri/src-tauri/permissions/quest-index.toml
@@ -4,3 +4,10 @@ description = "Allow the QuestLog widget to fetch the TASK tree snapshot (read-o
 commands.allow = [
   "get_quest_tree",
 ]
+
+[[permission]]
+identifier = "allow-quest-writeback"
+description = "Allow the QuestLog widget to toggle a single checkbox in a memo TASK file (write-back). Path whitelisted to {memo}/(wm|projects/karmolab|projects/yawnbot|life|hobby|learning)/tasks/TASK-*.md."
+commands.allow = [
+  "toggle_quest_check",
+]

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod flow_doc;
 mod karmoddrine_state;
 mod local_dev;
 mod quest_index;
+mod quest_writeback;
 mod repo_file;
 mod terminal;
 
@@ -10,6 +11,7 @@ use activity::{activity_list_days, activity_query_day, activity_status, Activity
 use flow_doc::{list_flow_docs, read_flow_doc};
 use karmoddrine_state::get_karmoddrine_state;
 use quest_index::get_quest_tree;
+use quest_writeback::toggle_quest_check;
 use local_dev::{
     localdev_deploy, localdev_deploy_stream, localdev_follow_log, localdev_get_repo_root,
     localdev_list_external_pids, localdev_list_tracked, localdev_npm_install,
@@ -691,6 +693,7 @@ pub fn run() {
             activity_status,
             get_karmoddrine_state,
             get_quest_tree,
+            toggle_quest_check,
             list_flow_docs,
             read_flow_doc,
             terminal_start,

--- a/apps/karmolab-tauri/src-tauri/src/quest_index.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_index.rs
@@ -40,6 +40,8 @@ pub struct CheckItem {
     pub text: String,
     pub done: bool,
     pub group: Option<String>,
+    /// 1-base 파일 라인 번호. v2 write-back (toggle_quest_check) 가 식별자로 사용.
+    pub line_number: u32,
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -82,14 +84,24 @@ const DOMAIN_DIRS: &[&str] = &[
 ];
 
 /// frontmatter 파싱 — `---\n key: value\n ... \n---\n body`.
-/// 반환: (key→value map, body). frontmatter 가 없거나 닫는 `---` 가 없으면 None.
-fn parse_frontmatter(content: &str) -> Option<(HashMap<String, String>, String)> {
+/// 반환: (key→value map, body, body_start_line).
+/// `body_start_line` 은 1-base 파일 라인 번호 — v2 write-back 이 사용.
+/// frontmatter 가 없거나 닫는 `---` 가 없으면 None.
+fn parse_frontmatter(content: &str) -> Option<(HashMap<String, String>, String, u32)> {
     let normalized = content.replace("\r\n", "\n");
     let after_open = normalized.strip_prefix("---\n")?;
     let close_idx = after_open.find("\n---")?;
     let fm_text = &after_open[..close_idx];
     let body_with_close = &after_open[close_idx + "\n---".len()..];
     let body = body_with_close.strip_prefix('\n').unwrap_or(body_with_close);
+
+    // body 시작 파일 라인 = 1 (open ---) + fm_lines + 1 (close ---) + 1 (다음 라인)
+    let fm_lines = if fm_text.is_empty() {
+        0
+    } else {
+        fm_text.matches('\n').count() + 1
+    };
+    let body_start_line = (fm_lines + 3) as u32;
 
     let mut map: HashMap<String, String> = HashMap::new();
     for raw_line in fm_text.split('\n') {
@@ -101,7 +113,7 @@ fn parse_frontmatter(content: &str) -> Option<(HashMap<String, String>, String)>
             map.insert(key.trim().to_string(), value.trim().to_string());
         }
     }
-    Some((map, body.to_string()))
+    Some((map, body.to_string(), body_start_line))
 }
 
 /// `[a, b, c]` 형식 → `vec![a, b, c]`. 따옴표 제거. 그 외 형식이면 단일 요소.
@@ -121,10 +133,12 @@ fn parse_list(value: &str) -> Vec<String> {
 }
 
 /// 본문 체크박스 추출 — `- [ ]` / `- [x]` / `- [X]` 라인. 가장 가까운 위 h2/h3 헤더가 group.
-fn extract_checks(body: &str) -> Vec<CheckItem> {
+/// `body_start_line` 은 body 의 첫 라인이 파일에서 몇 번째 라인인지 (1-base).
+/// 각 CheckItem 의 `line_number` = 절대 파일 라인 번호.
+fn extract_checks(body: &str, body_start_line: u32) -> Vec<CheckItem> {
     let mut checks: Vec<CheckItem> = Vec::new();
     let mut current_group: Option<String> = None;
-    for raw_line in body.split('\n') {
+    for (idx, raw_line) in body.split('\n').enumerate() {
         let line = raw_line.trim_end_matches('\r');
         let trimmed = line.trim_start();
 
@@ -156,6 +170,7 @@ fn extract_checks(body: &str) -> Vec<CheckItem> {
             text,
             done,
             group: current_group.clone(),
+            line_number: body_start_line + idx as u32,
         });
     }
     checks
@@ -193,7 +208,8 @@ fn extract_title(file_name: &str) -> String {
 
 /// 단일 TASK 파일 → TaskNode. parse 실패는 Err — 호출자가 errors[] 에 모음.
 fn parse_one_task(file_name: &str, rel_path: &str, content: &str) -> Result<TaskNode, String> {
-    let (fm, body) = parse_frontmatter(content).ok_or_else(|| "frontmatter 없음".to_string())?;
+    let (fm, body, body_start_line) =
+        parse_frontmatter(content).ok_or_else(|| "frontmatter 없음".to_string())?;
 
     let id = fm
         .get("id")
@@ -229,7 +245,7 @@ fn parse_one_task(file_name: &str, rel_path: &str, content: &str) -> Result<Task
         .unwrap_or_default();
 
     let title = extract_title(file_name);
-    let checks = extract_checks(&body);
+    let checks = extract_checks(&body, body_start_line);
 
     Ok(TaskNode {
         id,
@@ -337,10 +353,12 @@ mod tests {
 
     #[test]
     fn parse_frontmatter_basic() {
-        let (fm, body) = parse_frontmatter(SAMPLE).unwrap();
+        let (fm, body, body_start_line) = parse_frontmatter(SAMPLE).unwrap();
         assert_eq!(fm.get("id").map(String::as_str), Some("TASK-WM-007"));
         assert_eq!(fm.get("status").map(String::as_str), Some("ready"));
         assert!(body.starts_with("\n## 목표"));
+        // SAMPLE: --- (1) + 5 fm lines (2~6) + --- (7) → body 첫 라인 = 8
+        assert_eq!(body_start_line, 8);
     }
 
     #[test]
@@ -362,8 +380,8 @@ mod tests {
 
     #[test]
     fn extract_checks_grouped_and_mixed() {
-        let (_, body) = parse_frontmatter(SAMPLE).unwrap();
-        let checks = extract_checks(&body);
+        let (_, body, body_start_line) = parse_frontmatter(SAMPLE).unwrap();
+        let checks = extract_checks(&body, body_start_line);
         assert_eq!(checks.len(), 4);
         assert_eq!(checks[0].text, "완료된 거");
         assert!(checks[0].done);
@@ -376,9 +394,20 @@ mod tests {
     }
 
     #[test]
+    fn extract_checks_line_numbers_match_file_lines() {
+        // SAMPLE 파일의 체크박스는 라인 15, 16, 20, 21.
+        let (_, body, body_start_line) = parse_frontmatter(SAMPLE).unwrap();
+        let checks = extract_checks(&body, body_start_line);
+        assert_eq!(checks[0].line_number, 15);
+        assert_eq!(checks[1].line_number, 16);
+        assert_eq!(checks[2].line_number, 20);
+        assert_eq!(checks[3].line_number, 21);
+    }
+
+    #[test]
     fn extract_checks_empty_body() {
-        assert!(extract_checks("").is_empty());
-        assert!(extract_checks("## 목표\n\n그냥 본문\n").is_empty());
+        assert!(extract_checks("", 1).is_empty());
+        assert!(extract_checks("## 목표\n\n그냥 본문\n", 1).is_empty());
     }
 
     #[test]

--- a/apps/karmolab-tauri/src-tauri/src/quest_writeback.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_writeback.rs
@@ -1,0 +1,212 @@
+// quest_writeback.rs
+// QuestLog 위젯 v2 — 체크박스 토글 write-back.
+//
+// 위젯에서 체크박스 클릭 → invoke('toggle_quest_check', { filePath, lineNumber, expectedText, memoPath })
+// → 파일 경로 화이트리스트 검증 → 라인 텍스트 검증 → `- [ ]` ↔ `- [x]` 토글 → 파일 write.
+//
+// 보안:
+//   - filePath 는 무조건 {memoPath}/(wm|projects/karmolab|projects/yawnbot|life|hobby|learning)/tasks/TASK-*.md
+//   - 위젯이 임의 파일 쓰기 못하게 차단
+//
+// 정합성 (race-safe):
+//   - expectedText 와 실제 라인 텍스트가 다르면 Err("text mismatch") — 위젯에 강제 새로고침 trigger
+
+use crate::quest_index::DOMAIN_DIRS;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// 사용자 홈 디렉토리. quest_index 와 동일 정책.
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(PathBuf::from)
+}
+
+fn default_memo_path() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("repos").join("karmoddrine").join("memo"))
+}
+
+/// file_path 가 허용된 memo 도메인 안의 TASK-*.md 인지 검증. canonicalize 후 PathBuf 반환.
+fn validate_task_path(file_path: &str, memo_path: &Path) -> Result<PathBuf, String> {
+    let canonical_file = PathBuf::from(file_path)
+        .canonicalize()
+        .map_err(|e| format!("file not found: {}", e))?;
+    let canonical_memo = memo_path
+        .canonicalize()
+        .map_err(|e| format!("memo path invalid: {}", e))?;
+
+    let rel = canonical_file
+        .strip_prefix(&canonical_memo)
+        .map_err(|_| "file outside memo".to_string())?;
+    let rel_str = rel.to_string_lossy().replace('\\', "/");
+
+    let domain_ok = DOMAIN_DIRS
+        .iter()
+        .any(|domain| rel_str.starts_with(&format!("{}/", domain)));
+    if !domain_ok {
+        return Err(format!("file not in allowed domain: {}", rel_str));
+    }
+
+    let file_name = canonical_file
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| "invalid file name".to_string())?;
+    if !file_name.starts_with("TASK-") || !file_name.ends_with(".md") {
+        return Err(format!("filename must match TASK-*.md: {}", file_name));
+    }
+
+    Ok(canonical_file)
+}
+
+/// 단일 라인을 토글한 새 콘텐츠 생성. 라인 엔딩 (CRLF/LF) 보존.
+/// 반환: (new_content, new_done_state)
+fn toggle_line(content: &str, line_number: u32, expected_text: &str) -> Result<(String, bool), String> {
+    if line_number == 0 {
+        return Err("line_number must be 1-base".to_string());
+    }
+
+    let mut lines: Vec<String> = content.split('\n').map(|line| line.to_string()).collect();
+    let line_idx = (line_number - 1) as usize;
+    if line_idx >= lines.len() {
+        return Err(format!(
+            "line out of range: {} (file has {} lines)",
+            line_number,
+            lines.len()
+        ));
+    }
+
+    let raw_line = lines[line_idx].clone();
+    let has_cr = raw_line.ends_with('\r');
+    let line_no_cr = if has_cr {
+        &raw_line[..raw_line.len() - 1]
+    } else {
+        &raw_line[..]
+    };
+    let trimmed = line_no_cr.trim_start();
+    let leading_ws_len = line_no_cr.len() - trimmed.len();
+    let leading_ws = &line_no_cr[..leading_ws_len];
+
+    let (rest_after_box, current_done, new_marker) = if let Some(rest) = trimmed.strip_prefix("- [ ]") {
+        (rest, false, "- [x]")
+    } else if let Some(rest) = trimmed.strip_prefix("- [x]") {
+        (rest, true, "- [ ]")
+    } else if let Some(rest) = trimmed.strip_prefix("- [X]") {
+        (rest, true, "- [ ]")
+    } else {
+        return Err("not a checkbox line".to_string());
+    };
+
+    let actual_text = rest_after_box.trim();
+    if actual_text != expected_text.trim() {
+        return Err(format!(
+            "text mismatch — expected '{}', got '{}'",
+            expected_text.trim(),
+            actual_text
+        ));
+    }
+
+    let cr_suffix = if has_cr { "\r" } else { "" };
+    let new_line = format!("{}{}{}{}", leading_ws, new_marker, rest_after_box, cr_suffix);
+    lines[line_idx] = new_line;
+
+    Ok((lines.join("\n"), !current_done))
+}
+
+/// QuestLog 위젯에서 호출. 라인 번호 + 텍스트 검증 후 토글하여 파일 write.
+/// 반환: 새로운 done 상태 (true = checked).
+#[tauri::command]
+pub fn toggle_quest_check(
+    file_path: String,
+    line_number: u32,
+    expected_text: String,
+    memo_path: Option<String>,
+) -> Result<bool, String> {
+    let memo = memo_path
+        .map(PathBuf::from)
+        .or_else(default_memo_path)
+        .ok_or_else(|| "memo path could not be resolved".to_string())?;
+
+    let canonical_file = validate_task_path(&file_path, &memo)?;
+    let content = fs::read_to_string(&canonical_file).map_err(|e| format!("read failed: {}", e))?;
+    let (new_content, new_done) = toggle_line(&content, line_number, &expected_text)?;
+    fs::write(&canonical_file, new_content).map_err(|e| format!("write failed: {}", e))?;
+    Ok(new_done)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_LF: &str =
+        "---\nid: TASK-WM-007\n---\n\n## 단계\n\n- [x] 완료\n- [ ] 진행중\n";
+    const SAMPLE_CRLF: &str =
+        "---\r\nid: TASK-WM-007\r\n---\r\n\r\n## 단계\r\n\r\n- [x] 완료\r\n- [ ] 진행중\r\n";
+
+    #[test]
+    fn toggle_line_lf_unchecked_to_checked() {
+        // 라인 8 = "- [ ] 진행중"
+        let (new_content, new_done) = toggle_line(SAMPLE_LF, 8, "진행중").unwrap();
+        assert!(new_done);
+        assert!(new_content.contains("- [x] 진행중"));
+        assert!(new_content.contains("- [x] 완료")); // 다른 라인 보존
+    }
+
+    #[test]
+    fn toggle_line_lf_checked_to_unchecked() {
+        // 라인 7 = "- [x] 완료"
+        let (new_content, new_done) = toggle_line(SAMPLE_LF, 7, "완료").unwrap();
+        assert!(!new_done);
+        assert!(new_content.contains("- [ ] 완료"));
+    }
+
+    #[test]
+    fn toggle_line_crlf_preserved() {
+        let (new_content, _) = toggle_line(SAMPLE_CRLF, 8, "진행중").unwrap();
+        assert!(new_content.contains("- [x] 진행중\r\n"));
+        // CRLF 가 LF 로 깨지지 않았는지 확인
+        assert!(new_content.contains("\r\n"));
+    }
+
+    #[test]
+    fn toggle_line_uppercase_x_normalized() {
+        let upper = "- [X] foo\n";
+        let (new_content, new_done) = toggle_line(upper, 1, "foo").unwrap();
+        assert!(!new_done);
+        assert_eq!(new_content, "- [ ] foo\n");
+    }
+
+    #[test]
+    fn toggle_line_text_mismatch_errors() {
+        let res = toggle_line(SAMPLE_LF, 8, "다른 텍스트");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("text mismatch"));
+    }
+
+    #[test]
+    fn toggle_line_not_a_checkbox_errors() {
+        // 라인 5 = "## 단계"
+        let res = toggle_line(SAMPLE_LF, 5, "anything");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("not a checkbox line"));
+    }
+
+    #[test]
+    fn toggle_line_out_of_range_errors() {
+        let res = toggle_line(SAMPLE_LF, 999, "anything");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("out of range"));
+    }
+
+    #[test]
+    fn toggle_line_zero_errors() {
+        let res = toggle_line(SAMPLE_LF, 0, "anything");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn toggle_line_preserves_leading_whitespace() {
+        let indented = "  - [ ] indent\n";
+        let (new_content, _) = toggle_line(indented, 1, "indent").unwrap();
+        assert_eq!(new_content, "  - [x] indent\n");
+    }
+}

--- a/apps/karmolab/src/widgets/quest-log/quest-log.ts
+++ b/apps/karmolab/src/widgets/quest-log/quest-log.ts
@@ -28,6 +28,7 @@
     text: string;
     done: boolean;
     group: string | null;
+    lineNumber: number;
   }
   interface MemoTaskNode {
     id: string;
@@ -107,7 +108,8 @@
       id: t.id,
       title: t.title,
       status: mapMemoStatus(t.status),
-      checks: t.checks.map((c) => ({ t: c.text, done: c.done })),
+      filePath: t.filePath,
+      checks: t.checks.map((c) => ({ t: c.text, done: c.done, lineNumber: c.lineNumber })),
     };
   }
 
@@ -1189,11 +1191,32 @@
       `;
 
       $$('[data-check-idx]').forEach(el => {
-        el.addEventListener('click', (e) => {
+        el.addEventListener('click', async (e) => {
           e.preventDefault();
           const i = Number(el.dataset.checkIdx);
-          node.checks[i].done = !node.checks[i].done;
-          if (node.checks[i].done) Mdd.linePreset('success', { msg: '하나 끝!' });
+          const check = node.checks[i];
+
+          // 메모 정본 write-back (TASK-KL-017). filePath/lineNumber 가 있는 경우만.
+          // 없으면 (옛 localStorage 데이터) 시각만 토글.
+          const invoke = (window as any).__TAURI__?.core?.invoke;
+          if (node.filePath && check.lineNumber && typeof invoke === 'function') {
+            try {
+              const newDone = await invoke('toggle_quest_check', {
+                filePath: node.filePath,
+                lineNumber: check.lineNumber,
+                expectedText: check.t,
+              }) as boolean;
+              check.done = newDone;
+            } catch (err) {
+              console.error('toggle_quest_check 실패', err);
+              alert(`체크박스 쓰기 실패: ${err}\n\n파일이 외부에서 변경됐을 수 있습니다. 위젯을 재실행해 주세요.`);
+              return;
+            }
+          } else {
+            check.done = !check.done;
+          }
+
+          if (check.done) Mdd.linePreset('success', { msg: '하나 끝!' });
           save();
           openDrawer(id);
           renderColumns();


### PR DESCRIPTION
## 요약

QuestLog 위젯에서 체크박스 클릭 → memo `.md` 파일 즉시 write-back.

### Rust (A1+A2+A3)
- **CheckItem.lineNumber** — `extract_checks` 가 절대 파일 라인 번호 emit (1-base)
- **toggle_quest_check** Tauri 명령 신규
  - 경로 화이트리스트: `{memo}/(wm|projects/karmolab|projects/yawnbot|life|hobby|learning)/tasks/TASK-*.md`
  - 라인 번호 + expectedText 검증 (외부 변경 시 fail-safe)
  - `- [ ]` ↔ `- [x]` 토글, CRLF/LF 라인 엔딩 보존
- **allow-quest-writeback** permission + default capability 등록

### TypeScript (B1+B2)
- `MemoCheckItem.lineNumber` 추가
- `taskNodeToLeaf` 가 `filePath` + check `lineNumber` 를 leaf 로 전달
- 체크박스 클릭 핸들러 async — invoke 성공 시 갱신, 실패 시 alert

## 테스트

- cargo test: 44/44 pass (quest_writeback 9개 신규 — LF/CRLF/대문자X/들여쓰기/mismatch/out-of-range/zero/non-checkbox/preserves-leading-ws)
- TypeScript typecheck: quest-log.ts 클린

## 검증 시나리오 (사용자)

- [ ] 위젯 드로어에서 체크박스 클릭 → memo `.md` 파일 변경 확인 (`git diff`)
- [ ] 다음 위젯 재진입 시 갱신값 표시
- [ ] 외부에서 파일 수정 후 위젯 클릭 → text mismatch alert + 재실행 안내
- [ ] 화이트리스트 외 경로 invoke 시도 → reject (Rust 로그)

🤖 Generated with [Claude Code](https://claude.com/claude-code)