### PR TITLE
feat(questlog): TASK-KL-021 — QuestLog v3 set_quest_priority (LOW/NORMAL/HIGH 토글) + 리팩터

### DIFF
--- a/apps/karmolab-tauri/src-tauri/permissions/quest-index.toml
+++ b/apps/karmolab-tauri/src-tauri/permissions/quest-index.toml
@@ -11,6 +11,7 @@ description = "Allow the QuestLog widget to toggle a single checkbox or change t
 commands.allow = [
   "toggle_quest_check",
   "set_quest_status",
+  "set_quest_priority",
   "add_quest_check",
   "delete_quest_check",
 ]

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -11,7 +11,9 @@ use activity::{activity_list_days, activity_query_day, activity_status, Activity
 use flow_doc::{list_flow_docs, read_flow_doc};
 use karmoddrine_state::get_karmoddrine_state;
 use quest_index::get_quest_tree;
-use quest_writeback::{add_quest_check, delete_quest_check, set_quest_status, toggle_quest_check};
+use quest_writeback::{
+    add_quest_check, delete_quest_check, set_quest_priority, set_quest_status, toggle_quest_check,
+};
 use local_dev::{
     localdev_deploy, localdev_deploy_stream, localdev_follow_log, localdev_get_repo_root,
     localdev_list_external_pids, localdev_list_tracked, localdev_npm_install,
@@ -695,6 +697,7 @@ pub fn run() {
             get_quest_tree,
             toggle_quest_check,
             set_quest_status,
+            set_quest_priority,
             add_quest_check,
             delete_quest_check,
             list_flow_docs,

--- a/apps/karmolab-tauri/src-tauri/src/quest_writeback.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_writeback.rs
@@ -136,17 +136,17 @@ pub fn toggle_quest_check(
 /// memo TASK frontmatter status 값 6종 — KL-018 status write-back 화이트리스트.
 const ALLOWED_STATUSES: &[&str] = &["seed", "ready", "active", "hold", "done", "sealed"];
 
-/// frontmatter 안의 `status:` 라인을 새 값으로 교체. expected_status 와 현재 값이 다르면 fail-safe.
-/// CRLF/LF 보존. 반환: (new_content, new_status).
-fn replace_status(
-    content: &str,
-    new_status: &str,
-    expected_status: &str,
-) -> Result<(String, String), String> {
-    if !ALLOWED_STATUSES.contains(&new_status) {
-        return Err(format!("invalid status: {}", new_status));
-    }
+/// memo TASK frontmatter priority 값 3종 — KL-021 priority write-back 화이트리스트.
+const ALLOWED_PRIORITIES: &[&str] = &["low", "normal", "high"];
 
+/// frontmatter 안의 단일 필드 라인을 새 값으로 교체. expected_value 검증 race-safe.
+/// CRLF/LF 보존. KL-018/021 공용 헬퍼.
+fn replace_frontmatter_field(
+    content: &str,
+    field_key: &str,
+    new_value: &str,
+    expected_value: &str,
+) -> Result<String, String> {
     let normalized = content.replace("\r\n", "\n");
     let after_open = normalized
         .strip_prefix("---\n")
@@ -156,44 +156,69 @@ fn replace_status(
         .ok_or_else(|| "no frontmatter close".to_string())?;
     let fm_text = &after_open[..close_idx];
 
-    // status 라인 검색 — fm_text 안에서 1회만 등장한다고 가정.
-    let mut status_line_idx_in_fm: Option<usize> = None;
-    let mut current_status: Option<String> = None;
+    // 필드 라인 검색 — fm_text 안에서 1회만 등장한다고 가정.
+    let mut field_line_idx_in_fm: Option<usize> = None;
+    let mut current_value: Option<String> = None;
     for (idx, raw_line) in fm_text.split('\n').enumerate() {
         let trimmed = raw_line.trim();
         if let Some((key, value)) = trimmed.split_once(':') {
-            if key.trim() == "status" {
-                status_line_idx_in_fm = Some(idx);
-                current_status = Some(value.trim().to_string());
+            if key.trim() == field_key {
+                field_line_idx_in_fm = Some(idx);
+                current_value = Some(value.trim().to_string());
                 break;
             }
         }
     }
 
-    let status_idx = status_line_idx_in_fm.ok_or_else(|| "no status field".to_string())?;
-    let actual = current_status.unwrap_or_default();
-    if actual != expected_status {
+    let field_idx = field_line_idx_in_fm.ok_or_else(|| format!("no {} field", field_key))?;
+    let actual = current_value.unwrap_or_default();
+    if actual != expected_value {
         return Err(format!(
-            "status mismatch — expected '{}', got '{}'",
-            expected_status, actual
+            "{} mismatch — expected '{}', got '{}'",
+            field_key, expected_value, actual
         ));
     }
 
     // 원본 content 의 라인 단위로 교체. CRLF/LF 보존을 위해 `split('\n')` 후 join.
     let mut lines: Vec<String> = content.split('\n').map(|line| line.to_string()).collect();
-    // 파일 라인 = 1 (open ---) + status_idx (fm 안의 0-base) + 1 (1-base 변환) - 1 (인덱싱) = status_idx + 1
-    // 실제 인덱싱: lines[status_idx + 1] (open --- 뒤 첫 fm 라인 = lines[1])
-    let file_line_idx = status_idx + 1;
+    // 파일 라인 = 1 (open ---) + field_idx (fm 안의 0-base). 실제 인덱싱: lines[field_idx + 1].
+    let file_line_idx = field_idx + 1;
     if file_line_idx >= lines.len() {
-        return Err("internal: status line out of range".to_string());
+        return Err(format!("internal: {} line out of range", field_key));
     }
 
     let raw_line = lines[file_line_idx].clone();
     let has_cr = raw_line.ends_with('\r');
     let cr_suffix = if has_cr { "\r" } else { "" };
-    lines[file_line_idx] = format!("status: {}{}", new_status, cr_suffix);
+    lines[file_line_idx] = format!("{}: {}{}", field_key, new_value, cr_suffix);
 
-    Ok((lines.join("\n"), new_status.to_string()))
+    Ok(lines.join("\n"))
+}
+
+/// status 화이트리스트 + 공용 헬퍼 호출.
+fn replace_status(
+    content: &str,
+    new_status: &str,
+    expected_status: &str,
+) -> Result<(String, String), String> {
+    if !ALLOWED_STATUSES.contains(&new_status) {
+        return Err(format!("invalid status: {}", new_status));
+    }
+    let new_content = replace_frontmatter_field(content, "status", new_status, expected_status)?;
+    Ok((new_content, new_status.to_string()))
+}
+
+/// priority 화이트리스트 + 공용 헬퍼 호출.
+fn replace_priority(
+    content: &str,
+    new_priority: &str,
+    expected_priority: &str,
+) -> Result<(String, String), String> {
+    if !ALLOWED_PRIORITIES.contains(&new_priority) {
+        return Err(format!("invalid priority: {}", new_priority));
+    }
+    let new_content = replace_frontmatter_field(content, "priority", new_priority, expected_priority)?;
+    Ok((new_content, new_priority.to_string()))
 }
 
 /// QuestLog 위젯에서 호출. status 변경 후 파일 write.
@@ -213,6 +238,27 @@ pub fn set_quest_status(
     let canonical_file = validate_task_path(&file_path, &memo)?;
     let content = fs::read_to_string(&canonical_file).map_err(|e| format!("read failed: {}", e))?;
     let (new_content, written) = replace_status(&content, &new_status, &expected_status)?;
+    fs::write(&canonical_file, new_content).map_err(|e| format!("write failed: {}", e))?;
+    Ok(written)
+}
+
+/// QuestLog 위젯에서 호출. priority 변경 후 파일 write.
+/// 반환: 새로 쓰여진 priority 문자열.
+#[tauri::command]
+pub fn set_quest_priority(
+    file_path: String,
+    new_priority: String,
+    expected_priority: String,
+    memo_path: Option<String>,
+) -> Result<String, String> {
+    let memo = memo_path
+        .map(PathBuf::from)
+        .or_else(default_memo_path)
+        .ok_or_else(|| "memo path could not be resolved".to_string())?;
+
+    let canonical_file = validate_task_path(&file_path, &memo)?;
+    let content = fs::read_to_string(&canonical_file).map_err(|e| format!("read failed: {}", e))?;
+    let (new_content, written) = replace_priority(&content, &new_priority, &expected_priority)?;
     fs::write(&canonical_file, new_content).map_err(|e| format!("write failed: {}", e))?;
     Ok(written)
 }
@@ -580,5 +626,57 @@ mod tests {
     fn remove_check_line_zero_errors() {
         let res = remove_check_line(SAMPLE_LF, 0, "anything");
         assert!(res.is_err());
+    }
+
+    // ── KL-021 priority write-back ─────────────────────────────────────────
+    const SAMPLE_WITH_PRIORITY_LF: &str =
+        "---\nid: TASK-KL-021\nstatus: seed\npriority: normal\n---\n\n## 본문\n";
+
+    #[test]
+    fn replace_priority_lf_normal_to_high() {
+        let (new_content, written) =
+            replace_priority(SAMPLE_WITH_PRIORITY_LF, "high", "normal").unwrap();
+        assert_eq!(written, "high");
+        assert!(new_content.contains("priority: high"));
+        assert!(!new_content.contains("priority: normal"));
+        // 다른 frontmatter 보존
+        assert!(new_content.contains("status: seed"));
+    }
+
+    #[test]
+    fn replace_priority_mismatch_errors() {
+        let res = replace_priority(SAMPLE_WITH_PRIORITY_LF, "high", "low");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("priority mismatch"));
+    }
+
+    #[test]
+    fn replace_priority_invalid_errors() {
+        let res = replace_priority(SAMPLE_WITH_PRIORITY_LF, "urgent", "normal");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("invalid priority"));
+    }
+
+    #[test]
+    fn replace_priority_no_field_errors() {
+        let no_priority = "---\nid: TASK-WM-007\nstatus: seed\n---\n\n## 본문\n";
+        let res = replace_priority(no_priority, "high", "normal");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("no priority field"));
+    }
+
+    #[test]
+    fn replace_priority_all_three_allowed() {
+        for priority in &["low", "normal", "high"] {
+            let res = replace_priority(SAMPLE_WITH_PRIORITY_LF, priority, "normal");
+            assert!(res.is_ok(), "priority '{}' should be allowed", priority);
+        }
+    }
+
+    #[test]
+    fn replace_priority_crlf_preserved() {
+        let crlf = "---\r\nid: TASK-KL-021\r\npriority: normal\r\n---\r\n\r\n## 본문\r\n";
+        let (new_content, _) = replace_priority(crlf, "high", "normal").unwrap();
+        assert!(new_content.contains("priority: high\r\n"));
     }
 }

--- a/apps/karmolab/src/widgets/quest-log/quest-log.ts
+++ b/apps/karmolab/src/widgets/quest-log/quest-log.ts
@@ -118,6 +118,7 @@
       title: t.title,
       status: mapMemoStatus(t.status),
       memoStatus: t.status, // KL-018 — write-back 시 expected_status 로 사용
+      memoPriority: t.priority, // KL-021 — priority write-back expected
       filePath: t.filePath,
       checks: t.checks.map((c) => ({ t: c.text, done: c.done, lineNumber: c.lineNumber })),
     };
@@ -1158,6 +1159,14 @@
           `).join('')}
         </div>
 
+        <div class="priority-switcher" style="display:flex; gap:1px; margin-top:8px; background:var(--line-2); border:1px solid var(--line-2); width:fit-content;">
+          ${['low', 'normal', 'high'].map(p => `
+            <button class="chip priority-toggle ${node.memoPriority === p ? 'on' : ''}" data-set-priority="${p}" style="border:none; padding:7px 14px; font-size:12px;">
+              ${p === 'high' ? '! HIGH' : p === 'low' ? '· LOW' : '○ NORMAL'}
+            </button>
+          `).join('')}
+        </div>
+
         <div class="progress-wrap">
           <div class="lbl"><span>PROGRESS · ${starsHTML(progress / 100, false)}</span><b>${progress}%</b></div>
           <div class="bar"><div class="f" style="width:${progress}%; background:${statusColor};"></div></div>
@@ -1312,6 +1321,37 @@
           }
 
           if (node.status === 'fire') Mdd.linePreset('tool_run', { msg: '불 붙었어요 🔥' });
+          save();
+          openDrawer(id);
+          renderColumns();
+          renderStats();
+        });
+      });
+
+      $$('[data-set-priority]').forEach(el => {
+        el.addEventListener('click', async () => {
+          const newPriority = el.dataset.setPriority!;
+          // 같은 priority 클릭은 무동작 (status 와 달리 토글 의미 없음)
+          if (node.memoPriority === newPriority) return;
+
+          const invoke = (window as any).__TAURI__?.core?.invoke;
+          if (node.filePath && node.memoPriority && typeof invoke === 'function') {
+            try {
+              const written = await invoke('set_quest_priority', {
+                filePath: node.filePath,
+                newPriority,
+                expectedPriority: node.memoPriority,
+              }) as string;
+              node.memoPriority = written;
+            } catch (err) {
+              console.error('set_quest_priority 실패', err);
+              alert(`우선순위 쓰기 실패: ${err}\n\n파일이 외부에서 변경됐을 수 있습니다. 위젯을 재실행해 주세요.`);
+              return;
+            }
+          } else {
+            node.memoPriority = newPriority;
+          }
+
           save();
           openDrawer(id);
           renderColumns();


### PR DESCRIPTION
## 요약

QuestLog 드로어 status-switcher 아래 priority-switcher 추가 (LOW/NORMAL/HIGH chip) → memo `.md` frontmatter `priority:` 즉시 갱신. KL-018 패턴 그대로.

부수: KL-018 의 `replace_status` 와 신규 `replace_priority` 가 공용 `replace_frontmatter_field` 로 통합 (리팩터).

### Rust
- **replace_frontmatter_field** 공용 헬퍼 추출 — frontmatter 단일 필드 라인 교체
- **set_quest_priority** Tauri 명령 신규
  - 화이트리스트 3종 (low/normal/high)
  - expected_priority race-safe
  - CRLF/LF 보존
- replace_status 도 helper 사용하도록 리팩터 (기존 8개 status 테스트 그대로 통과)
- permission `allow-quest-writeback` 에 `set_quest_priority` 추가

### TypeScript
- `taskNodeToLeaf` 가 `memoPriority` 도 leaf 로 전달
- priority-switcher UI (LOW · NORMAL · HIGH chip) — status-switcher 아래
- 클릭 핸들러: 같은 priority 재클릭 no-op, 다른 값 invoke
- 실패 시 alert + return

## 테스트

- cargo test: 36/36 pass (replace_priority 6 신규: LF/mismatch/invalid/no-field/all-three/CRLF)
- TypeScript: quest-log.ts 클린

## 검증 시나리오

- [ ] 드로어에 LOW/NORMAL/HIGH 버튼 표시 + 현재 값 강조
- [ ] HIGH 클릭 → memo `priority: high` 변경 확인 (`git diff`)
- [ ] 같은 priority 재클릭 → 무동작
- [ ] 외부 변경 후 클릭 → mismatch alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)