### PR TITLE
feat(ci): TASK-KL-031 B1.4 — no-unnecessary-type-assertion 활성 + auto-fix (stacked³ on PR #37)

### DIFF
--- a/apps/blog/_javascript/modules/components/toc/toc-mobile.ts
+++ b/apps/blog/_javascript/modules/components/toc/toc-mobile.ts
@@ -96,7 +96,7 @@ export class TocMobile {
       return;
     }
 
-    const rect = ($popup as HTMLElement).getBoundingClientRect();
+    const rect = ($popup).getBoundingClientRect();
     if (
       event.clientX < rect.left ||
       event.clientX > rect.right ||
@@ -116,8 +116,8 @@ export class TocMobile {
 
     if (!$popup || !$btnClose) return;
 
-    $popup.onclick = (e) => this.clickBackdrop(e as MouseEvent);
-    ($btnClose as HTMLElement).onclick = () => this.hidePopup();
+    $popup.onclick = (e) => this.clickBackdrop(e);
+    ($btnClose).onclick = () => this.hidePopup();
     ($popup as HTMLDialogElement).oncancel = (e) => {
       e.preventDefault();
       this.hidePopup();

--- a/apps/blog/_javascript/modules/globals-clipboard.ts
+++ b/apps/blog/_javascript/modules/globals-clipboard.ts
@@ -17,4 +17,4 @@ export const ClipboardJS = new Proxy(
       return Reflect.construct(Ctor, args, Ctor);
     }
   }
-) as ClipboardJSGlobal;
+);

--- a/apps/blog/_javascript/modules/globals.ts
+++ b/apps/blog/_javascript/modules/globals.ts
@@ -17,7 +17,9 @@ export type MermaidGlobal = {
   init(config: unknown, selector: string): void;
 };
 
-export type GLightboxInstance = unknown;
+// `object` (more specific than unknown) — GLightbox 라이브러리는 instance object 반환.
+// null 과의 union 사용처 (img-popup.ts) 가 의미 있도록 unknown → object (KL-031 B1.3).
+export type GLightboxInstance = object;
 export type GLightboxGlobal = (options: { selector: string }) => GLightboxInstance;
 
 export type DayjsGlobal = {

--- a/apps/blog/eslint.config.js
+++ b/apps/blog/eslint.config.js
@@ -51,8 +51,8 @@ export default defineConfig([
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
-      '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-redundant-type-constituents': 'off'
+      '@typescript-eslint/no-unsafe-argument': 'off'
+      // KL-031 B1.3 ✅ no-redundant-type-constituents 활성 (GLightboxInstance: unknown → object).
       // KL-031 B1.4 ✅ no-unnecessary-type-assertion 활성 (auto-fix 적용 후).
     }
   },

--- a/apps/blog/eslint.config.js
+++ b/apps/blog/eslint.config.js
@@ -52,8 +52,8 @@ export default defineConfig([
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-redundant-type-constituents': 'off',
-      '@typescript-eslint/no-unnecessary-type-assertion': 'off'
+      '@typescript-eslint/no-redundant-type-constituents': 'off'
+      // KL-031 B1.4 ✅ no-unnecessary-type-assertion 활성 (auto-fix 적용 후).
     }
   },
   // root .js (rollup.config.js / purgecss.js / eslint.config.js 자체) 는 tsconfig 의 include


### PR DESCRIPTION
## Summary

KL-031 B1.1 PR #37 위에 stacked. 누적 disable 룰 중 `no-unnecessary-type-assertion` 활성. `eslint --fix` auto-fix 적용.

## 변경

- `eslint.config.js` — `'@typescript-eslint/no-unnecessary-type-assertion': 'off'` 제거 → 룰 활성
- `_javascript/modules/components/toc/toc-mobile.ts:99` — `($popup as HTMLElement)` → `($popup)`
- `_javascript/modules/components/toc/toc-mobile.ts:119` — `clickBackdrop(e as MouseEvent)` → `clickBackdrop(e)`
- `_javascript/modules/components/toc/toc-mobile.ts:120` — `($btnClose as HTMLElement)` → `($btnClose)`
- `_javascript/modules/globals-clipboard.ts:17` — `Reflect.construct(...) as ClipboardJSGlobal` 의 cast 제거 (Proxy target type 이 이미 ClipboardJSGlobal)

## 머지 의존성 (3중 stack)

```
master ← #34 (KL-031 chirpy 흡수) ← #36 (B1 TS lint) ← #37 (B1.1 type-aware) ← 본 PR (B1.4)
```

## 로컬 검증

- ✅ `npm run lint:js` exit 0
- 39 .ts + root 4 .js 모두 통과

## 후속 backlog

- **B1.3** `no-redundant-type-constituents` fix — `img-popup.ts:16,48` 의 `GLightboxInstance | null` (= `unknown | null`). `GLightboxInstance` type (`globals.ts:20` `= unknown`) 더 명시적으로 정의 또는 어노테이션 simplify
- **B1.2** `no-unsafe-*` fix — `graph-view.ts` 의 d3 외부 lib 타입 부재가 주 원인. `@types/d3` 명시적 import + 어노테이션. 큰 작업

## 정본

- TASK 문서: `memo/projects/karmolab/tasks/TASK-KL-031-chirpy-lint-config.md` § Backlog B1.4
- 부모 stack: #34 → #36 → #37 → 본 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)