### PR TITLE
feat(questlog): TASK-KL-024 — QuestLog file watcher (notify-rs, real-time refresh)

### DIFF
--- a/apps/karmolab-tauri/src-tauri/Cargo.lock
+++ b/apps/karmolab-tauri/src-tauri/Cargo.lock
@@ -1058,6 +1058,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,6 +1833,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +1998,7 @@ dependencies = [
 name = "karmolab-desktop"
 version = "0.1.15"
 dependencies = [
+ "notify",
  "notify-rust",
  "open",
  "serde",
@@ -1990,6 +2020,26 @@ dependencies = [
  "bitflags 2.11.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -2188,6 +2238,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -2269,6 +2331,25 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "notify-rust"
@@ -4370,7 +4451,7 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
@@ -5235,6 +5316,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5282,6 +5372,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5343,6 +5448,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5361,6 +5472,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5376,6 +5493,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5409,6 +5532,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5424,6 +5553,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5445,6 +5580,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5460,6 +5601,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/apps/karmolab-tauri/src-tauri/Cargo.toml
+++ b/apps/karmolab-tauri/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+notify = "6"
 notify-rust = "4"
 open = "5"
 serde = { version = "1", features = ["derive"] }

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod flow_doc;
 mod karmoddrine_state;
 mod local_dev;
 mod quest_index;
+mod quest_watcher;
 mod quest_writeback;
 mod repo_file;
 mod terminal;
@@ -719,6 +720,10 @@ pub fn run() {
         }))
         .setup(|app| {
             let handle = app.handle().clone();
+
+            // QuestLog 파일 watcher (KL-024) — memo TASK 디렉토리 6개 변경 시
+            // 'quest-tree-changed' 이벤트 emit. 위젯이 listen 해서 자동 새로고침.
+            quest_watcher::start(handle.clone());
 
             // 카모랩 재시작 시 detached 봇 PID 복원 (영속 파일 → 살아있는 것만 in-memory map).
             // OS 호출이 들어가니까 background thread로 — 메인 윈도우 표시를 막지 않음.

--- a/apps/karmolab-tauri/src-tauri/src/quest_index.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_index.rs
@@ -74,7 +74,7 @@ pub struct QuestTree {
     pub errors: Vec<TaskError>,
 }
 
-const DOMAIN_DIRS: &[&str] = &[
+pub const DOMAIN_DIRS: &[&str] = &[
     "wm/tasks",
     "projects/karmolab/tasks",
     "projects/yawnbot/tasks",

--- a/apps/karmolab-tauri/src-tauri/src/quest_watcher.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_watcher.rs
@@ -1,0 +1,124 @@
+// quest_watcher.rs
+// QuestLog 위젯용 — memo TASK 디렉토리 6개 파일 변경 감시.
+//
+// 동작:
+//   1. 앱 시작 시 단일 watcher 생성 (notify-rs)
+//   2. memo/{wm/tasks, projects/karmolab/tasks, projects/yawnbot/tasks, life/tasks, hobby/tasks, learning/tasks}
+//      6개 디렉토리 각각 NonRecursive 등록
+//   3. fs event 받으면 debounce (300ms) — 외부 에디터 atomic save 의 다중 이벤트 묶음
+//   4. debounce 만료 시 Tauri emit("quest-tree-changed") — 위젯이 받아서 fetchMemoTree 재호출
+//
+// 라이프사이클: app lifetime 동안 살아있음. setup() 에서 Box::leak (Tauri 일반 패턴).
+
+use crate::quest_index::DOMAIN_DIRS;
+use notify::{recommended_watcher, RecursiveMode, Watcher};
+use std::path::PathBuf;
+use std::sync::mpsc::{channel, RecvTimeoutError};
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Emitter};
+
+const DEBOUNCE_MS: u64 = 300;
+const POLL_TIMEOUT_MS: u64 = 100;
+
+/// 사용자 홈 (USERPROFILE / HOME). quest_index 와 동일 정책.
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(PathBuf::from)
+}
+
+fn default_memo_path() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("repos").join("karmoddrine").join("memo"))
+}
+
+/// 앱 시작 시 호출. memo TASK 디렉토리 6개를 감시하고 변경 시 'quest-tree-changed' 이벤트 emit.
+/// 실패 (memo 없음, 디렉토리 일부 없음 등) 는 panic 안 함 — 로그 후 skip.
+/// watcher 는 Box::leak 으로 app lifetime 동안 유지 (process 종료 시 같이 해제).
+pub fn start(app_handle: AppHandle) {
+    let memo_path = match default_memo_path() {
+        Some(path) => path,
+        None => {
+            eprintln!("[quest_watcher] home dir resolve 실패 — watcher 시작 안 함");
+            return;
+        }
+    };
+
+    if !memo_path.exists() {
+        eprintln!(
+            "[quest_watcher] memo path 없음 ({}) — watcher 시작 안 함",
+            memo_path.display()
+        );
+        return;
+    }
+
+    let (event_sender, event_receiver) = channel();
+    let mut watcher = match recommended_watcher(event_sender) {
+        Ok(w) => w,
+        Err(err) => {
+            eprintln!("[quest_watcher] watcher 생성 실패: {}", err);
+            return;
+        }
+    };
+
+    let mut watched_count = 0usize;
+    for domain in DOMAIN_DIRS {
+        let dir = memo_path.join(domain);
+        if !dir.exists() {
+            continue;
+        }
+        match watcher.watch(&dir, RecursiveMode::NonRecursive) {
+            Ok(()) => {
+                watched_count += 1;
+            }
+            Err(err) => {
+                eprintln!("[quest_watcher] {} watch 실패: {}", dir.display(), err);
+            }
+        }
+    }
+
+    if watched_count == 0 {
+        eprintln!("[quest_watcher] watch 가능한 디렉토리 0 — watcher 시작 안 함");
+        return;
+    }
+
+    eprintln!(
+        "[quest_watcher] {} 도메인 감시 시작 (memo: {})",
+        watched_count,
+        memo_path.display()
+    );
+
+    // Debounce thread — fs event 받으면 last_event 시각 갱신, 마지막 이벤트 후 DEBOUNCE_MS 지나면 emit.
+    std::thread::spawn(move || {
+        let mut pending_since: Option<Instant> = None;
+        let debounce = Duration::from_millis(DEBOUNCE_MS);
+        let poll_timeout = Duration::from_millis(POLL_TIMEOUT_MS);
+
+        loop {
+            match event_receiver.recv_timeout(poll_timeout) {
+                Ok(Ok(_event)) => {
+                    pending_since = Some(Instant::now());
+                }
+                Ok(Err(err)) => {
+                    eprintln!("[quest_watcher] fs event 에러: {}", err);
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    if let Some(since) = pending_since {
+                        if since.elapsed() >= debounce {
+                            if let Err(err) = app_handle.emit("quest-tree-changed", ()) {
+                                eprintln!("[quest_watcher] emit 실패: {}", err);
+                            }
+                            pending_since = None;
+                        }
+                    }
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    eprintln!("[quest_watcher] channel disconnect — debounce thread 종료");
+                    break;
+                }
+            }
+        }
+    });
+
+    // Watcher 가 drop 되면 thread 가 disconnect 받음. App lifetime 동안 살리려고 leak.
+    Box::leak(Box::new(watcher));
+}

--- a/apps/karmolab/src/widgets/quest-log/quest-log.ts
+++ b/apps/karmolab/src/widgets/quest-log/quest-log.ts
@@ -774,43 +774,71 @@
       container.innerHTML = `<div class="kl-quest-log"><div style="padding:48px 24px; text-align:center; color:#888;">Quest Log 는 KarmoLab 데스크톱 앱 (Tauri) 에서만 동작합니다.<br/>memo TASK 파일을 런타임에 읽어 트리로 표시합니다.</div></div>`;
       return;
     }
-    container.innerHTML = `
-      <div class="kl-quest-log">
-        <div class="wrap">
-          <header class="hd">
-            <h1 class="serif">QUEST LOG <em>— in progress</em></h1>
-          </header>
 
-          <div class="stats" data-kl-ql="stats"></div>
+    // KL-024 — 이전 마운트의 file-watcher unlisten 이 있으면 정리.
+    const prevUnlisten = (container as any).__kl_quest_unlisten as (() => void) | undefined;
+    if (typeof prevUnlisten === 'function') {
+      try { prevUnlisten(); } catch (e) { console.error('previous unlisten 실패', e); }
+      (container as any).__kl_quest_unlisten = null;
+    }
 
-          <div data-kl-ql="featured-wrap"></div>
-          <div class="sub-grid" data-kl-ql="sub-columns"></div>
+    const renderOnce = (): void => {
+      container.innerHTML = `
+        <div class="kl-quest-log">
+          <div class="wrap">
+            <header class="hd">
+              <h1 class="serif">QUEST LOG <em>— in progress</em></h1>
+            </header>
 
-        </div>
+            <div class="stats" data-kl-ql="stats"></div>
 
-        <div class="drawer-backdrop" data-kl-ql="backdrop"></div>
-        <aside class="drawer" data-kl-ql="drawer">
-          <div class="drawer-head">
-            <div class="crumb" data-kl-ql="crumb">KMLB-QST / <b>—</b></div>
-            <button class="drawer-close" data-kl-ql="drawer-close" aria-label="Close">✕</button>
+            <div data-kl-ql="featured-wrap"></div>
+            <div class="sub-grid" data-kl-ql="sub-columns"></div>
+
           </div>
-          <div class="drawer-body" data-kl-ql="drawer-body"></div>
-        </aside>
-      </div>
-    `;
 
-    const root = container.querySelector('.kl-quest-log') as HTMLElement;
+          <div class="drawer-backdrop" data-kl-ql="backdrop"></div>
+          <aside class="drawer" data-kl-ql="drawer">
+            <div class="drawer-head">
+              <div class="crumb" data-kl-ql="crumb">KMLB-QST / <b>—</b></div>
+              <button class="drawer-close" data-kl-ql="drawer-close" aria-label="Close">✕</button>
+            </div>
+            <div class="drawer-body" data-kl-ql="drawer-body"></div>
+          </aside>
+        </div>
+      `;
 
-    // 비동기 invoke + 변환 + run
-    void (async () => {
-      const tree = await fetchMemoTree();
-      if (!tree) {
-        root.innerHTML = `<div style="padding:48px 24px; text-align:center; color:#c08080;">데이터 로딩 실패. F12 콘솔에 get_quest_tree 에러 확인.</div>`;
-        return;
-      }
-      const src = transformMemoToOld(tree);
-      runQuestLog(root, src);
-    })();
+      const root = container.querySelector('.kl-quest-log') as HTMLElement;
+
+      // 비동기 invoke + 변환 + run
+      void (async () => {
+        const tree = await fetchMemoTree();
+        if (!tree) {
+          root.innerHTML = `<div style="padding:48px 24px; text-align:center; color:#c08080;">데이터 로딩 실패. F12 콘솔에 get_quest_tree 에러 확인.</div>`;
+          return;
+        }
+        const src = transformMemoToOld(tree);
+        runQuestLog(root, src);
+      })();
+    };
+
+    renderOnce();
+
+    // KL-024 — Tauri file watcher 가 emit 하는 'quest-tree-changed' 이벤트 listen.
+    // 외부 에디터에서 memo TASK 파일이 변경되면 자동 새로고침.
+    const tauriEvent = (window as any).__TAURI__?.event;
+    if (tauriEvent && typeof tauriEvent.listen === 'function') {
+      void (async () => {
+        try {
+          const unlisten = await tauriEvent.listen('quest-tree-changed', () => {
+            renderOnce();
+          });
+          (container as any).__kl_quest_unlisten = unlisten;
+        } catch (err) {
+          console.error('quest-tree-changed listen 실패', err);
+        }
+      })();
+    }
   }
 
   // ── runQuestLog: 원본 IIFE 로직 (document → root, ID → data-kl-ql) ──────


### PR DESCRIPTION
## 요약

KL-009 시점에 cosmetic skip 됐던 **Phase E (notify-rs file watcher)** 도입. memo TASK 디렉토리 6개 변경 감시 → 위젯 자동 새로고침. v3 CRUD 위에 read-after-write 루프 닫기.

### Rust
- **quest_watcher.rs** 신규 — notify v6 + debounce 300ms + Tauri emit('quest-tree-changed')
- 6개 도메인 디렉토리 (`wm/tasks`, `projects/karmolab/tasks`, ..., `learning/tasks`) NonRecursive 감시
- App lifetime 단일 watcher (Box::leak)
- 실패 케이스 panic 없음 (memo 없음 / 일부 디렉토리 없음 / watcher 생성 실패)
- `lib.rs` setup() 에서 `quest_watcher::start(handle)` 호출
- `quest_index::DOMAIN_DIRS` → `pub const` (writeback + watcher 공용)
- `Cargo.toml` — notify v6 추가

### TypeScript
- `renderQuestLog` 내부 `renderOnce()` 추출
- `'quest-tree-changed'` 이벤트 listen → DOM 재구축
- 이전 마운트 unlisten 정리 (idempotent re-mount)

## 효과

| 시나리오 | Before | After |
|----------|--------|-------|
| 외부 에디터로 status 변경 | mismatch alert ("재실행해 주세요") | 0.3s 내 자동 갱신 |
| 위젯에서 토글 | in-memory only | in-memory + 0.3s 후 한번 더 (이중 보강) |
| 다중 위젯 인스턴스 | 각자 stale | 모두 동시 갱신 |
| 외부에서 TASK 신규/삭제 | 위젯 모름 | 자동 인지 |

## 검증 시나리오

- [ ] 외부 에디터 (VS Code) 로 TASK 파일 status 변경 → 0.3s 내 위젯 갱신
- [ ] 위젯에서 체크박스 토글 → 즉시 반영 + 0.3s 후 자동 새로고침 한번 더 (에러 X)
- [ ] TASK 파일 신규 생성 → 위젯에 추가
- [ ] TASK 파일 삭제 → 위젯에서 제거
- [ ] memo 디렉토리 없음 → panic X, 위젯 정상 동작 (watcher 만 skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 퀘스트 작업 디렉토리의 변경사항을 자동으로 감지하고 퀘스트 로그를 실시간으로 업데이트합니다.

* **개선사항**
  * 퀘스트 로그 렌더링 성능을 개선하고 동적 업데이트 및 재마운트 시 더욱 안정적인 처리를 지원합니다.
  * 오류 감지 및 보고 기능을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->