### PR TITLE
feat(questlog): TASK-KL-023 — QuestLog v3 rename_quest_check (체크박스 텍스트 인라인 편집, CRUD 완성)

### DIFF
--- a/apps/karmolab-tauri/src-tauri/permissions/quest-index.toml
+++ b/apps/karmolab-tauri/src-tauri/permissions/quest-index.toml
@@ -14,4 +14,5 @@ commands.allow = [
   "set_quest_priority",
   "add_quest_check",
   "delete_quest_check",
+  "rename_quest_check",
 ]

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -12,7 +12,8 @@ use flow_doc::{list_flow_docs, read_flow_doc};
 use karmoddrine_state::get_karmoddrine_state;
 use quest_index::get_quest_tree;
 use quest_writeback::{
-    add_quest_check, delete_quest_check, set_quest_priority, set_quest_status, toggle_quest_check,
+    add_quest_check, delete_quest_check, rename_quest_check, set_quest_priority, set_quest_status,
+    toggle_quest_check,
 };
 use local_dev::{
     localdev_deploy, localdev_deploy_stream, localdev_follow_log, localdev_get_repo_root,
@@ -700,6 +701,7 @@ pub fn run() {
             set_quest_priority,
             add_quest_check,
             delete_quest_check,
+            rename_quest_check,
             list_flow_docs,
             read_flow_doc,
             terminal_start,

--- a/apps/karmolab-tauri/src-tauri/src/quest_writeback.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_writeback.rs
@@ -388,6 +388,95 @@ pub fn delete_quest_check(
     Ok(())
 }
 
+/// 단일 체크박스 라인의 텍스트만 교체. 마커 (`- [ ]` / `- [x]` / `- [X]`) 와 들여쓰기 보존.
+fn rename_check_line(
+    content: &str,
+    line_number: u32,
+    expected_text: &str,
+    new_text: &str,
+) -> Result<String, String> {
+    if line_number == 0 {
+        return Err("line_number must be 1-base".to_string());
+    }
+
+    let trimmed_new = new_text.trim();
+    if trimmed_new.is_empty() {
+        return Err("new text empty".to_string());
+    }
+    if trimmed_new.contains('\n') || trimmed_new.contains('\r') {
+        return Err("new text contains newline".to_string());
+    }
+
+    let mut lines: Vec<String> = content.split('\n').map(|line| line.to_string()).collect();
+    let line_idx = (line_number - 1) as usize;
+    if line_idx >= lines.len() {
+        return Err(format!(
+            "line out of range: {} (file has {} lines)",
+            line_number,
+            lines.len()
+        ));
+    }
+
+    let raw_line = lines[line_idx].clone();
+    let has_cr = raw_line.ends_with('\r');
+    let line_no_cr = if has_cr {
+        &raw_line[..raw_line.len() - 1]
+    } else {
+        &raw_line[..]
+    };
+    let trimmed = line_no_cr.trim_start();
+    let leading_ws_len = line_no_cr.len() - trimmed.len();
+    let leading_ws = &line_no_cr[..leading_ws_len];
+
+    // 마커 보존 — `- [ ]` / `- [x]` / `- [X]` 그대로.
+    let (marker, rest_after_box) = if let Some(rest) = trimmed.strip_prefix("- [ ]") {
+        ("- [ ]", rest)
+    } else if let Some(rest) = trimmed.strip_prefix("- [x]") {
+        ("- [x]", rest)
+    } else if let Some(rest) = trimmed.strip_prefix("- [X]") {
+        ("- [X]", rest)
+    } else {
+        return Err("not a checkbox line".to_string());
+    };
+
+    let actual_text = rest_after_box.trim();
+    if actual_text != expected_text.trim() {
+        return Err(format!(
+            "text mismatch — expected '{}', got '{}'",
+            expected_text.trim(),
+            actual_text
+        ));
+    }
+
+    let cr_suffix = if has_cr { "\r" } else { "" };
+    // 마커 + space + new text — 일관된 단일 space (rest_after_box 의 다중 공백은 정규화).
+    lines[line_idx] = format!("{}{} {}{}", leading_ws, marker, trimmed_new, cr_suffix);
+
+    Ok(lines.join("\n"))
+}
+
+/// QuestLog 위젯에서 호출. 라인 번호 + expected_text 검증 후 텍스트만 new_text 로 교체.
+/// 체크 상태 (마커) 보존.
+#[tauri::command]
+pub fn rename_quest_check(
+    file_path: String,
+    line_number: u32,
+    expected_text: String,
+    new_text: String,
+    memo_path: Option<String>,
+) -> Result<(), String> {
+    let memo = memo_path
+        .map(PathBuf::from)
+        .or_else(default_memo_path)
+        .ok_or_else(|| "memo path could not be resolved".to_string())?;
+
+    let canonical_file = validate_task_path(&file_path, &memo)?;
+    let content = fs::read_to_string(&canonical_file).map_err(|e| format!("read failed: {}", e))?;
+    let new_content = rename_check_line(&content, line_number, &expected_text, &new_text)?;
+    fs::write(&canonical_file, new_content).map_err(|e| format!("write failed: {}", e))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -678,5 +767,85 @@ mod tests {
         let crlf = "---\r\nid: TASK-KL-021\r\npriority: normal\r\n---\r\n\r\n## 본문\r\n";
         let (new_content, _) = replace_priority(crlf, "high", "normal").unwrap();
         assert!(new_content.contains("priority: high\r\n"));
+    }
+
+    // ── KL-023 rename_check_line ─────────────────────────────────────────
+    #[test]
+    fn rename_check_line_lf_unchecked_preserves_marker() {
+        // SAMPLE_LF 라인 8 = "- [ ] 진행중"
+        let new_content = rename_check_line(SAMPLE_LF, 8, "진행중", "수정된 텍스트").unwrap();
+        assert!(new_content.contains("- [ ] 수정된 텍스트"));
+        assert!(!new_content.contains("진행중"));
+        assert!(new_content.contains("- [x] 완료")); // 다른 라인 보존
+    }
+
+    #[test]
+    fn rename_check_line_lf_checked_preserves_marker() {
+        // SAMPLE_LF 라인 7 = "- [x] 완료"
+        let new_content = rename_check_line(SAMPLE_LF, 7, "완료", "완료된 작업").unwrap();
+        assert!(new_content.contains("- [x] 완료된 작업"));
+    }
+
+    #[test]
+    fn rename_check_line_uppercase_x_preserved() {
+        let upper = "- [X] foo\n";
+        let new_content = rename_check_line(upper, 1, "foo", "bar").unwrap();
+        // 대문자 X 보존 (toggle 과 달리 정규화 안 함 — 사용자 의도 존중)
+        assert_eq!(new_content, "- [X] bar\n");
+    }
+
+    #[test]
+    fn rename_check_line_crlf_preserved() {
+        // SAMPLE_CRLF 라인 8 = "- [ ] 진행중" (unchecked) — 마커 보존
+        let new_content = rename_check_line(SAMPLE_CRLF, 8, "진행중", "신규").unwrap();
+        assert!(new_content.contains("- [ ] 신규\r\n"));
+        assert!(new_content.contains("\r\n"));
+    }
+
+    #[test]
+    fn rename_check_line_text_mismatch_errors() {
+        let res = rename_check_line(SAMPLE_LF, 8, "다른", "신규");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("text mismatch"));
+    }
+
+    #[test]
+    fn rename_check_line_empty_new_text_errors() {
+        let res = rename_check_line(SAMPLE_LF, 8, "진행중", "");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("new text empty"));
+    }
+
+    #[test]
+    fn rename_check_line_whitespace_only_new_text_errors() {
+        let res = rename_check_line(SAMPLE_LF, 8, "진행중", "   ");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn rename_check_line_newline_in_new_text_errors() {
+        let res = rename_check_line(SAMPLE_LF, 8, "진행중", "한줄\n다른줄");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("newline"));
+    }
+
+    #[test]
+    fn rename_check_line_not_a_checkbox_errors() {
+        let res = rename_check_line(SAMPLE_LF, 5, "anything", "신규");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("not a checkbox"));
+    }
+
+    #[test]
+    fn rename_check_line_preserves_leading_whitespace() {
+        let indented = "  - [ ] 들여쓰기\n";
+        let new_content = rename_check_line(indented, 1, "들여쓰기", "변경됨").unwrap();
+        assert_eq!(new_content, "  - [ ] 변경됨\n");
+    }
+
+    #[test]
+    fn rename_check_line_new_text_trimmed() {
+        let new_content = rename_check_line(SAMPLE_LF, 8, "진행중", "  공백 양쪽  ").unwrap();
+        assert!(new_content.contains("- [ ] 공백 양쪽\n"));
     }
 }

--- a/apps/karmolab/src/widgets/quest-log/quest-log.ts
+++ b/apps/karmolab/src/widgets/quest-log/quest-log.ts
@@ -661,15 +661,24 @@
   color: var(--ink); letter-spacing: -0.005em;
 }
 .kl-quest-log .check-row.done .check-label { color: var(--ink-3); text-decoration: line-through; text-decoration-color: var(--line-3); }
-.kl-quest-log .check-row { position: relative; padding-right: 28px; }
-.kl-quest-log .check-delete {
-  position: absolute; right: 4px; top: 50%; transform: translateY(-50%);
+.kl-quest-log .check-row { position: relative; padding-right: 56px; }
+.kl-quest-log .check-edit, .kl-quest-log .check-delete {
+  position: absolute; top: 50%; transform: translateY(-50%);
   background: none; border: none; cursor: pointer;
-  color: var(--ink-3); font-size: 18px; line-height: 1; padding: 4px 8px;
+  color: var(--ink-3); font-size: 14px; line-height: 1; padding: 4px 6px;
   opacity: 0; transition: opacity 0.12s, color 0.12s;
 }
+.kl-quest-log .check-edit { right: 28px; }
+.kl-quest-log .check-delete { right: 4px; font-size: 18px; }
+.kl-quest-log .check-row:hover .check-edit,
 .kl-quest-log .check-row:hover .check-delete { opacity: 1; }
+.kl-quest-log .check-edit:hover { color: var(--accent); }
 .kl-quest-log .check-delete:hover { color: #d4504e; }
+.kl-quest-log .check-edit-input {
+  font-family: 'Noto Serif KR', serif; font-size: 16px; line-height: 1.45;
+  background: var(--paper); color: var(--ink); border: 1px solid var(--accent);
+  outline: none; padding: 2px 6px; flex: 1; min-width: 0;
+}
 
 .kl-quest-log .add-check input {
   flex: 1; background: var(--paper); border: none; outline: none;
@@ -1184,6 +1193,7 @@
                   <input type="checkbox" ${c.done ? 'checked' : ''} style="display:none;">
                   <span class="check-box"></span>
                   <span class="check-label">${esc(c.t)}</span>
+                  <button class="check-edit" data-check-edit="${i}" title="편집">✎</button>
                   <button class="check-delete" data-check-del="${i}" title="삭제">×</button>
                 </label>
               `).join('')}
@@ -1222,8 +1232,9 @@
       $$('[data-check-idx]').forEach(el => {
         el.addEventListener('click', async (e) => {
           e.preventDefault();
-          // 삭제 버튼 클릭은 별도 핸들러에서 처리 — 토글 안 함
+          // 삭제·편집 버튼 클릭은 별도 핸들러에서 처리 — 토글 안 함
           if ((e.target as HTMLElement).matches('[data-check-del]')) return;
+          if ((e.target as HTMLElement).matches('[data-check-edit]')) return;
 
           const i = Number(el.dataset.checkIdx);
           const check = node.checks[i];
@@ -1291,6 +1302,86 @@
           openDrawer(id);
           renderColumns();
           renderStats();
+        });
+      });
+
+      $$('[data-check-edit]').forEach(el => {
+        el.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const i = Number(el.dataset.checkEdit);
+          const check = node.checks[i];
+          const labelEl = el.previousElementSibling as HTMLElement | null;
+          if (!labelEl || !labelEl.classList.contains('check-label')) return;
+
+          // input 으로 swap. 기존 텍스트 selected.
+          const input = document.createElement('input');
+          input.type = 'text';
+          input.className = 'check-edit-input';
+          input.value = check.t;
+          labelEl.replaceWith(input);
+          input.focus();
+          input.select();
+
+          const restoreLabel = (newText: string) => {
+            const span = document.createElement('span');
+            span.className = 'check-label';
+            span.textContent = newText;
+            input.replaceWith(span);
+          };
+
+          let committed = false;
+          const commit = async () => {
+            if (committed) return;
+            committed = true;
+            const newText = input.value.trim();
+            if (!newText || newText === check.t) {
+              // 변경 없음 — 원복만
+              restoreLabel(check.t);
+              return;
+            }
+
+            const invoke = (window as any).__TAURI__?.core?.invoke;
+            if (node.filePath && check.lineNumber && typeof invoke === 'function') {
+              try {
+                await invoke('rename_quest_check', {
+                  filePath: node.filePath,
+                  lineNumber: check.lineNumber,
+                  expectedText: check.t,
+                  newText,
+                });
+              } catch (err) {
+                console.error('rename_quest_check 실패', err);
+                alert(`체크박스 텍스트 수정 실패: ${err}\n\n파일이 외부에서 변경됐을 수 있습니다. 위젯을 재실행해 주세요.`);
+                restoreLabel(check.t);
+                return;
+              }
+            }
+
+            check.t = newText;
+            restoreLabel(newText);
+            save();
+            openDrawer(id);
+            renderColumns();
+            renderStats();
+          };
+
+          const cancel = () => {
+            if (committed) return;
+            committed = true;
+            restoreLabel(check.t);
+          };
+
+          input.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              void commit();
+            } else if (event.key === 'Escape') {
+              event.preventDefault();
+              cancel();
+            }
+          });
+          input.addEventListener('blur', () => { void commit(); });
         });
       });
 


### PR DESCRIPTION
## 요약

QuestLog 체크박스 옆 ✎ 편집 버튼 → label 이 input 으로 swap → 텍스트 수정 → Enter/blur 저장. memo `.md` 본문의 해당 라인 텍스트만 교체, 마커 (`- [ ]`/`- [x]`) 보존.

**QuestLog v3 CRUD 완성**:
- ✅ Create: KL-019 (체크박스 추가)
- ✅ Read: KL-009 (트리 표시)
- ✅ Update toggle: KL-017
- ✅ Update status: KL-018
- ✅ Update priority: KL-021
- ✅ **Update text: KL-023** ← 본 PR
- ✅ Delete: KL-020

### Rust
- **rename_quest_check** Tauri 명령 신규
  - 마커 + 들여쓰기 보존, 텍스트만 교체
  - new_text trim, 빈/newline 차단, expected_text race-safe
- permission `allow-quest-writeback` 에 추가

### TypeScript
- check-row 에 ✎ 편집 버튼 (X 옆, 호버 시 노출)
- 클릭 → label → input swap, autofocus + select
- Enter/blur → invoke (같은 텍스트면 no-op), Esc → cancel
- 토글 핸들러에 edit 버튼 가드 추가 (충돌 방지)

## 테스트

- cargo test: 47/47 pass (rename_check_line 11 신규)
- TypeScript: quest-log.ts 클린

## 검증 시나리오

- [ ] 체크박스 호버 → ✎ + × 버튼 표시
- [ ] ✎ 클릭 → input 모드, 텍스트 selected
- [ ] 텍스트 수정 + Enter → memo `.md` 변경 (`git diff`), 마커 보존
- [ ] Esc → cancel, invoke 안 함
- [ ] 같은 텍스트 → invoke 안 함
- [ ] 체크된 항목 (`- [x]`) 편집 → 체크 상태 유지
- [ ] blur (다른 곳 클릭) → 자동 저장

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- **Quest checklist inline editing**: Users can now edit checklist item text directly in the Quest Log drawer without leaving the interface. Each item includes an edit button that enables in-place editing with save and cancel options for easy correction and modification of quest tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->