### PR TITLE
feat(ci): TASK-KL-031 B1.3 — no-redundant-type-constituents 활성 (stacked⁴ on PR #38)

### DIFF
--- a/apps/blog/_javascript/modules/globals.ts
+++ b/apps/blog/_javascript/modules/globals.ts
@@ -17,7 +17,9 @@ export type MermaidGlobal = {
   init(config: unknown, selector: string): void;
 };
 
-export type GLightboxInstance = unknown;
+// `object` (more specific than unknown) — GLightbox 라이브러리는 instance object 반환.
+// null 과의 union 사용처 (img-popup.ts) 가 의미 있도록 unknown → object (KL-031 B1.3).
+export type GLightboxInstance = object;
 export type GLightboxGlobal = (options: { selector: string }) => GLightboxInstance;
 
 export type DayjsGlobal = {

--- a/apps/blog/eslint.config.js
+++ b/apps/blog/eslint.config.js
@@ -51,8 +51,8 @@ export default defineConfig([
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
-      '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-redundant-type-constituents': 'off'
+      '@typescript-eslint/no-unsafe-argument': 'off'
+      // KL-031 B1.3 ✅ no-redundant-type-constituents 활성 (GLightboxInstance: unknown → object).
       // KL-031 B1.4 ✅ no-unnecessary-type-assertion 활성 (auto-fix 적용 후).
     }
   },


### PR DESCRIPTION
## Summary

KL-031 B1.4 PR #38 위에 stacked. `no-redundant-type-constituents` 룰 활성.

`GLightboxInstance` type: `unknown` → `object`. `unknown` 은 모든 type 흡수 → `GLightboxInstance | null` = `unknown | null` = `unknown` (redundant). `object` 로 변경 시 union 의 의미 보존.

## 변경

- `_javascript/modules/globals.ts:20` — `export type GLightboxInstance = unknown` → `export type GLightboxInstance = object`
- `eslint.config.js` — `'@typescript-eslint/no-redundant-type-constituents': 'off'` 제거 → 룰 활성

## 머지 의존성 (4중 stack)

```
master ← #34 ← #36 (B1) ← #37 (B1.1) ← #38 (B1.4) ← 본 PR (B1.3)
```

## 로컬 검증

- ✅ `npm run lint:js` exit 0
- ✅ `npx tsc --noEmit` (apps/blog) 0 error

## 후속 backlog

- **B1.2** `no-unsafe-*` fix — `graph-view.ts` 의 d3 외부 lib 타입 부재. 큰 작업 (`@types/d3` 명시적 import + 어노테이션). 별 sub TASK.

## 정본

- TASK 문서: `memo/projects/karmolab/tasks/TASK-KL-031-chirpy-lint-config.md` § Backlog B1.3
- 부모 stack: #34 → #36 → #37 → #38 → 본 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)