### PR TITLE
perf(tauri): KL-043 sync Tauri command → async + spawn_blocking 마이그레이션

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,3 +343,8 @@ master 브랜치는 항상 다음을 만족:
     - 봉제 명령 (`localdev_send_stdin`), 외부 실행 PID 발견·종료 (`localdev_list_external_pids` / `localdev_stop_external`), 재기동 후 PID reattach 등도 자동.
     - 트레이 「개발 모드 (로컬 8899)」 토글은 KarmoLab 자체 (WebView 가 보는 페이지) 를 로컬 정적 서버로 띄울 때만. 일반 봇/서버는 `devProfiles` 가 정답.
     - 코드: `apps/karmolab-tauri/src-tauri/src/local_dev.rs`. 사용자 문서: `apps/karmolab/js/widgets/docs/local-dev-runner.md`.
+13. **IO 무거운 `#[tauri::command]` = `async` + `tauri::async_runtime::spawn_blocking` 강제** (TASK-KL-043, 2026-05-13).
+    - 기준: `fs::read_dir` 다중 호출 / external `std::process::Command` spawn (git, claude CLI, gh 등) / xcap + OCR + LLM 등 수 초 작업.
+    - 패턴: `pub async fn cmd(params) -> Result<T, String> { tauri::async_runtime::spawn_blocking(move || cmd_blocking(params)).await.map_err(|e| format!("spawn_blocking join 실패: {}", e))? }`
+    - 이미 마이그된 명령: `get_questlog_hub` (KL-035), `get_quest_tree`, `adventure_claude_complete`, `adventure_save_raw`, `adventure_commit_summary`, `life_screen_capture`, `desktop_install_pending_update`.
+    - Sync OK (< 10ms, 단일 파일 R/W): `toggle_quest_check`, `set_quest_status`, `set_quest_priority`, `add/delete/rename_quest_check`, `repofile_*`, `open_task_in_editor`, `create_task`, `terminal_*`, `life_get_feature_states`, `life_set_feature`, `desktop_notify`, `desktop_restart_app`.

--- a/apps/karmolab-tauri/src-tauri/src/adventure.rs
+++ b/apps/karmolab-tauri/src-tauri/src/adventure.rs
@@ -85,13 +85,17 @@ fn run_claude(prompt: &str, model_id: &str) -> Result<String, String> {
 }
 
 #[tauri::command]
-pub fn adventure_claude_complete(
+pub async fn adventure_claude_complete(
     payload: AdventureCompletePayload,
 ) -> Result<AdventureCompleteResult, String> {
-    let prompt = build_prompt(&payload);
-    let model_id = payload.model_id.clone();
-    let text = run_claude(&prompt, &model_id)?;
-    Ok(AdventureCompleteResult { text, model_id })
+    tauri::async_runtime::spawn_blocking(move || {
+        let prompt = build_prompt(&payload);
+        let model_id = payload.model_id.clone();
+        let text = run_claude(&prompt, &model_id)?;
+        Ok(AdventureCompleteResult { text, model_id })
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
 }
 
 /* ===== ζ-2: raw save + wiki commit ===== */
@@ -126,7 +130,13 @@ pub struct AdventureSessionPayload {
 }
 
 #[tauri::command]
-pub fn adventure_save_raw(payload: AdventureSessionPayload) -> Result<(), String> {
+pub async fn adventure_save_raw(payload: AdventureSessionPayload) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || adventure_save_raw_blocking(payload))
+        .await
+        .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
+}
+
+fn adventure_save_raw_blocking(payload: AdventureSessionPayload) -> Result<(), String> {
     let session = &payload.session;
     let slug = session
         .get("slug")
@@ -181,7 +191,15 @@ fn run_git(cwd: &PathBuf, args: &[&str]) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn adventure_commit_summary(
+pub async fn adventure_commit_summary(
+    payload: AdventureSummaryPayload,
+) -> Result<AdventureCommitResult, String> {
+    tauri::async_runtime::spawn_blocking(move || adventure_commit_summary_blocking(payload))
+        .await
+        .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
+}
+
+fn adventure_commit_summary_blocking(
     payload: AdventureSummaryPayload,
 ) -> Result<AdventureCommitResult, String> {
     if payload.slug.is_empty() {

--- a/apps/karmolab-tauri/src-tauri/src/life/screen.rs
+++ b/apps/karmolab-tauri/src-tauri/src/life/screen.rs
@@ -46,8 +46,10 @@ pub struct CaptureResult {
 
 /// Tauri command — webview 또는 외부 invoke 진입점. trigger="manual".
 #[tauri::command]
-pub fn life_screen_capture() -> Result<CaptureResult, String> {
-    capture_with_trigger("manual")
+pub async fn life_screen_capture() -> Result<CaptureResult, String> {
+    tauri::async_runtime::spawn_blocking(|| capture_with_trigger("manual"))
+        .await
+        .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
 }
 
 /// 핵심 capture 함수 — sub-F-3 hotkey handler 가 trigger="hotkey" 로 호출.
@@ -202,7 +204,7 @@ mod live_tests {
 
         // 라이브 vision 호출 비용 회피 (claude vision 30s+) — env 로 disabled.
         std::env::set_var("LIFE_VISION_PROVIDER", "none");
-        let result = life_screen_capture().expect("capture 실패");
+        let result = capture_with_trigger("manual").expect("capture 실패");
         eprintln!(
             "[live] png={} md={} ocr_chars={} domain={:?} app={:?} trigger={} vision={:?} slug-summary='{}'",
             result.png_path,
@@ -248,7 +250,7 @@ mod live_tests {
         }
         std::env::remove_var("LIFE_VISION_PROVIDER");
 
-        let result = life_screen_capture().expect("capture 실패");
+        let result = capture_with_trigger("manual").expect("capture 실패");
         eprintln!("=== sub-G-1 라이브 검증 ===");
         eprintln!("png_path: {}", result.png_path);
         eprintln!("md_path: {}", result.md_path);

--- a/apps/karmolab-tauri/src-tauri/src/quest_index.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_index.rs
@@ -271,7 +271,13 @@ fn parse_one_task(
 }
 
 #[tauri::command]
-pub fn get_quest_tree(memo_path: Option<String>) -> Result<QuestTree, String> {
+pub async fn get_quest_tree(memo_path: Option<String>) -> Result<QuestTree, String> {
+    tauri::async_runtime::spawn_blocking(move || get_quest_tree_blocking(memo_path))
+        .await
+        .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
+}
+
+fn get_quest_tree_blocking(memo_path: Option<String>) -> Result<QuestTree, String> {
     let memo = match memo_path.filter(|s| !s.is_empty()) {
         Some(value) => PathBuf::from(value),
         None => default_memo_path().ok_or_else(|| {


### PR DESCRIPTION
## Summary

- `get_quest_tree` — 6-dir YAML walk, async + spawn_blocking 전환
- `adventure_claude_complete` / `adventure_save_raw` / `adventure_commit_summary` — claude CLI subprocess + git spawn 전환
- `life_screen_capture` — xcap + OCR + LLM subprocess 전환
- `CLAUDE.md` 룰 박음: "IO 무거운 `#[tauri::command]` = `async` + `spawn_blocking` 강제"
- `life/screen.rs` `#[ignore]` 테스트: `life_screen_capture()` → `capture_with_trigger("manual")` (async wrapper 직접 호출 불가)

이미 async 인 명령 (변경 없음): `get_questlog_hub`, `desktop_install_pending_update`.
Sync OK 유지 (단일 파일 R/W < 10ms): `toggle_quest_check`, `set_quest_status` 등 quest_writeback 일체, `repofile_*`, `terminal_*`, `desktop_notify/restart_app`.

## Test plan

- [x] `cargo check --all-targets` 통과 (warnings 2개 — pre-existing, 변경 없음)
- [ ] Tauri 앱 빌드 후 QuestLog 위젯 로드 확인 (get_quest_tree 응답 정상)
- [ ] Adventure 기능 한 번 실행해보기 (claude_complete 응답, save_raw 파일 생성)
- [ ] life_screen_capture hotkey (PrintScreen) 응답 정상 (hotkey 는 여전히 sync thread spawn → 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 주요 변경사항

* **리팩토링**
  * 모험 기록 저장, 요약 커밋, 화면 캡처, 퀘스트 인덱싱 등 무거운 작업의 응답성을 개선했습니다.

* **문서**
  * 개발팀을 위한 입출력 성능 최적화 가이드라인을 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/44)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->