### PR TITLE
chore(ci): TASK-KL-041 — explicit least-privilege permissions for all GH Actions workflows

### DIFF
--- a/.github/workflows/deploy-discord-bots.yml
+++ b/.github/workflows/deploy-discord-bots.yml
@@ -16,6 +16,9 @@ on:
       - '.github/workflows/deploy-discord-bots.yml'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 concurrency:
   group: deploy-discord-bots
   cancel-in-progress: false

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,6 +22,9 @@ on:
   # KL-029 해결 후엔 push trigger 정상 작동 → 본 trigger 는 응급 가치만 남음.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: verify (master invariant)


### PR DESCRIPTION
## Summary

- **verify.yml**: Added `permissions: contents: read` (checkout only, no GH API writes needed)
- **deploy-discord-bots.yml**: Added `permissions: contents: read` (all meaningful ops use PAT or local git; GITHUB_TOKEN unused)
- All other workflows already had explicit `permissions:` blocks: `pages-deploy.yml`, `karmolab-tauri-release.yml`, `auto-merge.yml`, `pat-expiry-check.yml`, `claude.yml`

**Motivation**: Follow-up from KL-035 v0.1.19 release incident — repo `default_workflow_permissions` was changed to `write` as a workaround. Goal: every workflow yaml specifies its own `permissions:` so behavior is repo-default-agnostic. If default ever goes back to `read`, nothing silently breaks.

## Test plan

- [ ] `verify.yml` CI run passes after merge (contents:read is sufficient for checkout + build steps)
- [ ] `deploy-discord-bots.yml` remains functional on next yawnbot deploy (contents:read doesn't restrict PAT ops)
- [ ] No other workflow behavior changed

Closes TASK-KL-041

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * GitHub Actions 워크플로우 보안 설정 업데이트: 배포 및 검증 워크플로우에 대한 권한 제한을 추가하여 보안 구성을 강화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/45)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->