### PR TITLE
feat(launcher): TASK-KL-025 — TASK Launcher 위젯 (flat 검색 + 외부 에디터 오픈 + 새 TASK 즉석 생성)

### DIFF
--- a/apps/karmolab-tauri/src-tauri/capabilities/default.json
+++ b/apps/karmolab-tauri/src-tauri/capabilities/default.json
@@ -27,6 +27,7 @@
     "allow-karmoddrine-state",
     "allow-quest-index",
     "allow-quest-writeback",
+    "allow-task-launcher",
     "allow-flow-doc",
     "allow-terminal",
     "updater:default"

--- a/apps/karmolab-tauri/src-tauri/permissions/quest-launcher.toml
+++ b/apps/karmolab-tauri/src-tauri/permissions/quest-launcher.toml
@@ -1,0 +1,7 @@
+[[permission]]
+identifier = "allow-task-launcher"
+description = "Allow the TASK launcher widget to open existing TASK files in the OS default editor and create new TASK files (next ID auto + frontmatter skeleton). File paths whitelisted to {memo}/(wm|projects/karmolab|projects/yawnbot|life|hobby|learning)/tasks/TASK-*.md."
+commands.allow = [
+  "open_task_in_editor",
+  "create_task",
+]

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod flow_doc;
 mod karmoddrine_state;
 mod local_dev;
 mod quest_index;
+mod quest_launcher;
 mod quest_watcher;
 mod quest_writeback;
 mod repo_file;
@@ -12,6 +13,7 @@ use activity::{activity_list_days, activity_query_day, activity_status, Activity
 use flow_doc::{list_flow_docs, read_flow_doc};
 use karmoddrine_state::get_karmoddrine_state;
 use quest_index::get_quest_tree;
+use quest_launcher::{create_task, open_task_in_editor};
 use quest_writeback::{
     add_quest_check, delete_quest_check, rename_quest_check, set_quest_priority, set_quest_status,
     toggle_quest_check,
@@ -703,6 +705,8 @@ pub fn run() {
             add_quest_check,
             delete_quest_check,
             rename_quest_check,
+            open_task_in_editor,
+            create_task,
             list_flow_docs,
             read_flow_doc,
             terminal_start,

--- a/apps/karmolab-tauri/src-tauri/src/quest_launcher.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_launcher.rs
@@ -1,0 +1,289 @@
+// quest_launcher.rs
+// TASK launcher 위젯 (TASK-KL-025) — 외부 에디터 오픈 + 신규 TASK 생성.
+//
+// 명령 2개:
+//   1. open_task_in_editor — file_path 화이트리스트 검증 후 OS 기본 에디터로 오픈
+//   2. create_task — 도메인 + 제목 → 다음 ID 자동 발급 + frontmatter skeleton 생성
+
+use crate::quest_index::DOMAIN_DIRS;
+use crate::quest_writeback::validate_task_path;
+use std::fs;
+use std::path::PathBuf;
+
+/// 사용자 홈 (USERPROFILE / HOME). quest_writeback 와 동일 정책.
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(PathBuf::from)
+}
+
+fn default_memo_path() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("repos").join("karmoddrine").join("memo"))
+}
+
+/// 위젯에서 TASK 파일 클릭 → OS 기본 에디터로 오픈.
+#[tauri::command]
+pub fn open_task_in_editor(file_path: String, memo_path: Option<String>) -> Result<(), String> {
+    let memo = memo_path
+        .map(PathBuf::from)
+        .or_else(default_memo_path)
+        .ok_or_else(|| "memo path could not be resolved".to_string())?;
+
+    let canonical_file = validate_task_path(&file_path, &memo)?;
+    open::that(canonical_file).map_err(|err| format!("open failed: {}", err))
+}
+
+/// 도메인 → TASK ID prefix 매핑. 6 도메인 화이트리스트.
+fn domain_to_prefix(domain: &str) -> Option<&'static str> {
+    match domain {
+        "wm" => Some("WM"),
+        "karmolab" => Some("KL"),
+        "yawnbot" => Some("YB"),
+        "life" => Some("LIFE"),
+        "hobby" => Some("HOBBY"),
+        "learning" => Some("LEARN"),
+        _ => None,
+    }
+}
+
+/// 도메인 → tasks 디렉토리 상대경로 (memo 기준).
+fn domain_to_tasks_dir(domain: &str) -> Option<&'static str> {
+    match domain {
+        "wm" => Some("wm/tasks"),
+        "karmolab" => Some("projects/karmolab/tasks"),
+        "yawnbot" => Some("projects/yawnbot/tasks"),
+        "life" => Some("life/tasks"),
+        "hobby" => Some("hobby/tasks"),
+        "learning" => Some("learning/tasks"),
+        _ => None,
+    }
+}
+
+/// 디렉토리 안의 TASK-{PREFIX}-{NNN} 패턴에서 max NNN + 1 반환.
+/// 디렉토리 없거나 비었으면 1.
+fn next_task_id_number(tasks_dir: &PathBuf, prefix: &str) -> u32 {
+    let mut max_nnn: u32 = 0;
+    let pattern_prefix = format!("TASK-{}-", prefix);
+
+    if let Ok(entries) = fs::read_dir(tasks_dir) {
+        for entry in entries.flatten() {
+            let file_name = match entry.file_name().to_str() {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            if !file_name.starts_with(&pattern_prefix) {
+                continue;
+            }
+            // TASK-WM-007-foo.md → after_prefix = "007-foo.md"
+            let after_prefix = &file_name[pattern_prefix.len()..];
+            // 다음 `-` 또는 `.` 까지가 NNN 문자열
+            let nnn_end = after_prefix
+                .find(|c: char| c == '-' || c == '.')
+                .unwrap_or(after_prefix.len());
+            let nnn_str = &after_prefix[..nnn_end];
+            if let Ok(n) = nnn_str.parse::<u32>() {
+                if n > max_nnn {
+                    max_nnn = n;
+                }
+            }
+        }
+    }
+
+    max_nnn + 1
+}
+
+/// 사용자 입력 title 을 파일명 안전 형태로 정규화.
+/// - 공백 → `-`
+/// - 안전하지 않은 문자 (`/ \ : * ? " < > |`) 제거
+/// - 양 끝 `-` trim, 연속 `-` → 단일
+fn normalize_title_for_filename(title: &str) -> String {
+    let unsafe_chars: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
+    let mut result = String::new();
+    let mut last_was_dash = false;
+    for ch in title.trim().chars() {
+        if unsafe_chars.contains(&ch) {
+            continue;
+        }
+        if ch.is_whitespace() || ch == '-' {
+            if !last_was_dash && !result.is_empty() {
+                result.push('-');
+                last_was_dash = true;
+            }
+        } else {
+            result.push(ch);
+            last_was_dash = false;
+        }
+    }
+    while result.ends_with('-') {
+        result.pop();
+    }
+    result
+}
+
+/// 위젯에서 "+ 새 TASK" → 다음 ID 자동 발급 + frontmatter skeleton 생성.
+/// 반환: 생성된 파일 절대 경로 (위젯이 즉시 open_task_in_editor 호출).
+#[tauri::command]
+pub fn create_task(
+    domain: String,
+    title: String,
+    memo_path: Option<String>,
+) -> Result<String, String> {
+    let memo = memo_path
+        .map(PathBuf::from)
+        .or_else(default_memo_path)
+        .ok_or_else(|| "memo path could not be resolved".to_string())?;
+
+    let prefix = domain_to_prefix(&domain).ok_or_else(|| format!("invalid domain: {}", domain))?;
+    let tasks_rel = domain_to_tasks_dir(&domain).ok_or_else(|| "internal: domain mapping inconsistent".to_string())?;
+
+    if title.trim().is_empty() {
+        return Err("title empty".to_string());
+    }
+    let normalized_title = normalize_title_for_filename(&title);
+    if normalized_title.is_empty() {
+        return Err("title invalid after normalization".to_string());
+    }
+
+    let tasks_dir = memo.join(tasks_rel);
+    fs::create_dir_all(&tasks_dir).map_err(|err| format!("mkdir failed: {}", err))?;
+
+    let next_nnn = next_task_id_number(&tasks_dir, prefix);
+    let task_id = format!("TASK-{}-{:03}", prefix, next_nnn);
+    let file_name = format!("{}-{}.md", task_id, normalized_title);
+    let file_path = tasks_dir.join(&file_name);
+
+    if file_path.exists() {
+        return Err(format!("task id collision: {}", file_path.display()));
+    }
+
+    // 의도적으로 DOMAIN_DIRS 검증은 prefix/dir 매핑이 일관함을 확인하는 sanity check.
+    debug_assert!(DOMAIN_DIRS.iter().any(|d| *d == tasks_rel));
+
+    let frontmatter = format!(
+        "---\nid: {}\nstatus: seeded\npriority: normal\npath: [{}]\ntags: []\n---\n\n## 목표\n\n",
+        task_id, domain
+    );
+    fs::write(&file_path, frontmatter).map_err(|err| format!("write failed: {}", err))?;
+
+    let canonical = file_path
+        .canonicalize()
+        .map_err(|err| format!("canonicalize after write failed: {}", err))?;
+    Ok(canonical.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn domain_to_prefix_all_six() {
+        assert_eq!(domain_to_prefix("wm"), Some("WM"));
+        assert_eq!(domain_to_prefix("karmolab"), Some("KL"));
+        assert_eq!(domain_to_prefix("yawnbot"), Some("YB"));
+        assert_eq!(domain_to_prefix("life"), Some("LIFE"));
+        assert_eq!(domain_to_prefix("hobby"), Some("HOBBY"));
+        assert_eq!(domain_to_prefix("learning"), Some("LEARN"));
+    }
+
+    #[test]
+    fn domain_to_prefix_invalid() {
+        assert_eq!(domain_to_prefix("invalid"), None);
+        assert_eq!(domain_to_prefix(""), None);
+        assert_eq!(domain_to_prefix("WM"), None); // case-sensitive
+    }
+
+    #[test]
+    fn normalize_title_basic() {
+        assert_eq!(normalize_title_for_filename("hello world"), "hello-world");
+        assert_eq!(normalize_title_for_filename("새  TASK  생성"), "새-TASK-생성");
+    }
+
+    #[test]
+    fn normalize_title_strips_unsafe_chars() {
+        assert_eq!(normalize_title_for_filename("test/foo:bar"), "testfoobar");
+        assert_eq!(normalize_title_for_filename("a*b?c<d>"), "abcd");
+    }
+
+    #[test]
+    fn normalize_title_trims_dashes() {
+        assert_eq!(normalize_title_for_filename("  hello  "), "hello");
+        assert_eq!(normalize_title_for_filename("---test---"), "test");
+        assert_eq!(normalize_title_for_filename("a---b"), "a-b");
+    }
+
+    #[test]
+    fn normalize_title_empty_or_only_unsafe() {
+        assert_eq!(normalize_title_for_filename(""), "");
+        assert_eq!(normalize_title_for_filename("   "), "");
+        assert_eq!(normalize_title_for_filename("///"), "");
+    }
+
+    #[test]
+    fn next_task_id_empty_dir_returns_one() {
+        let temp = std::env::temp_dir().join("kl-025-test-empty");
+        let _ = fs::remove_dir_all(&temp);
+        fs::create_dir_all(&temp).unwrap();
+        assert_eq!(next_task_id_number(&temp, "WM"), 1);
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn next_task_id_max_plus_one() {
+        let temp = std::env::temp_dir().join("kl-025-test-max");
+        let _ = fs::remove_dir_all(&temp);
+        fs::create_dir_all(&temp).unwrap();
+        fs::write(temp.join("TASK-WM-001-foo.md"), "x").unwrap();
+        fs::write(temp.join("TASK-WM-007-bar.md"), "x").unwrap();
+        fs::write(temp.join("TASK-WM-003-baz.md"), "x").unwrap();
+        assert_eq!(next_task_id_number(&temp, "WM"), 8);
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn next_task_id_ignores_other_prefixes() {
+        let temp = std::env::temp_dir().join("kl-025-test-other");
+        let _ = fs::remove_dir_all(&temp);
+        fs::create_dir_all(&temp).unwrap();
+        fs::write(temp.join("TASK-WM-005-x.md"), "x").unwrap();
+        fs::write(temp.join("TASK-KL-099-y.md"), "x").unwrap();
+        // WM 만 카운트 — KL 99 무시
+        assert_eq!(next_task_id_number(&temp, "WM"), 6);
+        // KL 카운트 — WM 무시
+        assert_eq!(next_task_id_number(&temp, "KL"), 100);
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn next_task_id_handles_sub_phase_letters() {
+        // TASK-KL-009-A-foo.md, TASK-KL-009-B-bar.md → 모두 NNN=9. next = 10.
+        let temp = std::env::temp_dir().join("kl-025-test-sub");
+        let _ = fs::remove_dir_all(&temp);
+        fs::create_dir_all(&temp).unwrap();
+        fs::write(temp.join("TASK-KL-009-A-foo.md"), "x").unwrap();
+        fs::write(temp.join("TASK-KL-009-B-bar.md"), "x").unwrap();
+        assert_eq!(next_task_id_number(&temp, "KL"), 10);
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn next_task_id_handles_no_dash_after_nnn() {
+        // TASK-KL-005.md (제목 없음) — `.` 이 NNN 끝.
+        let temp = std::env::temp_dir().join("kl-025-test-nodash");
+        let _ = fs::remove_dir_all(&temp);
+        fs::create_dir_all(&temp).unwrap();
+        fs::write(temp.join("TASK-KL-005.md"), "x").unwrap();
+        assert_eq!(next_task_id_number(&temp, "KL"), 6);
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn next_task_id_skips_non_numeric() {
+        let temp = std::env::temp_dir().join("kl-025-test-skip");
+        let _ = fs::remove_dir_all(&temp);
+        fs::create_dir_all(&temp).unwrap();
+        fs::write(temp.join("TASK-WM-foo-bar.md"), "x").unwrap(); // not a number
+        fs::write(temp.join("TASK-WM-002-real.md"), "x").unwrap();
+        assert_eq!(next_task_id_number(&temp, "WM"), 3);
+        let _ = fs::remove_dir_all(&temp);
+    }
+}

--- a/apps/karmolab-tauri/src-tauri/src/quest_writeback.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_writeback.rs
@@ -27,7 +27,8 @@ fn default_memo_path() -> Option<PathBuf> {
 }
 
 /// file_path 가 허용된 memo 도메인 안의 TASK-*.md 인지 검증. canonicalize 후 PathBuf 반환.
-fn validate_task_path(file_path: &str, memo_path: &Path) -> Result<PathBuf, String> {
+/// `pub(crate)` — quest_launcher 도 같은 화이트리스트 사용.
+pub(crate) fn validate_task_path(file_path: &str, memo_path: &Path) -> Result<PathBuf, String> {
     let canonical_file = PathBuf::from(file_path)
         .canonicalize()
         .map_err(|e| format!("file not found: {}", e))?;

--- a/apps/karmolab/src/widgets-lazy-meta.ts
+++ b/apps/karmolab/src/widgets-lazy-meta.ts
@@ -142,6 +142,16 @@ window.KARMOLAB_LAZY_META = [
     lazyScriptPaths: ['quest-log/quest-log']
   },
   {
+    id: 'task-launcher',
+    title: 'TASK Launcher',
+    category: 'desktop',
+    desc: 'memo TASK 파일 flat 검색 + 외부 에디터 즉시 오픈 + 새 TASK 즉석 생성 (id 자동 발급, frontmatter skeleton)',
+    layout: 'full',
+    noHero: true,
+    icon: '<circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="1.8" fill="none"/><path d="M16 16l5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>',
+    lazyScriptPaths: ['task-launcher']
+  },
+  {
     id: 'karmoddrine-dashboard',
     title: 'karmoddrine 대시보드',
     category: 'desktop',

--- a/apps/karmolab/src/widgets/task-launcher.ts
+++ b/apps/karmolab/src/widgets/task-launcher.ts
@@ -1,0 +1,347 @@
+/**
+ * TASK Launcher 위젯 (TASK-KL-025) — Tauri 데스크톱 전용 (category: 'desktop').
+ *
+ * QuestLog (tree) 와 다른 axis: flat 검색 + 외부 에디터 즉시 오픈 + 새 TASK 즉석 생성.
+ *
+ * 데이터:
+ *   - get_quest_tree (KL-009) 로 모든 TASK 읽음
+ *   - 검색은 클라이언트 측 부분 일치 (id / title / tag / status)
+ *
+ * 명령:
+ *   - open_task_in_editor (KL-025) — 행 클릭
+ *   - create_task (KL-025) — "+ 새 TASK" 모달
+ *
+ * 자동 새로고침: KL-024 'quest-tree-changed' 이벤트 listen.
+ */
+;(function (): void {
+  interface MemoTaskNode {
+    id: string;
+    status: string;
+    priority: string;
+    path: string[];
+    parent: string | null;
+    tags: string[];
+    title: string;
+    filePath: string;
+  }
+  interface MemoQuestTree {
+    tasks: MemoTaskNode[];
+    generatedAtUnix: number;
+    memoPath: string;
+  }
+
+  const DOMAINS: Array<{ value: string; label: string; prefix: string }> = [
+    { value: 'wm', label: 'WitchMendokusai (WM)', prefix: 'WM' },
+    { value: 'karmolab', label: 'KarmoLab (KL)', prefix: 'KL' },
+    { value: 'yawnbot', label: 'YawnBot (YB)', prefix: 'YB' },
+    { value: 'life', label: '인생 (LIFE)', prefix: 'LIFE' },
+    { value: 'hobby', label: '취미 (HOBBY)', prefix: 'HOBBY' },
+    { value: 'learning', label: '학습 (LEARN)', prefix: 'LEARN' },
+  ];
+
+  const STATUS_COLORS: Record<string, string> = {
+    seed: 'var(--ink-3)',
+    ready: 'var(--accent-2)',
+    active: 'var(--accent)',
+    hold: '#a08060',
+    done: 'var(--mag-project)',
+    sealed: 'var(--mag-learn)',
+  };
+
+  const STYLE_ID = 'kl-task-launcher-styles';
+  const CSS = `
+.kl-task-launcher {
+  --bg: #0b0d12;
+  --bg-2: #0f1218;
+  --paper: #12151c;
+  --ink: #f2f2ee;
+  --ink-2: #9a9a94;
+  --ink-3: #55555a;
+  --line: #1f242d;
+  --line-2: #2a3040;
+  --accent: #d4a849;
+  --accent-2: #7fa6d4;
+  --mag-project: #9ec4a8;
+  --mag-learn: #b7a3d6;
+  background: var(--bg); color: var(--ink); font-family: 'Noto Sans KR', sans-serif;
+  height: 100%; display: flex; flex-direction: column; padding: 24px; gap: 16px; overflow: hidden;
+}
+.kl-task-launcher .header { display: flex; gap: 12px; align-items: center; }
+.kl-task-launcher .search {
+  flex: 1; background: var(--paper); border: 1px solid var(--line-2); border-radius: 4px;
+  padding: 10px 14px; font-size: 14px; color: var(--ink); outline: none;
+}
+.kl-task-launcher .search:focus { border-color: var(--accent); }
+.kl-task-launcher .new-btn {
+  background: var(--accent); color: var(--bg); border: none; border-radius: 4px;
+  padding: 10px 16px; font-weight: 600; cursor: pointer; font-size: 13px;
+}
+.kl-task-launcher .new-btn:hover { background: #e6b85a; }
+.kl-task-launcher .meta { font-size: 12px; color: var(--ink-3); }
+.kl-task-launcher .list { flex: 1; overflow-y: auto; border: 1px solid var(--line); border-radius: 4px; }
+.kl-task-launcher .row {
+  display: grid; grid-template-columns: 130px 80px 1fr auto;
+  gap: 12px; padding: 10px 14px; border-bottom: 1px solid var(--line);
+  cursor: pointer; transition: background 0.12s; align-items: center;
+}
+.kl-task-launcher .row:hover { background: var(--bg-2); }
+.kl-task-launcher .row:last-child { border-bottom: none; }
+.kl-task-launcher .row .id { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--accent-2); }
+.kl-task-launcher .row .status {
+  font-family: 'JetBrains Mono', monospace; font-size: 11px; text-transform: uppercase;
+  text-align: center; padding: 2px 6px; border: 1px solid currentColor; border-radius: 3px;
+}
+.kl-task-launcher .row .title { font-size: 14px; }
+.kl-task-launcher .row .tags { font-size: 11px; color: var(--ink-3); white-space: nowrap; }
+.kl-task-launcher .empty { padding: 48px; text-align: center; color: var(--ink-3); }
+
+/* 모달 */
+.kl-task-launcher .modal-backdrop {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 100;
+  display: flex; align-items: center; justify-content: center;
+}
+.kl-task-launcher .modal {
+  background: var(--paper); border: 1px solid var(--line-2); border-radius: 6px;
+  padding: 24px; min-width: 420px; max-width: 90%;
+}
+.kl-task-launcher .modal h3 { margin: 0 0 16px; font-size: 16px; color: var(--ink); }
+.kl-task-launcher .modal label { display: block; font-size: 12px; color: var(--ink-2); margin-bottom: 4px; }
+.kl-task-launcher .modal select, .kl-task-launcher .modal input {
+  width: 100%; background: var(--bg-2); border: 1px solid var(--line-2); color: var(--ink);
+  padding: 8px 10px; border-radius: 3px; font-size: 14px; outline: none; margin-bottom: 12px;
+}
+.kl-task-launcher .modal-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 8px; }
+.kl-task-launcher .modal-cancel, .kl-task-launcher .modal-create {
+  border: none; padding: 8px 16px; border-radius: 3px; font-size: 13px; cursor: pointer;
+}
+.kl-task-launcher .modal-cancel { background: var(--line-2); color: var(--ink); }
+.kl-task-launcher .modal-create { background: var(--accent); color: var(--bg); font-weight: 600; }
+`;
+
+  function isKarmolabDesktop(): boolean {
+    return typeof (window as any).__TAURI__ !== 'undefined';
+  }
+
+  function esc(s: unknown): string {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  async function fetchTree(): Promise<MemoQuestTree | null> {
+    const invoke = (window as any).__TAURI__?.core?.invoke;
+    if (typeof invoke !== 'function') return null;
+    try {
+      return (await invoke('get_quest_tree')) as MemoQuestTree;
+    } catch (err) {
+      console.error('get_quest_tree 실패', err);
+      return null;
+    }
+  }
+
+  function matches(task: MemoTaskNode, query: string): boolean {
+    if (!query) return true;
+    const q = query.toLowerCase();
+    if (task.id.toLowerCase().includes(q)) return true;
+    if (task.title.toLowerCase().includes(q)) return true;
+    if (task.status.toLowerCase().includes(q)) return true;
+    if (task.tags.some((tag) => tag.toLowerCase().includes(q))) return true;
+    return false;
+  }
+
+  function renderList(listEl: HTMLElement, tasks: MemoTaskNode[], query: string): void {
+    const filtered = tasks.filter((t) => matches(t, query));
+    if (filtered.length === 0) {
+      listEl.innerHTML = `<div class="empty">조건에 맞는 TASK 없음 — 검색어 변경 또는 + 새 TASK</div>`;
+      return;
+    }
+    // 도메인 → status → id 순 정렬
+    const sorted = [...filtered].sort((a, b) => {
+      const domainA = a.path[0] ?? '';
+      const domainB = b.path[0] ?? '';
+      if (domainA !== domainB) return domainA.localeCompare(domainB);
+      return a.id.localeCompare(b.id);
+    });
+    listEl.innerHTML = sorted
+      .map((t) => {
+        const statusColor = STATUS_COLORS[t.status] ?? 'var(--ink-3)';
+        const tagsLabel = t.tags.length > 0 ? `[${t.tags.slice(0, 3).join(', ')}${t.tags.length > 3 ? '…' : ''}]` : '';
+        return `
+          <div class="row" data-file="${esc(t.filePath)}">
+            <span class="id">${esc(t.id)}</span>
+            <span class="status" style="color:${statusColor};">${esc(t.status)}</span>
+            <span class="title">${esc(t.title)}</span>
+            <span class="tags">${esc(tagsLabel)}</span>
+          </div>
+        `;
+      })
+      .join('');
+  }
+
+  function showCreateModal(root: HTMLElement, onCreated: (newPath: string) => void): void {
+    const backdrop = document.createElement('div');
+    backdrop.className = 'modal-backdrop';
+    backdrop.innerHTML = `
+      <div class="modal">
+        <h3>+ 새 TASK 생성</h3>
+        <label>도메인</label>
+        <select class="modal-domain">
+          ${DOMAINS.map((d) => `<option value="${d.value}">${d.label}</option>`).join('')}
+        </select>
+        <label>제목 (한글/영문 OK, 파일명 자동 정규화)</label>
+        <input type="text" class="modal-title" placeholder="예: 새 시스템 시드" autofocus>
+        <div class="modal-actions">
+          <button class="modal-cancel">취소</button>
+          <button class="modal-create">생성 + 오픈</button>
+        </div>
+      </div>
+    `;
+    root.appendChild(backdrop);
+
+    const domainSelect = backdrop.querySelector('.modal-domain') as HTMLSelectElement;
+    const titleInput = backdrop.querySelector('.modal-title') as HTMLInputElement;
+    const cancelBtn = backdrop.querySelector('.modal-cancel') as HTMLButtonElement;
+    const createBtn = backdrop.querySelector('.modal-create') as HTMLButtonElement;
+
+    setTimeout(() => titleInput.focus(), 50);
+
+    const close = () => backdrop.remove();
+    cancelBtn.addEventListener('click', close);
+    backdrop.addEventListener('click', (e) => { if (e.target === backdrop) close(); });
+
+    const submit = async () => {
+      const domain = domainSelect.value;
+      const title = titleInput.value.trim();
+      if (!title) {
+        titleInput.style.borderColor = '#d4504e';
+        return;
+      }
+      const invoke = (window as any).__TAURI__?.core?.invoke;
+      if (typeof invoke !== 'function') {
+        alert('Tauri invoke 사용 불가 — KarmoLab 데스크톱 앱이어야 동작합니다.');
+        return;
+      }
+      try {
+        const newPath = (await invoke('create_task', { domain, title })) as string;
+        close();
+        onCreated(newPath);
+      } catch (err) {
+        console.error('create_task 실패', err);
+        alert(`TASK 생성 실패: ${err}`);
+      }
+    };
+
+    createBtn.addEventListener('click', () => { void submit(); });
+    titleInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); void submit(); }
+      else if (e.key === 'Escape') { e.preventDefault(); close(); }
+    });
+  }
+
+  async function openInEditor(filePath: string): Promise<void> {
+    const invoke = (window as any).__TAURI__?.core?.invoke;
+    if (typeof invoke !== 'function') return;
+    try {
+      await invoke('open_task_in_editor', { filePath });
+    } catch (err) {
+      console.error('open_task_in_editor 실패', err);
+      alert(`외부 에디터 오픈 실패: ${err}`);
+    }
+  }
+
+  function build(container: HTMLElement): void {
+    if (!isKarmolabDesktop()) {
+      container.innerHTML = `<div class="kl-task-launcher"><div class="empty">TASK Launcher 는 KarmoLab 데스크톱 앱 (Tauri) 에서만 동작합니다.</div></div>`;
+      return;
+    }
+
+    if (!document.getElementById(STYLE_ID)) {
+      const style = document.createElement('style');
+      style.id = STYLE_ID;
+      style.textContent = CSS;
+      document.head.appendChild(style);
+    }
+
+    // 이전 마운트의 unlisten 정리
+    const prevUnlisten = (container as any).__kl_launcher_unlisten as (() => void) | undefined;
+    if (typeof prevUnlisten === 'function') {
+      try { prevUnlisten(); } catch (e) { console.error('previous unlisten 실패', e); }
+      (container as any).__kl_launcher_unlisten = null;
+    }
+
+    container.innerHTML = `
+      <div class="kl-task-launcher">
+        <div class="header">
+          <input type="text" class="search" placeholder="검색 — id / title / tag / status">
+          <button class="new-btn">+ 새 TASK</button>
+        </div>
+        <div class="meta" data-meta>로딩 중…</div>
+        <div class="list" data-list></div>
+      </div>
+    `;
+
+    const root = container.querySelector('.kl-task-launcher') as HTMLElement;
+    const searchEl = root.querySelector('.search') as HTMLInputElement;
+    const listEl = root.querySelector('[data-list]') as HTMLElement;
+    const metaEl = root.querySelector('[data-meta]') as HTMLElement;
+    const newBtn = root.querySelector('.new-btn') as HTMLButtonElement;
+
+    let currentTasks: MemoTaskNode[] = [];
+
+    const reload = async (): Promise<void> => {
+      const tree = await fetchTree();
+      if (!tree) {
+        listEl.innerHTML = `<div class="empty">데이터 로딩 실패. F12 콘솔 확인.</div>`;
+        metaEl.textContent = '오류';
+        return;
+      }
+      currentTasks = tree.tasks;
+      metaEl.textContent = `${currentTasks.length} TASK · memo: ${tree.memoPath}`;
+      renderList(listEl, currentTasks, searchEl.value);
+    };
+
+    void reload();
+
+    searchEl.addEventListener('input', () => {
+      renderList(listEl, currentTasks, searchEl.value);
+    });
+
+    listEl.addEventListener('click', (e) => {
+      const row = (e.target as HTMLElement).closest('.row') as HTMLElement | null;
+      if (!row) return;
+      const filePath = row.dataset.file;
+      if (filePath) void openInEditor(filePath);
+    });
+
+    newBtn.addEventListener('click', () => {
+      showCreateModal(root, async (newPath) => {
+        // 생성 후 자동 오픈 + 트리 새로고침 (file watcher 도 잡지만 즉시 반영)
+        await openInEditor(newPath);
+        await reload();
+      });
+    });
+
+    setTimeout(() => searchEl.focus(), 100);
+
+    // KL-024 file watcher 이벤트 listen — 외부 변경 시 자동 새로고침
+    const tauriEvent = (window as any).__TAURI__?.event;
+    if (tauriEvent && typeof tauriEvent.listen === 'function') {
+      void (async () => {
+        try {
+          const unlisten = await tauriEvent.listen('quest-tree-changed', () => { void reload(); });
+          (container as any).__kl_launcher_unlisten = unlisten;
+        } catch (err) {
+          console.error('quest-tree-changed listen 실패', err);
+        }
+      })();
+    }
+  }
+
+  Toolbox.register({
+    ...Toolbox.getLazyWidgetPublicMeta('task-launcher'),
+    tabs: [{ id: 'task-launcher-main', label: 'Launcher', build }],
+  });
+})();


### PR DESCRIPTION
## 요약

QuestLog (도메인 트리) 와 다른 axis — **flat 검색 + 외부 에디터 오픈 + 새 TASK 즉석 생성** 위젯.

### Rust (quest_launcher.rs 신규)
- **open_task_in_editor** — 화이트리스트 검증 후 `open` crate 로 OS 기본 에디터 (Obsidian/VS Code 등)
- **create_task** — 도메인 + 제목 → 다음 ID 자동 발급 + frontmatter skeleton 생성 + 절대 경로 반환
- 6 도메인 prefix 매핑 (wm→WM, karmolab→KL, yawnbot→YB, life→LIFE, hobby→HOBBY, learning→LEARN)
- 파일명 정규화 (공백→`-`, unsafe 문자 제거, 양 끝 trim)
- `next_task_id_number` — 디렉토리 스캔, sub-phase letter (`-A-`, `-B-`) 무시, max NNN + 1
- 12 cargo test

### TypeScript (task-launcher.ts 신규)
- `get_quest_tree` 재사용 → flat 리스트
- 검색 (id/title/tag/status 부분 일치, 클라이언트 측 즉시 필터)
- 행 클릭 → `open_task_in_editor`
- "+ 새 TASK" 모달 — domain dropdown + title input + Enter/Escape 단축
- KL-024 `quest-tree-changed` listen → 외부 변경 자동 새로고침

### 인프라
- `validate_task_path` 를 `pub(crate)` 로 — launcher 도 같은 화이트리스트
- `allow-task-launcher` permission 신규 + capability 등록
- `widgets-lazy-meta.ts` 에 task-launcher 항목 추가 (category=desktop)

## 검증 시나리오

- [ ] 위젯 열림 → 모든 TASK flat 리스트 표시
- [ ] 검색 "WM" 입력 → WM 도메인만 필터
- [ ] 검색 "questlog" → 태그 매칭으로 KL-017~024 표시
- [ ] 행 클릭 → 외부 에디터 (.md 기본 연결 앱) 에서 파일 오픈
- [ ] "+ 새 TASK" → KL 도메인 + "test new task" → KL-026 (또는 그 이후) 파일 생성 + 자동 오픈
- [ ] 외부에서 새 TASK 만들기 → 위젯 자동 갱신 (KL-024 watcher)

## 후속

- 행 우측에 빠른 액션 버튼 (status 변경 dropdown, 삭제 등)
- 정렬 옵션 (최근 수정, status 별)
- 키보드 nav (↑↓ + Enter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)