### PR TITLE
chore(ci): TASK-KL-029 — auto-merge.yml GH_TOKEN: PAT_FOR_AUTO_MERGE

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,7 +13,10 @@ jobs:
       contents: write
     steps:
       - name: Enable auto-merge
+        # PAT 사용 (GITHUB_TOKEN 아님) — GitHub 재귀 방지로 GITHUB_TOKEN 머지는
+        # master push event trigger 차단 → pages-deploy.yml / verify.yml 자동 미작동.
+        # 정본: memo/projects/karmolab/tasks/TASK-KL-029-pat-auto-merge.md.
         run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_FOR_AUTO_MERGE }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,6 +12,17 @@ jobs:
       pull-requests: write
       contents: write
     steps:
+      - name: Check PAT availability
+        # PAT_FOR_AUTO_MERGE 누락 시 silent 실패 방지 — visible ::error:: 로 전환.
+        # 누락 원인: 신규 등록 누락 / fine-grained PAT 1년 만료. 정본 TASK-KL-029.
+        env:
+          PAT: ${{ secrets.PAT_FOR_AUTO_MERGE }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::error::secret PAT_FOR_AUTO_MERGE 누락 — auto-merge 차단됨. memo/projects/karmolab/tasks/TASK-KL-029-pat-auto-merge.md § 사용자 액션 참고."
+            exit 1
+          fi
+
       - name: Enable auto-merge
         # PAT 사용 (GITHUB_TOKEN 아님) — GitHub 재귀 방지로 GITHUB_TOKEN 머지는
         # master push event trigger 차단 → pages-deploy.yml / verify.yml 자동 미작동.


### PR DESCRIPTION
## Summary

- `auto-merge.yml` 의 `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` → `${{ secrets.PAT_FOR_AUTO_MERGE }}` 교체
- GitHub 재귀 방지로 `GITHUB_TOKEN` 머지는 master push event trigger 차단 → `pages-deploy.yml` + `verify.yml` 자동 미작동 빚 해소

## 컨텍스트 (PR #27 머지 후 발견)

- 가장 최근 master push event = `b9718c2c` 2026-05-05 22:02:47 (사용자 직접 push)
- PR #15 ~ #27 모두 Auto Merge bot 으로 머지됨 → master push event trigger 안 발동
- `pages-deploy.yml` 마지막 push 트리거 = 5/5. 그 후 사이트 변경 미배포 상태였음
- 일시 복구는 `gh workflow run pages-deploy.yml --ref master` 수동 trigger

## 머지 전 선행 — 사용자 액션 (필수)

1. **PAT 생성** — Settings → Developer settings → Personal access tokens → Fine-grained tokens
   - Repository: \`Mascari4615/Mascari4615.github.io\`
   - Permissions: \`contents: write\`, \`pull-requests: write\`
   - Expiration: 1 year (또는 정책)
2. **Repo secret 등록**:
   \`\`\`
   gh secret set PAT_FOR_AUTO_MERGE -R Mascari4615/Mascari4615.github.io --body <token>
   \`\`\`

> ⚠ 위 두 단계 *없이* 본 PR 머지하면 다음 PR 의 auto-merge 워크플로가 *silent 실패* 합니다 (PAT_FOR_AUTO_MERGE 가 빈 값으로 평가). PAT 등록 후 PR Ready → 머지 순서 권장.

## Test plan

- [ ] (사용자) PAT 생성 + \`gh secret set PAT_FOR_AUTO_MERGE\` 등록
- [ ] 본 PR Ready → 머지
- [ ] 다음 PR (예: KL-030/031/032 후속 PR) 머지 직후 \`gh run list --branch master --event push --limit 5\` 실행
- [ ] 결과에 \`verify (master invariant)\` + \`Build and Deploy\` 워크플로 자동 출현 확인
- [ ] (회귀 모니터) 한 번 더 머지 후 동일 결과 — 안정 작동 확인

## 정본

- TASK 문서: \`memo/projects/karmolab/tasks/TASK-KL-029-pat-auto-merge.md\`
- 부모 PR: #27 (verify 합성 잡 + 검증 워크플로 4개 폐기)
- 자매 follow-up: KL-030 (workflow_dispatch), KL-031 (chirpy lint), KL-032 (typos)
- 룰 단일 출처: \`memo/UMBRELLA.md\` § 자동화 가능 룰은 코드로

## 후속 backlog (TASK-KL-029 § Backlog)

- B1: WitchMendokusai 레포 동일 패턴 점검 (verify 인프라 도입 전 사전 작업)
- C1: PAT 만료 알림 자동화 (1년 후 silent 차단 방지)
- C2: auto-merge.yml fallback 안전망 — PAT 누락 시 silent 실패 detect
- C3: Branch Protection 「PAT bot 우회 허용」 점검
- D1: PR 템플릿에 PAT 요구사항 한 줄 추가 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)