### PR TITLE
feat(questlog): TASK-KL-020 — QuestLog v3 delete_quest_check (체크박스 X 버튼)

### DIFF
--- a/apps/karmolab-tauri/src-tauri/permissions/quest-index.toml
+++ b/apps/karmolab-tauri/src-tauri/permissions/quest-index.toml
@@ -12,4 +12,5 @@ commands.allow = [
   "toggle_quest_check",
   "set_quest_status",
   "add_quest_check",
+  "delete_quest_check",
 ]

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ use activity::{activity_list_days, activity_query_day, activity_status, Activity
 use flow_doc::{list_flow_docs, read_flow_doc};
 use karmoddrine_state::get_karmoddrine_state;
 use quest_index::get_quest_tree;
-use quest_writeback::{add_quest_check, set_quest_status, toggle_quest_check};
+use quest_writeback::{add_quest_check, delete_quest_check, set_quest_status, toggle_quest_check};
 use local_dev::{
     localdev_deploy, localdev_deploy_stream, localdev_follow_log, localdev_get_repo_root,
     localdev_list_external_pids, localdev_list_tracked, localdev_npm_install,
@@ -696,6 +696,7 @@ pub fn run() {
             toggle_quest_check,
             set_quest_status,
             add_quest_check,
+            delete_quest_check,
             list_flow_docs,
             read_flow_doc,
             terminal_start,

--- a/apps/karmolab-tauri/src-tauri/src/quest_writeback.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_writeback.rs
@@ -274,6 +274,74 @@ pub fn add_quest_check(
     Ok(new_line_number)
 }
 
+/// 단일 체크박스 라인을 제거. expected_text 검증으로 race-safe.
+/// CRLF/LF 라인 엔딩 보존 — 라인 자체를 통째로 제거하므로 join 시 자동 보존.
+fn remove_check_line(
+    content: &str,
+    line_number: u32,
+    expected_text: &str,
+) -> Result<String, String> {
+    if line_number == 0 {
+        return Err("line_number must be 1-base".to_string());
+    }
+
+    let mut lines: Vec<String> = content.split('\n').map(|line| line.to_string()).collect();
+    let line_idx = (line_number - 1) as usize;
+    if line_idx >= lines.len() {
+        return Err(format!(
+            "line out of range: {} (file has {} lines)",
+            line_number,
+            lines.len()
+        ));
+    }
+
+    let raw_line = &lines[line_idx];
+    let line_no_cr = raw_line.trim_end_matches('\r');
+    let trimmed = line_no_cr.trim_start();
+
+    let rest_after_box = if let Some(rest) = trimmed.strip_prefix("- [ ]") {
+        rest
+    } else if let Some(rest) = trimmed.strip_prefix("- [x]") {
+        rest
+    } else if let Some(rest) = trimmed.strip_prefix("- [X]") {
+        rest
+    } else {
+        return Err("not a checkbox line".to_string());
+    };
+
+    let actual_text = rest_after_box.trim();
+    if actual_text != expected_text.trim() {
+        return Err(format!(
+            "text mismatch — expected '{}', got '{}'",
+            expected_text.trim(),
+            actual_text
+        ));
+    }
+
+    lines.remove(line_idx);
+    Ok(lines.join("\n"))
+}
+
+/// QuestLog 위젯에서 호출. 라인 번호 + 텍스트 검증 후 해당 체크박스 라인 제거.
+#[tauri::command]
+pub fn delete_quest_check(
+    file_path: String,
+    line_number: u32,
+    expected_text: String,
+    memo_path: Option<String>,
+) -> Result<(), String> {
+    let memo = memo_path
+        .map(PathBuf::from)
+        .or_else(default_memo_path)
+        .ok_or_else(|| "memo path could not be resolved".to_string())?;
+
+    let canonical_file = validate_task_path(&file_path, &memo)?;
+    let content = fs::read_to_string(&canonical_file).map_err(|e| format!("read failed: {}", e))?;
+    let new_content = remove_check_line(&content, line_number, &expected_text)?;
+    fs::write(&canonical_file, new_content).map_err(|e| format!("write failed: {}", e))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -462,5 +530,55 @@ mod tests {
     fn append_check_text_trimmed() {
         let (new_content, _) = append_check(SAMPLE_LF, "  공백 양쪽  ").unwrap();
         assert!(new_content.contains("- [ ] 공백 양쪽\n"));
+    }
+
+    #[test]
+    fn remove_check_line_lf_basic() {
+        // SAMPLE_LF 라인 8 = "- [ ] 진행중", 라인 7 = "- [x] 완료"
+        let new_content = remove_check_line(SAMPLE_LF, 8, "진행중").unwrap();
+        assert!(!new_content.contains("진행중"));
+        assert!(new_content.contains("- [x] 완료")); // 다른 라인 보존
+    }
+
+    #[test]
+    fn remove_check_line_crlf_preserved() {
+        let new_content = remove_check_line(SAMPLE_CRLF, 8, "진행중").unwrap();
+        assert!(!new_content.contains("진행중"));
+        assert!(new_content.contains("\r\n")); // CRLF 보존
+    }
+
+    #[test]
+    fn remove_check_line_uppercase_x_works() {
+        let upper = "- [X] foo\n";
+        let new_content = remove_check_line(upper, 1, "foo").unwrap();
+        assert_eq!(new_content, "");
+    }
+
+    #[test]
+    fn remove_check_line_text_mismatch_errors() {
+        let res = remove_check_line(SAMPLE_LF, 8, "다른 텍스트");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("text mismatch"));
+    }
+
+    #[test]
+    fn remove_check_line_not_a_checkbox_errors() {
+        // 라인 5 = "## 단계"
+        let res = remove_check_line(SAMPLE_LF, 5, "anything");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("not a checkbox line"));
+    }
+
+    #[test]
+    fn remove_check_line_out_of_range_errors() {
+        let res = remove_check_line(SAMPLE_LF, 999, "anything");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("out of range"));
+    }
+
+    #[test]
+    fn remove_check_line_zero_errors() {
+        let res = remove_check_line(SAMPLE_LF, 0, "anything");
+        assert!(res.is_err());
     }
 }

--- a/apps/karmolab/src/widgets/quest-log/quest-log.ts
+++ b/apps/karmolab/src/widgets/quest-log/quest-log.ts
@@ -660,6 +660,15 @@
   color: var(--ink); letter-spacing: -0.005em;
 }
 .kl-quest-log .check-row.done .check-label { color: var(--ink-3); text-decoration: line-through; text-decoration-color: var(--line-3); }
+.kl-quest-log .check-row { position: relative; padding-right: 28px; }
+.kl-quest-log .check-delete {
+  position: absolute; right: 4px; top: 50%; transform: translateY(-50%);
+  background: none; border: none; cursor: pointer;
+  color: var(--ink-3); font-size: 18px; line-height: 1; padding: 4px 8px;
+  opacity: 0; transition: opacity 0.12s, color 0.12s;
+}
+.kl-quest-log .check-row:hover .check-delete { opacity: 1; }
+.kl-quest-log .check-delete:hover { color: #d4504e; }
 
 .kl-quest-log .add-check input {
   flex: 1; background: var(--paper); border: none; outline: none;
@@ -1166,6 +1175,7 @@
                   <input type="checkbox" ${c.done ? 'checked' : ''} style="display:none;">
                   <span class="check-box"></span>
                   <span class="check-label">${esc(c.t)}</span>
+                  <button class="check-delete" data-check-del="${i}" title="삭제">×</button>
                 </label>
               `).join('')}
             </div>
@@ -1203,6 +1213,9 @@
       $$('[data-check-idx]').forEach(el => {
         el.addEventListener('click', async (e) => {
           e.preventDefault();
+          // 삭제 버튼 클릭은 별도 핸들러에서 처리 — 토글 안 함
+          if ((e.target as HTMLElement).matches('[data-check-del]')) return;
+
           const i = Number(el.dataset.checkIdx);
           const check = node.checks[i];
 
@@ -1227,6 +1240,44 @@
           }
 
           if (check.done) Mdd.linePreset('success', { msg: '하나 끝!' });
+          save();
+          openDrawer(id);
+          renderColumns();
+          renderStats();
+        });
+      });
+
+      $$('[data-check-del]').forEach(el => {
+        el.addEventListener('click', async (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const i = Number(el.dataset.checkDel);
+          const check = node.checks[i];
+          if (!confirm(`정말 삭제할까요?\n\n"${check.t}"`)) return;
+
+          const invoke = (window as any).__TAURI__?.core?.invoke;
+          if (node.filePath && check.lineNumber && typeof invoke === 'function') {
+            try {
+              await invoke('delete_quest_check', {
+                filePath: node.filePath,
+                lineNumber: check.lineNumber,
+                expectedText: check.t,
+              });
+            } catch (err) {
+              console.error('delete_quest_check 실패', err);
+              alert(`체크박스 삭제 실패: ${err}\n\n파일이 외부에서 변경됐을 수 있습니다. 위젯을 재실행해 주세요.`);
+              return;
+            }
+          }
+
+          // 파일에서 라인 1개 사라지면 그 뒤 체크박스들의 절대 라인 번호가 1씩 당겨짐.
+          // in-memory 도 동기화 안 하면 다음 토글에서 text mismatch 로 실패.
+          for (let j = i + 1; j < node.checks.length; j++) {
+            if (typeof node.checks[j].lineNumber === 'number') {
+              node.checks[j].lineNumber -= 1;
+            }
+          }
+          node.checks.splice(i, 1);
           save();
           openDrawer(id);
           renderColumns();


### PR DESCRIPTION
## 요약

QuestLog 드로어의 각 체크박스 옆에 X 버튼 → memo `.md` 본문에서 해당 라인 제거. KL-019 (추가) 의 자연 짝.

### Rust
- **delete_quest_check** Tauri 명령 신규 (`quest_writeback.rs`)
  - KL-017 패턴 (line_number + expected_text 검증)
  - 라인 제거 후 write back, CRLF/LF 보존
- permission `allow-quest-writeback` 에 `delete_quest_check` 추가

### TypeScript
- check-row 에 X 버튼 + 호버 시 노출 CSS
- 삭제 핸들러: stopPropagation + confirm + invoke
- 삭제 후 후속 체크박스 lineNumber 시프트 (재진입 없이도 일관성 유지)
- 토글 핸들러는 X 클릭 무시 (부모 label 토글 차단)

## 테스트

- cargo test: 30/30 pass (remove_check_line 7 신규)
- TypeScript: quest-log.ts 클린

## 검증 시나리오

- [ ] 체크박스 호버 → X 버튼 표시
- [ ] X 클릭 → confirm 다이얼로그
- [ ] 확인 → memo `.md` 라인 제거 확인 (`git diff`)
- [ ] 삭제 후 다른 체크박스 토글 → 정상 동작 (line shift 적용)
- [ ] cancel → 무동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)