### PR TITLE
feat(launcher): TASK-KL-027 — mtime 정렬 (최근 수정 desc 디폴트)

### DIFF
--- a/apps/karmolab-tauri/src-tauri/src/quest_index.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_index.rs
@@ -56,6 +56,9 @@ pub struct TaskNode {
     pub title: String,
     pub file_path: String,
     pub checks: Vec<CheckItem>,
+    /// 파일 mtime (UNIX seconds). KL-027 launcher 정렬 사용.
+    /// metadata read 실패 시 0 (가장 오래된 것으로 정렬됨).
+    pub modified_unix: u64,
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -207,7 +210,13 @@ fn extract_title(file_name: &str) -> String {
 }
 
 /// 단일 TASK 파일 → TaskNode. parse 실패는 Err — 호출자가 errors[] 에 모음.
-fn parse_one_task(file_name: &str, rel_path: &str, content: &str) -> Result<TaskNode, String> {
+/// `modified_unix` 는 호출자가 metadata 에서 미리 read 해 넘긴다 (read 실패 시 0).
+fn parse_one_task(
+    file_name: &str,
+    rel_path: &str,
+    content: &str,
+    modified_unix: u64,
+) -> Result<TaskNode, String> {
     let (fm, body, body_start_line) =
         parse_frontmatter(content).ok_or_else(|| "frontmatter 없음".to_string())?;
 
@@ -257,6 +266,7 @@ fn parse_one_task(file_name: &str, rel_path: &str, content: &str) -> Result<Task
         title,
         file_path: rel_path.to_string(),
         checks,
+        modified_unix,
     })
 }
 
@@ -319,7 +329,15 @@ pub fn get_quest_tree(memo_path: Option<String>) -> Result<QuestTree, String> {
                 }
             };
 
-            match parse_one_task(&file_name, &rel_path, &content) {
+            // 파일 mtime — KL-027 launcher 정렬 사용. 실패 시 0.
+            let modified_unix = fs::metadata(&path)
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(|st| st.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+
+            match parse_one_task(&file_name, &rel_path, &content, modified_unix) {
                 Ok(task) => tasks.push(task),
                 Err(reason) => errors.push(TaskError {
                     file_path: rel_path,
@@ -433,25 +451,26 @@ mod tests {
 
     #[test]
     fn parse_one_task_full_path() {
-        let task = parse_one_task("TASK-WM-007-나무벌목-컨텐츠.md", "wm/tasks/TASK-WM-007-나무벌목-컨텐츠.md", SAMPLE).unwrap();
+        let task = parse_one_task("TASK-WM-007-나무벌목-컨텐츠.md", "wm/tasks/TASK-WM-007-나무벌목-컨텐츠.md", SAMPLE, 1234567890).unwrap();
         assert_eq!(task.id, "TASK-WM-007");
         assert_eq!(task.status, "ready");
         assert_eq!(task.path, vec!["wm".to_string()]);
         assert_eq!(task.tags, vec!["content".to_string(), "lumber".to_string()]);
         assert!(task.parent.is_none());
         assert_eq!(task.checks.len(), 4);
+        assert_eq!(task.modified_unix, 1234567890);
     }
 
     #[test]
     fn parse_one_task_missing_id_errors() {
-        let res = parse_one_task("TASK-WM-001-x.md", "wm/tasks/TASK-WM-001-x.md", SAMPLE_NO_ID);
+        let res = parse_one_task("TASK-WM-001-x.md", "wm/tasks/TASK-WM-001-x.md", SAMPLE_NO_ID, 0);
         assert!(res.is_err());
         assert!(res.unwrap_err().contains("id"));
     }
 
     #[test]
     fn parse_one_task_no_frontmatter_errors() {
-        let res = parse_one_task("TASK-WM-001-x.md", "wm/tasks/TASK-WM-001-x.md", SAMPLE_NO_FM);
+        let res = parse_one_task("TASK-WM-001-x.md", "wm/tasks/TASK-WM-001-x.md", SAMPLE_NO_FM, 0);
         assert!(res.is_err());
         assert!(res.unwrap_err().contains("frontmatter"));
     }
@@ -459,7 +478,7 @@ mod tests {
     #[test]
     fn parse_one_task_with_parent_chain() {
         let content = "---\nid: TASK-WM-027-A\nstatus: done\npriority: normal\npath: [wm, voxel]\nparent: TASK-WM-027\n---\n\n본문\n";
-        let task = parse_one_task("TASK-WM-027-A-블록.md", "wm/tasks/TASK-WM-027-A-블록.md", content).unwrap();
+        let task = parse_one_task("TASK-WM-027-A-블록.md", "wm/tasks/TASK-WM-027-A-블록.md", content, 0).unwrap();
         assert_eq!(task.parent.as_deref(), Some("TASK-WM-027"));
         assert_eq!(task.path, vec!["wm".to_string(), "voxel".to_string()]);
     }

--- a/apps/karmolab/src/widgets/task-launcher.ts
+++ b/apps/karmolab/src/widgets/task-launcher.ts
@@ -23,6 +23,7 @@
     tags: string[];
     title: string;
     filePath: string;
+    modifiedUnix: number;
   }
   interface MemoQuestTree {
     tasks: MemoTaskNode[];
@@ -77,6 +78,11 @@
   padding: 10px 16px; font-weight: 600; cursor: pointer; font-size: 13px;
 }
 .kl-task-launcher .new-btn:hover { background: #e6b85a; }
+.kl-task-launcher .sort-mode {
+  background: var(--paper); color: var(--ink); border: 1px solid var(--line-2);
+  padding: 9px 10px; border-radius: 4px; font-size: 13px; cursor: pointer; outline: none;
+}
+.kl-task-launcher .sort-mode:focus { border-color: var(--accent); }
 .kl-task-launcher .meta { font-size: 12px; color: var(--ink-3); }
 .kl-task-launcher .list { flex: 1; overflow-y: auto; border: 1px solid var(--line); border-radius: 4px; }
 .kl-task-launcher .row {
@@ -165,13 +171,25 @@
   }
 
   /// 필터링된 + 정렬된 task 배열 반환 (DOM 변경 없이 데이터만).
-  function applyFilter(tasks: MemoTaskNode[], query: string, statusFilter: string): MemoTaskNode[] {
-    return [...tasks.filter((t) => matches(t, query, statusFilter))].sort((a, b) => {
-      const domainA = a.path[0] ?? '';
-      const domainB = b.path[0] ?? '';
-      if (domainA !== domainB) return domainA.localeCompare(domainB);
-      return a.id.localeCompare(b.id);
-    });
+  /// sortMode: 'mtime' (최근 수정 desc) 또는 'id' (도메인 → id asc).
+  function applyFilter(
+    tasks: MemoTaskNode[],
+    query: string,
+    statusFilter: string,
+    sortMode: string,
+  ): MemoTaskNode[] {
+    const filtered = [...tasks.filter((t) => matches(t, query, statusFilter))];
+    if (sortMode === 'mtime') {
+      filtered.sort((a, b) => (b.modifiedUnix ?? 0) - (a.modifiedUnix ?? 0));
+    } else {
+      filtered.sort((a, b) => {
+        const domainA = a.path[0] ?? '';
+        const domainB = b.path[0] ?? '';
+        if (domainA !== domainB) return domainA.localeCompare(domainB);
+        return a.id.localeCompare(b.id);
+      });
+    }
+    return filtered;
   }
 
   function renderList(listEl: HTMLElement, sorted: MemoTaskNode[], selectedIdx: number): void {
@@ -296,6 +314,10 @@
       <div class="kl-task-launcher">
         <div class="header">
           <input type="text" class="search" placeholder="검색 — id / title / tag / status (↑↓ Enter Esc)">
+          <select class="sort-mode" data-sort title="정렬 모드">
+            <option value="mtime">최근 수정 ▾</option>
+            <option value="id">ID</option>
+          </select>
           <button class="new-btn">+ 새 TASK</button>
         </div>
         <div class="filter-chips" data-chips>
@@ -312,14 +334,16 @@
     const metaEl = root.querySelector('[data-meta]') as HTMLElement;
     const newBtn = root.querySelector('.new-btn') as HTMLButtonElement;
     const chipsEl = root.querySelector('[data-chips]') as HTMLElement;
+    const sortEl = root.querySelector('[data-sort]') as HTMLSelectElement;
 
     let currentTasks: MemoTaskNode[] = [];
     let filteredTasks: MemoTaskNode[] = [];
     let selectedIdx = 0;
     let statusFilter = 'all';
+    let sortMode = 'mtime';
 
     const refilter = (): void => {
-      filteredTasks = applyFilter(currentTasks, searchEl.value, statusFilter);
+      filteredTasks = applyFilter(currentTasks, searchEl.value, statusFilter, sortMode);
       // 검색·필터 변경 시 첫 행 자동 선택 (범위 밖이면 0)
       if (selectedIdx >= filteredTasks.length) selectedIdx = 0;
       renderList(listEl, filteredTasks, selectedIdx);
@@ -379,6 +403,13 @@
       if (statusFilter === next) return;
       statusFilter = next;
       chipsEl.querySelectorAll('.chip').forEach((c) => c.classList.toggle('on', (c as HTMLElement).dataset.filter === next));
+      selectedIdx = 0;
+      refilter();
+      searchEl.focus();
+    });
+
+    sortEl.addEventListener('change', () => {
+      sortMode = sortEl.value;
       selectedIdx = 0;
       refilter();
       searchEl.focus();


### PR DESCRIPTION
## 요약

KL-025/026 후속 — launcher 에 **mtime (최근 수정) 정렬** 추가. "방금 뭐 만지고 있었지" 워크플로 — 직전 편집 TASK 가 항상 최상단.

### Rust (quest_index.rs)
- `TaskNode.modified_unix: u64` 필드 추가 (UNIX seconds)
- `get_quest_tree` 가 `fs::metadata` 로 mtime 읽어 `parse_one_task` 에 전달
- metadata 읽기 실패 시 0 (정렬 시 가장 오래된 것)
- `parse_one_task` 시그니처: `(file_name, rel_path, content, modified_unix)`

### TypeScript (task-launcher.ts)
- `MemoTaskNode.modifiedUnix` 인터페이스 확장
- `applyFilter(tasks, query, statusFilter, sortMode)` — sortMode 분기 (`mtime` desc / `id` asc)
- 검색창 옆 `<select>` dropdown — 디폴트 `mtime`, fallback `id`
- 정렬 변경 시 selectedIdx 0 + 검색창 포커스 자동 복귀

## 테스트

- cargo test: 13/13 (parse_one_task_full_path 가 modified_unix=1234567890 검증 추가)
- TypeScript: 클린

## 검증 시나리오

- [ ] 위젯 열기 → 디폴트 정렬 = 최근 수정 desc, 가장 최근 TASK 가 최상단
- [ ] 외부에서 임의 TASK 수정 → 위젯 자동 새로고침 (KL-024 watcher) → 그 TASK 가 최상단
- [ ] 정렬 dropdown "ID" 선택 → 도메인 → id 오름차순으로 회귀
- [ ] 정렬 변경 후 ↑↓ 키 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)