### PR TITLE
feat(questlog): TASK-KL-018 — QuestLog v2 status write-back (FIRE/SLEEP/SEED)

### DIFF
--- a/apps/karmolab-tauri/src-tauri/permissions/quest-index.toml
+++ b/apps/karmolab-tauri/src-tauri/permissions/quest-index.toml
@@ -7,7 +7,8 @@ commands.allow = [
 
 [[permission]]
 identifier = "allow-quest-writeback"
-description = "Allow the QuestLog widget to toggle a single checkbox in a memo TASK file (write-back). Path whitelisted to {memo}/(wm|projects/karmolab|projects/yawnbot|life|hobby|learning)/tasks/TASK-*.md."
+description = "Allow the QuestLog widget to toggle a single checkbox or change the frontmatter status in a memo TASK file (write-back). Path whitelisted to {memo}/(wm|projects/karmolab|projects/yawnbot|life|hobby|learning)/tasks/TASK-*.md."
 commands.allow = [
   "toggle_quest_check",
+  "set_quest_status",
 ]

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ use activity::{activity_list_days, activity_query_day, activity_status, Activity
 use flow_doc::{list_flow_docs, read_flow_doc};
 use karmoddrine_state::get_karmoddrine_state;
 use quest_index::get_quest_tree;
-use quest_writeback::toggle_quest_check;
+use quest_writeback::{set_quest_status, toggle_quest_check};
 use local_dev::{
     localdev_deploy, localdev_deploy_stream, localdev_follow_log, localdev_get_repo_root,
     localdev_list_external_pids, localdev_list_tracked, localdev_npm_install,
@@ -694,6 +694,7 @@ pub fn run() {
             get_karmoddrine_state,
             get_quest_tree,
             toggle_quest_check,
+            set_quest_status,
             list_flow_docs,
             read_flow_doc,
             terminal_start,

--- a/apps/karmolab-tauri/src-tauri/src/quest_writeback.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_writeback.rs
@@ -133,6 +133,90 @@ pub fn toggle_quest_check(
     Ok(new_done)
 }
 
+/// memo TASK frontmatter status 값 6종 — KL-018 status write-back 화이트리스트.
+const ALLOWED_STATUSES: &[&str] = &["seed", "ready", "active", "hold", "done", "sealed"];
+
+/// frontmatter 안의 `status:` 라인을 새 값으로 교체. expected_status 와 현재 값이 다르면 fail-safe.
+/// CRLF/LF 보존. 반환: (new_content, new_status).
+fn replace_status(
+    content: &str,
+    new_status: &str,
+    expected_status: &str,
+) -> Result<(String, String), String> {
+    if !ALLOWED_STATUSES.contains(&new_status) {
+        return Err(format!("invalid status: {}", new_status));
+    }
+
+    let normalized = content.replace("\r\n", "\n");
+    let after_open = normalized
+        .strip_prefix("---\n")
+        .ok_or_else(|| "no frontmatter".to_string())?;
+    let close_idx = after_open
+        .find("\n---")
+        .ok_or_else(|| "no frontmatter close".to_string())?;
+    let fm_text = &after_open[..close_idx];
+
+    // status 라인 검색 — fm_text 안에서 1회만 등장한다고 가정.
+    let mut status_line_idx_in_fm: Option<usize> = None;
+    let mut current_status: Option<String> = None;
+    for (idx, raw_line) in fm_text.split('\n').enumerate() {
+        let trimmed = raw_line.trim();
+        if let Some((key, value)) = trimmed.split_once(':') {
+            if key.trim() == "status" {
+                status_line_idx_in_fm = Some(idx);
+                current_status = Some(value.trim().to_string());
+                break;
+            }
+        }
+    }
+
+    let status_idx = status_line_idx_in_fm.ok_or_else(|| "no status field".to_string())?;
+    let actual = current_status.unwrap_or_default();
+    if actual != expected_status {
+        return Err(format!(
+            "status mismatch — expected '{}', got '{}'",
+            expected_status, actual
+        ));
+    }
+
+    // 원본 content 의 라인 단위로 교체. CRLF/LF 보존을 위해 `split('\n')` 후 join.
+    let mut lines: Vec<String> = content.split('\n').map(|line| line.to_string()).collect();
+    // 파일 라인 = 1 (open ---) + status_idx (fm 안의 0-base) + 1 (1-base 변환) - 1 (인덱싱) = status_idx + 1
+    // 실제 인덱싱: lines[status_idx + 1] (open --- 뒤 첫 fm 라인 = lines[1])
+    let file_line_idx = status_idx + 1;
+    if file_line_idx >= lines.len() {
+        return Err("internal: status line out of range".to_string());
+    }
+
+    let raw_line = lines[file_line_idx].clone();
+    let has_cr = raw_line.ends_with('\r');
+    let cr_suffix = if has_cr { "\r" } else { "" };
+    lines[file_line_idx] = format!("status: {}{}", new_status, cr_suffix);
+
+    Ok((lines.join("\n"), new_status.to_string()))
+}
+
+/// QuestLog 위젯에서 호출. status 변경 후 파일 write.
+/// 반환: 새로 쓰여진 status 문자열.
+#[tauri::command]
+pub fn set_quest_status(
+    file_path: String,
+    new_status: String,
+    expected_status: String,
+    memo_path: Option<String>,
+) -> Result<String, String> {
+    let memo = memo_path
+        .map(PathBuf::from)
+        .or_else(default_memo_path)
+        .ok_or_else(|| "memo path could not be resolved".to_string())?;
+
+    let canonical_file = validate_task_path(&file_path, &memo)?;
+    let content = fs::read_to_string(&canonical_file).map_err(|e| format!("read failed: {}", e))?;
+    let (new_content, written) = replace_status(&content, &new_status, &expected_status)?;
+    fs::write(&canonical_file, new_content).map_err(|e| format!("write failed: {}", e))?;
+    Ok(written)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -141,6 +225,10 @@ mod tests {
         "---\nid: TASK-WM-007\n---\n\n## 단계\n\n- [x] 완료\n- [ ] 진행중\n";
     const SAMPLE_CRLF: &str =
         "---\r\nid: TASK-WM-007\r\n---\r\n\r\n## 단계\r\n\r\n- [x] 완료\r\n- [ ] 진행중\r\n";
+    const SAMPLE_WITH_STATUS_LF: &str =
+        "---\nid: TASK-KL-018\nstatus: seed\npriority: normal\n---\n\n## 본문\n";
+    const SAMPLE_WITH_STATUS_CRLF: &str =
+        "---\r\nid: TASK-KL-018\r\nstatus: seed\r\npriority: normal\r\n---\r\n\r\n## 본문\r\n";
 
     #[test]
     fn toggle_line_lf_unchecked_to_checked() {
@@ -208,5 +296,63 @@ mod tests {
         let indented = "  - [ ] indent\n";
         let (new_content, _) = toggle_line(indented, 1, "indent").unwrap();
         assert_eq!(new_content, "  - [x] indent\n");
+    }
+
+    #[test]
+    fn replace_status_lf_seed_to_active() {
+        let (new_content, written) =
+            replace_status(SAMPLE_WITH_STATUS_LF, "active", "seed").unwrap();
+        assert_eq!(written, "active");
+        assert!(new_content.contains("status: active"));
+        assert!(!new_content.contains("status: seed"));
+        // 다른 frontmatter 보존
+        assert!(new_content.contains("id: TASK-KL-018"));
+        assert!(new_content.contains("priority: normal"));
+    }
+
+    #[test]
+    fn replace_status_crlf_preserved() {
+        let (new_content, _) =
+            replace_status(SAMPLE_WITH_STATUS_CRLF, "hold", "seed").unwrap();
+        assert!(new_content.contains("status: hold\r\n"));
+        assert!(new_content.contains("\r\n"));
+    }
+
+    #[test]
+    fn replace_status_mismatch_errors() {
+        let res = replace_status(SAMPLE_WITH_STATUS_LF, "active", "active");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("status mismatch"));
+    }
+
+    #[test]
+    fn replace_status_invalid_status_errors() {
+        let res = replace_status(SAMPLE_WITH_STATUS_LF, "exploding", "seed");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("invalid status"));
+    }
+
+    #[test]
+    fn replace_status_no_status_field_errors() {
+        let no_status = "---\nid: TASK-WM-007\n---\n\n## 본문\n";
+        let res = replace_status(no_status, "active", "seed");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("no status field"));
+    }
+
+    #[test]
+    fn replace_status_no_frontmatter_errors() {
+        let no_fm = "## 본문\n그냥 본문\n";
+        let res = replace_status(no_fm, "active", "seed");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("no frontmatter"));
+    }
+
+    #[test]
+    fn replace_status_all_six_allowed() {
+        for status in &["seed", "ready", "active", "hold", "done", "sealed"] {
+            let res = replace_status(SAMPLE_WITH_STATUS_LF, status, "seed");
+            assert!(res.is_ok(), "status '{}' should be allowed", status);
+        }
     }
 }

--- a/apps/karmolab/src/widgets/quest-log/quest-log.ts
+++ b/apps/karmolab/src/widgets/quest-log/quest-log.ts
@@ -103,11 +103,21 @@
     return 'seed';
   }
 
+  /// 위젯 → memo status 역방향 매핑 (KL-018 status write-back).
+  /// `ready` 는 위젯 표현 불가 → 위젯 'seed' 클릭은 memo 'seed' 로 통일 (lossy).
+  function mapWidgetStatusToMemo(widgetStatus: string): string {
+    if (widgetStatus === 'fire') return 'active';
+    if (widgetStatus === 'sleep') return 'hold';
+    if (widgetStatus === 'sealed') return 'done';
+    return 'seed';
+  }
+
   function taskNodeToLeaf(t: MemoTaskNode): any {
     return {
       id: t.id,
       title: t.title,
       status: mapMemoStatus(t.status),
+      memoStatus: t.status, // KL-018 — write-back 시 expected_status 로 사용
       filePath: t.filePath,
       checks: t.checks.map((c) => ({ t: c.text, done: c.done, lineNumber: c.lineNumber })),
     };
@@ -1225,9 +1235,31 @@
       });
 
       $$('[data-set-status]').forEach(el => {
-        el.addEventListener('click', () => {
+        el.addEventListener('click', async () => {
           const s = el.dataset.setStatus!;
-          node.status = node.status === s ? 'seed' : s;
+          const newWidgetStatus = node.status === s ? 'seed' : s;
+
+          // memo 정본 status write-back (TASK-KL-018). filePath/memoStatus 가 있는 경우만.
+          const invoke = (window as any).__TAURI__?.core?.invoke;
+          if (node.filePath && node.memoStatus && typeof invoke === 'function') {
+            const newMemoStatus = mapWidgetStatusToMemo(newWidgetStatus);
+            try {
+              const written = await invoke('set_quest_status', {
+                filePath: node.filePath,
+                newStatus: newMemoStatus,
+                expectedStatus: node.memoStatus,
+              }) as string;
+              node.memoStatus = written;
+              node.status = mapMemoStatus(written);
+            } catch (err) {
+              console.error('set_quest_status 실패', err);
+              alert(`상태 쓰기 실패: ${err}\n\n파일이 외부에서 변경됐을 수 있습니다. 위젯을 재실행해 주세요.`);
+              return;
+            }
+          } else {
+            node.status = newWidgetStatus;
+          }
+
           if (node.status === 'fire') Mdd.linePreset('tool_run', { msg: '불 붙었어요 🔥' });
           save();
           openDrawer(id);


### PR DESCRIPTION
## 요약

QuestLog 위젯의 FIRE/SLEEP/SEED 토글 → memo `.md` frontmatter `status:` 즉시 write-back. KL-017 (체크박스 토글) 의 자연 후속.

### Rust
- **set_quest_status** Tauri 명령 신규 (`quest_writeback.rs`)
  - 화이트리스트 6종 status 검증 (seed/ready/active/hold/done/sealed)
  - expected_status race-safe (외부 변경 시 fail-safe)
  - CRLF/LF 라인 엔딩 보존
- permission `allow-quest-writeback` 에 `set_quest_status` 추가

### TypeScript
- `mapWidgetStatusToMemo` 신규 — 위젯 fire/seed/sleep/sealed → memo active/seed/hold/done
  - `ready` 는 위젯 표현 불가 (UI 에 ready 버튼 없음) → 위젯 'seed' 클릭은 memo 'seed' 로 통일 (lossy 허용)
- `taskNodeToLeaf` 가 `memoStatus` 도 leaf 로 전달 (expected_status 용)
- status 클릭 핸들러 async — invoke 성공 시 갱신, 실패 시 alert

## 테스트

- cargo test: 16/16 pass (replace_status 7 신규: LF/CRLF/mismatch/invalid/no-field/no-fm/all-six)
- TypeScript: quest-log.ts 클린

## 검증 시나리오

- [ ] FIRE 클릭 → memo `status: active` 확인 (`git diff`)
- [ ] FIRE 다시 클릭 → memo `status: seed` (토글 해제)
- [ ] SLEEP 클릭 → memo `status: hold`
- [ ] 외부 에디터로 status 수정 후 위젯 클릭 → mismatch alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)