### PR TITLE
feat(karmolab-tauri): TASK-KL-037 — adventure 이미지 raw 분리 (dataUrl → 별 PNG)

### DIFF
--- a/apps/karmolab-tauri/src-tauri/Cargo.lock
+++ b/apps/karmolab-tauri/src-tauri/Cargo.lock
@@ -2857,6 +2857,7 @@ dependencies = [
 name = "karmolab-desktop"
 version = "0.1.19"
 dependencies = [
+ "base64 0.22.1",
  "byteorder",
  "candle-core",
  "candle-nn",

--- a/apps/karmolab-tauri/src-tauri/Cargo.toml
+++ b/apps/karmolab-tauri/src-tauri/Cargo.toml
@@ -53,6 +53,9 @@ byteorder = "1"
 # token sampling (greedy / temperature). candle 0.10 dep tree 와 일치 (0.9).
 rand = "0.9"
 
+# TASK-KL-037: adventure dataUrl → 별 PNG 파일 분리 시 base64 디코드.
+base64 = "0.22"
+
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winuser", "processthreadsapi", "psapi", "handleapi", "minwindef", "sysinfoapi"] }
 

--- a/apps/karmolab-tauri/src-tauri/permissions/adventure.toml
+++ b/apps/karmolab-tauri/src-tauri/permissions/adventure.toml
@@ -1,8 +1,9 @@
 [[permission]]
 identifier = "allow-adventure"
-description = "Allow the adventure widget (TASK-KL-032) to: (1) invoke the local claude CLI for narrative turns (Pro/Max OAuth, no API key), (2) write raw turn JSON into memo/projects/karmolab/raw/adventures/, (3) commit + push wiki entity summary on adventure end."
+description = "Allow the adventure widget (TASK-KL-032) to: (1) invoke the local claude CLI for narrative turns (Pro/Max OAuth, no API key), (2) write raw turn JSON into memo/projects/karmolab/raw/adventures/, (3) write turn images as separate PNG files under {slug}/images/ (TASK-KL-037), (4) commit + push wiki entity summary on adventure end."
 commands.allow = [
   "adventure_claude_complete",
   "adventure_save_raw",
+  "adventure_save_image",
   "adventure_commit_summary",
 ]

--- a/apps/karmolab-tauri/src-tauri/src/adventure.rs
+++ b/apps/karmolab-tauri/src-tauri/src/adventure.rs
@@ -8,6 +8,7 @@
 //! ζ-1 (done): adventure_claude_complete — narrative + 선택지 N개 응답.
 //! ζ-2 (현재): adventure_save_raw (memo raw JSON write) + adventure_commit_summary (wiki entity 박기 + git commit + push).
 
+use base64::Engine;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
@@ -123,6 +124,107 @@ fn karmolab_repo_path() -> Result<PathBuf, String> {
 #[derive(Deserialize)]
 pub struct AdventureSessionPayload {
     pub session: serde_json::Value,
+}
+
+/* ===== TASK-KL-037: dataUrl → 별 PNG 파일 분리 ===== */
+
+#[derive(Deserialize)]
+pub struct AdventureSaveImagePayload {
+    #[serde(rename = "sessionSlug")]
+    pub session_slug: String,
+    #[serde(rename = "turnIndex")]
+    pub turn_index: u32,
+    #[serde(rename = "dataUrl")]
+    pub data_url: String,
+}
+
+#[derive(Serialize)]
+pub struct AdventureSaveImageResult {
+    /// session 폴더 기준 상대 경로 (예: "images/turn-03-20260510T0235.png").
+    pub path: String,
+}
+
+/// "data:image/<ext>;base64,<encoded>" → (extension, bytes) 디코드.
+fn parse_data_url(data_url: &str) -> Result<(String, Vec<u8>), String> {
+    let prefix = "data:";
+    if !data_url.starts_with(prefix) {
+        return Err("dataUrl 가 'data:' prefix 아님".to_string());
+    }
+    let after = &data_url[prefix.len()..];
+    let comma = after
+        .find(',')
+        .ok_or_else(|| "dataUrl 에 ',' 구분자 없음".to_string())?;
+    let header = &after[..comma];
+    let encoded = &after[comma + 1..];
+
+    let mut mime = header;
+    let mut is_base64 = false;
+    if let Some((m, params)) = header.split_once(';') {
+        mime = m;
+        for p in params.split(';') {
+            if p.trim().eq_ignore_ascii_case("base64") {
+                is_base64 = true;
+            }
+        }
+    }
+    if !is_base64 {
+        return Err("dataUrl base64 인코딩 아님 (raw URL-encoded 미지원)".to_string());
+    }
+
+    let ext = match mime.to_ascii_lowercase().as_str() {
+        "image/png" => "png",
+        "image/jpeg" | "image/jpg" => "jpg",
+        "image/webp" => "webp",
+        "image/gif" => "gif",
+        other => return Err(format!("지원 안 하는 이미지 mime: {other}")),
+    };
+
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded.trim())
+        .map_err(|e| format!("base64 디코드 실패: {e}"))?;
+
+    Ok((ext.to_string(), bytes))
+}
+
+fn safe_session_slug(slug: &str) -> Result<&str, String> {
+    if slug.is_empty() {
+        return Err("sessionSlug 빈 문자열".to_string());
+    }
+    // path traversal 방지 — slug 는 파일명 segment 만 허용.
+    for ch in slug.chars() {
+        if !(ch.is_ascii_alphanumeric() || ch == '-' || ch == '_') {
+            return Err(format!("sessionSlug 허용 외 문자: {ch:?}"));
+        }
+    }
+    Ok(slug)
+}
+
+#[tauri::command]
+pub fn adventure_save_image(
+    payload: AdventureSaveImagePayload,
+) -> Result<AdventureSaveImageResult, String> {
+    let slug = safe_session_slug(&payload.session_slug)?;
+    let (ext, bytes) = parse_data_url(&payload.data_url)?;
+
+    let memo = memo_path()?;
+    let session_dir = memo
+        .join("projects")
+        .join("karmolab")
+        .join("raw")
+        .join("adventures")
+        .join(slug);
+    let images_dir = session_dir.join("images");
+    fs::create_dir_all(&images_dir)
+        .map_err(|e| format!("images dir 생성 실패 {images_dir:?}: {e}"))?;
+
+    // ts: YYYYMMDDTHHMMSS (압축 ISO 8601 — 파일명 친화). chrono 의존 (이미 있음).
+    let ts = chrono::Utc::now().format("%Y%m%dT%H%M%S").to_string();
+    let filename = format!("turn-{:02}-{ts}.{ext}", payload.turn_index);
+    let abs = images_dir.join(&filename);
+    fs::write(&abs, &bytes).map_err(|e| format!("이미지 쓰기 실패 {abs:?}: {e}"))?;
+
+    let rel = format!("images/{filename}");
+    Ok(AdventureSaveImageResult { path: rel })
 }
 
 #[tauri::command]
@@ -254,31 +356,58 @@ pub fn adventure_commit_summary(
     let mut karmolab_pushed = true;
     let _ = &mut karmolab_pushed; // silence dead_assignment if future short-circuit
 
-    // memo 레포 raw JSON 도 commit + push (모험 종료 시 한 번)
+    // memo 레포 raw JSON + images/ 폴더 commit + push (모험 종료 시 한 번)
+    // KL-037: dataUrl 폐기 후 raw JSON 사이즈 ↓ + images/ 폴더 별 add.
     let memo = memo_path()?;
     let raw_rel = format!("projects/karmolab/raw/adventures/{}.json", payload.slug);
+    let images_rel = format!("projects/karmolab/raw/adventures/{}/images", payload.slug);
+    let session_dir_rel = format!("projects/karmolab/raw/adventures/{}", payload.slug);
     let mut memo_pushed = false;
-    if memo.join(&raw_rel).exists() {
+    let raw_exists = memo.join(&raw_rel).exists();
+    let images_exists = memo.join(&images_rel).exists();
+    if raw_exists || images_exists {
         run_git(&memo, &["fetch", "origin", "main"])?;
-        // raw 가 modified 안 됐을 수도 — git add 후 diff --cached 비어있으면 commit skip
-        run_git(&memo, &["add", &raw_rel])?;
+        // raw json + images/ 폴더 add. 폴더 path 는 git 가 sub 전부 add.
+        let mut add_args: Vec<&str> = vec!["add"];
+        if raw_exists {
+            add_args.push(&raw_rel);
+        }
+        if images_exists {
+            add_args.push(&session_dir_rel);
+        }
+        run_git(&memo, &add_args)?;
+
+        // diff --cached 가 빈지 검사 — pathspec 은 session_dir_rel 안 모두 포함.
         let staged = Command::new("git")
             .current_dir(&memo)
-            .args(["diff", "--cached", "--quiet", "--", &raw_rel])
+            .args([
+                "diff",
+                "--cached",
+                "--quiet",
+                "--",
+                &raw_rel,
+                &session_dir_rel,
+            ])
             .status()
             .map_err(|e| format!("git diff 실패: {e}"))?;
         if !staged.success() {
-            // diff 있음 (rc=1) — commit
-            run_git(
-                &memo,
-                &[
-                    "commit",
-                    "-o",
-                    &raw_rel,
-                    "-m",
-                    &format!("data(kl): KL-032 모험 raw 박음 — {} ({})", payload.title, payload.slug),
-                ],
-            )?;
+            // diff 있음 (rc=1) — commit (path-only 로 다른 세션 staged race 방어).
+            let mut commit_args: Vec<&str> = vec!["commit"];
+            if raw_exists {
+                commit_args.push("-o");
+                commit_args.push(&raw_rel);
+            }
+            if images_exists {
+                commit_args.push("-o");
+                commit_args.push(&session_dir_rel);
+            }
+            let msg = format!(
+                "data(kl): KL-032 모험 raw + 이미지 박음 — {} ({})",
+                payload.title, payload.slug,
+            );
+            commit_args.push("-m");
+            commit_args.push(&msg);
+            run_git(&memo, &commit_args)?;
             run_git(&memo, &["push", "origin", "main"])?;
             memo_pushed = true;
         }

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -11,7 +11,9 @@ mod repo_file;
 mod terminal;
 
 use activity::{activity_list_days, activity_query_day, activity_status, ActivityState};
-use adventure::{adventure_claude_complete, adventure_commit_summary, adventure_save_raw};
+use adventure::{
+    adventure_claude_complete, adventure_commit_summary, adventure_save_image, adventure_save_raw,
+};
 use questlog_hub::get_questlog_hub;
 use life::life_screen_capture;
 use quest_index::get_quest_tree;
@@ -896,6 +898,7 @@ pub fn run() {
             life_set_feature,
             adventure_claude_complete,
             adventure_save_raw,
+            adventure_save_image,
             adventure_commit_summary
         ])
         .plugin(tauri_plugin_updater::Builder::new().build())

--- a/apps/karmolab/src/widgets/adventure/adventure.ts
+++ b/apps/karmolab/src/widgets/adventure/adventure.ts
@@ -304,7 +304,8 @@ import { attachImageRef } from './turn-loop';
         void (async () => {
           try {
             const result = await generateAdventureImage(narrative);
-            attachImageRef(state!.session, result.dataUrl);
+            // 실시간 표시는 dataUrl (메모리), 영구 저장은 path (KL-037 — Tauri 시 별 PNG).
+            await attachImageRef(state!.session, result.dataUrl);
             const img = el('img', {
               src: result.dataUrl,
               alt: result.prompt.slice(0, 100),

--- a/apps/karmolab/src/widgets/adventure/storage.ts
+++ b/apps/karmolab/src/widgets/adventure/storage.ts
@@ -5,6 +5,9 @@
  * 브라우저: localStorage 임시 (Tauri 미가용 시 fallback).
  *
  * raw = turn 마다 user/assistant message + parsed (선택지 / NPC / scene) + image refs 누적.
+ *
+ * KL-037: 이미지 (η Vertex Imagen) 는 dataUrl 인라인 X — `adventure_save_image` 가
+ * 별 PNG 로 박고 path 만 imageRef 에 박힘. raw JSON 사이즈 폭주 방지 + git diff/push 비용 ↓.
  */
 
 export interface AdventureTurnRecord {
@@ -56,6 +59,47 @@ export function createSession(castSlugs: string[]): AdventureSession {
     castSlugs: castSlugs.slice(),
     turns: [],
   };
+}
+
+/**
+ * KL-037: dataUrl → 별 PNG 파일 박고 session-relative path 반환.
+ *
+ * Tauri 환경: `adventure_save_image` 호출 → `images/turn-NN-ts.png` write → path return.
+ * Tauri 미가용 시 (브라우저): dataUrl 그대로 반환하지만 size limit (~256KB) 초과면 경고 + null.
+ */
+export async function saveImage(
+  slug: string,
+  turnIndex: number,
+  dataUrl: string,
+): Promise<string | null> {
+  const invoke = getTauriInvoke();
+  if (invoke) {
+    try {
+      const result = (await invoke('adventure_save_image', {
+        payload: {
+          sessionSlug: slug,
+          turnIndex,
+          dataUrl,
+        },
+      })) as { path?: string };
+      if (result?.path) {
+        return result.path;
+      }
+      console.warn('[adventure] adventure_save_image: path 없음', result);
+      return null;
+    } catch (err) {
+      console.warn('[adventure] adventure_save_image 실패, dataUrl fallback', err);
+    }
+  }
+  // 브라우저 fallback — dataUrl 직접 박지만 size limit 강제 (KL-037 raw JSON 폭주 방지).
+  const SIZE_LIMIT = 256 * 1024; // 256KB
+  if (dataUrl.length > SIZE_LIMIT) {
+    console.warn(
+      `[adventure] dataUrl 크기 ${dataUrl.length} > ${SIZE_LIMIT} — 인라인 박지 않음`,
+    );
+    return null;
+  }
+  return dataUrl;
 }
 
 export async function saveSession(session: AdventureSession): Promise<void> {

--- a/apps/karmolab/src/widgets/adventure/turn-loop.ts
+++ b/apps/karmolab/src/widgets/adventure/turn-loop.ts
@@ -9,6 +9,7 @@ import { buildSystemInstruction, parseTurnResponse, type ParsedTurn } from './pr
 import {
   type AdventureSession,
   type AdventureTurnRecord,
+  saveImage,
   saveSession,
 } from './storage';
 
@@ -100,10 +101,24 @@ export async function runTurn(
   }
 }
 
-export function attachImageRef(state: TurnLoopState, imageRef: string): void {
-  const last = state.session.turns[state.session.turns.length - 1];
+/**
+ * KL-037: dataUrl → 별 PNG 파일 박고 imageRefs 에 path 박음.
+ *
+ * Tauri 환경: `adventure_save_image` → `images/turn-NN-ts.png` 박힘 + path 받음.
+ * 브라우저: dataUrl size limit (~256KB) 안이면 dataUrl 박힘, 초과면 imageRef 박지 않음.
+ *
+ * 호출처가 `state.session` 만 넘기는 패턴이라 첫 인자 = AdventureSession.
+ */
+export async function attachImageRef(
+  session: AdventureSession,
+  dataUrl: string,
+): Promise<void> {
+  const turnIndex = session.turns.length - 1;
+  const last = session.turns[turnIndex];
   if (!last) return;
+  const ref = await saveImage(session.slug, turnIndex, dataUrl);
+  if (!ref) return;
   last.imageRefs = last.imageRefs ?? [];
-  last.imageRefs.push(imageRef);
-  void saveSession(state.session);
+  last.imageRefs.push(ref);
+  await saveSession(session);
 }


### PR DESCRIPTION
## 의도

Vertex Imagen dataUrl 이 raw JSON 인라인되어 사이즈 폭주 (5 turn × 1 image ≈ 5MB+) + git diff/push 비용 ↑. dataUrl → 별 PNG 파일 분리 + path 만 imageRefs 박힘.

TASK: [TASK-KL-037](../blob/master/memo/projects/karmolab/tasks/TASK-KL-037-adventure-이미지-raw-분리.md) (memo PR 별도).

## 변경

### Rust (Tauri)
- `adventure_save_image` Tauri command 신설 — base64 디코드 + ext 추론 (png/jpg/webp/gif).
  - output: `memo/projects/karmolab/raw/adventures/{slug}/images/turn-NN-YYYYMMDDTHHMMSS.png`
  - return: session-relative path (예: `images/turn-03-20260510T0235.png`)
- `safe_session_slug` — path traversal 방지 (alphanumeric + hyphen + underscore).
- `adventure_commit_summary` — raw JSON 외 `images/` 폴더도 git add. path-only commit (`-o` pathspec) 로 다른 세션 staged race 방어.

### ACL (KL-035 룰 정합)
- `permissions/adventure.toml` — `adventure_save_image` 추가.
- `lib.rs invoke_handler` — 등록.

### TS
- `storage.ts saveImage(slug, turnIndex, dataUrl)` — Tauri 시 invoke + path 반환, 브라우저 시 dataUrl size limit 256KB 강제.
- `turn-loop.ts attachImageRef` — `Promise<void>` 반환 (signature 시그너처 정합: `session` 직접 받음). Tauri 시 별 PNG 박고 imageRefs 에 path push.
- `adventure.ts` — `await` 박음 (race window 닫음).

## Test plan

- [x] 로컬 verify — `cd apps/karmolab-tauri/src-tauri && cargo check --all-targets` ✅ (error 0, KL-037 무관 warning 2 기존)
- [x] 로컬 build — `cd apps/karmolab && npm run build` ✅
- [ ] 사용자 수동 검증 — KarmoLab dev 에서 모험 시작 → 📷 버튼 클릭 → `images/turn-NN-...png` 박힘 + raw JSON 안 path 만 박힘 확인
- [ ] CI verify — verify (master invariant)
- [ ] 모험 종료 (모험 종료 + 정수 추출) → memo 레포 commit message 「raw + 이미지 박음」 확인 + images/ 폴더 push

## 후속

- 세션 재로드 시 imageRefs path → `<img src>` 표시 (Tauri convertFileSrc) — KL-038 (resume UX) 영역
- KL-032 정수 추출 시 이미지 1장도 정수 candidate (별 sub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 모험 카메라로 캡처한 이미지 스냅샷이 이제 자동으로 저장됩니다.
* 각 이미지는 타임스탬프가 지정된 파일로 저장되어 추적 및 관리가 가능합니다.
* 데스크톱 애플리케이션과 웹 브라우저 환경을 모두 지원합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/41)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->