### PR TITLE
chore(ci): TASK-KL-030 — verify.yml workflow_dispatch 응급 manual trigger

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,6 +17,10 @@ on:
     branches: [master, main]
   pull_request:
     branches: [master, main]
+  # 응급 manual trigger — KL-029 (PAT) 미해결 / Auto Merge 우회 등으로 master push
+  # event 미발동 시점에 사용자/자동화가 master 검증 강제 호출 (`gh workflow run verify.yml --ref master`).
+  # KL-029 해결 후엔 push trigger 정상 작동 → 본 trigger 는 응급 가치만 남음.
+  workflow_dispatch:
 
 jobs:
   verify:


### PR DESCRIPTION
## Summary

`verify.yml` 의 `on:` 에 `workflow_dispatch:` 1줄 추가.

- 응급 시 `gh workflow run verify.yml --ref master` 로 master 검증 강제 호출 가능
- KL-029 (PAT) 미해결 상태 + Auto Merge 머지 → master push event trigger 차단 → 본 trigger 가 응급 우회

## 가치

- **KL-029 해결 전**: master push trigger 차단됨 → 응급 시 본 dispatch trigger 가 유일한 master 검증 경로
- **KL-029 해결 후**: push trigger 정상 작동 → 본 trigger 는 응급 가치만 남음 (rare 사용)

## Test plan

- [ ] (자동) verify.yml syntax check 통과
- [ ] (사용자) 본 PR 머지 후 `gh workflow run verify.yml --ref master` 수동 trigger
- [ ] (확인) Actions UI 에서 `workflow_dispatch` event 로 verify run 출현 확인

## 정본

- TASK 문서: `memo/projects/karmolab/tasks/TASK-KL-030-verify-workflow-dispatch.md`
- 부모 PR: #27 (verify 합성 잡 + 검증 워크플로 4개 폐기)
- 자매 follow-up: KL-029 (PAT 우선 — PR #31), KL-031 (chirpy lint), KL-032 (typos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)