### PR TITLE
feat(yawnbot): TASK-YB-004 — dev-digest Yawn 톤 가공 Discord post

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
@@ -3,6 +3,7 @@ import { EmbedBuilder } from 'discord.js';
 import type { Client } from 'discord.js';
 import type { GameDataService } from '../services/gamedata';
 import { getChannelsForRepo } from '../services/webhook-routes';
+import { isDigestCommit, handleDigestCommit } from '../services/digest-webhook';
 
 export function createGithubWebhookApp(client: Client, gameData: GameDataService) {
   const app = express();
@@ -37,6 +38,17 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
           res.sendStatus(200);
           return;
         }
+
+        // TASK-YB-004 — dev-digest commit 감지: chore(digests): + digests/*.md added.
+        // 해당 commit 발견 시 Yawn AI 가공 후 별도 embed 전송 + regular embed skip.
+        const digestCommit = payload.commits.find((c: any) => isDigestCommit(c));
+        if (digestCommit) {
+          res.sendStatus(200);
+          // async 이므로 res 먼저 보내고 AI 처리 (최대 수 초 소요)
+          void handleDigestCommit(client, digestCommit, repoFullName ?? '', channelIds);
+          return;
+        }
+
         embed.setTitle(gameData.getMessage('Webhook_Push_Title', payload.commits.length));
         const desc = payload.commits
           .slice(0, 5)

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
@@ -1,0 +1,132 @@
+/**
+ * TASK-YB-004 — dev-digest webhook 분기 핸들러.
+ *
+ * trigger: push event, commit message starts with "chore(digests):", added path contains "digests/YYYY-MM-DD.md"
+ * 처리:
+ *   1. GitHub raw URL 에서 digest .md 본문 fetch
+ *   2. Yawn 캐릭터 톤으로 AI 가공 (generateBlobTextFromEnvWithOptions)
+ *   3. Discord 채널에 embed 전송 (regular commit embed 는 skip)
+ */
+import type { Client } from 'discord.js';
+import { EmbedBuilder } from 'discord.js';
+import { generateBlobTextFromEnvWithOptions } from 'karmolab-ai/node';
+
+const DIGEST_CHANNEL_ENV = 'YAWN_DIGEST_CHANNEL_ID';
+const MAX_PLAIN_CHARS = 1800;
+const MAX_FETCH_CHARS = 8000;
+
+/** .md 본문에서 앞 YAML frontmatter (--- ... ---) 를 제거하고 본문만 반환 */
+function stripFrontmatter(raw: string): string {
+  const m = raw.match(/^---[\s\S]*?---\r?\n([\s\S]*)$/);
+  return m ? m[1].trim() : raw.trim();
+}
+
+/**
+ * push payload 의 commit 하나가 dev-digest commit 인지 판별.
+ * 조건: message 첫 줄이 "chore(digests):" 로 시작 + added 파일 중 "digests/" 경로 .md 있음.
+ */
+export function isDigestCommit(commit: any): string | null {
+  const firstLine = String(commit?.message ?? '').split('\n', 1)[0];
+  if (!firstLine.startsWith('chore(digests):')) return null;
+  const added: string[] = Array.isArray(commit?.added) ? commit.added : [];
+  const digestFile = added.find((p) => p.startsWith('digests/') && p.endsWith('.md'));
+  return digestFile ?? null;
+}
+
+/**
+ * digest commit 을 Yawn 톤으로 가공 후 Discord 전송.
+ * 실패해도 예외를 삼켜 호출부 흐름 유지 (digest 실패가 전체 webhook 을 깨지 않게).
+ */
+export async function handleDigestCommit(
+  client: Client,
+  commit: any,
+  repoFullName: string,
+  channelIds: string[],
+): Promise<void> {
+  const digestFile = isDigestCommit(commit);
+  if (!digestFile) return;
+
+  const sha: string = String(commit.id ?? '');
+  const rawUrl = `https://raw.githubusercontent.com/${repoFullName}/${sha}/${digestFile}`;
+
+  try {
+    // 1. fetch digest body
+    let rawBody = '';
+    try {
+      const resp = await fetch(rawUrl, { signal: AbortSignal.timeout(10_000) });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      rawBody = await resp.text();
+    } catch (e: any) {
+      console.error(`[DigestWebhook] raw fetch 실패 (${rawUrl}):`, e?.message ?? e);
+      return;
+    }
+    const body = stripFrontmatter(rawBody).slice(0, MAX_FETCH_CHARS);
+    if (!body.trim()) {
+      console.warn('[DigestWebhook] 빈 digest 본문 — 전송 skip');
+      return;
+    }
+
+    // 2. Yawn AI 가공
+    const systemPrompt = buildYawnDigestSystemPrompt();
+    const userPrompt = buildYawnDigestUserPrompt(body);
+
+    let yawnResponse = '';
+    try {
+      const { text } = await generateBlobTextFromEnvWithOptions(process.env, userPrompt, {
+        systemInstruction: systemPrompt,
+        modelId: process.env.YAWN_DIGEST_MODEL_ID,
+      });
+      yawnResponse = text.trim();
+    } catch (e: any) {
+      console.error('[DigestWebhook] AI 가공 실패:', e?.message ?? e);
+      // fallback: 원본 첫 500자 그대로
+      yawnResponse = body.slice(0, 500) + (body.length > 500 ? '\n…' : '');
+    }
+
+    // 3. Discord 전송 — embed description 한계 4096, 실 메시지 2000자 권장
+    const dateLabel = digestFile.replace('digests/', '').replace('.md', '');
+    const repoUrl = `https://github.com/${repoFullName}/blob/${sha}/${digestFile}`;
+
+    const embed = new EmbedBuilder()
+      .setAuthor({ name: 'Yawn', iconURL: process.env.YAWN_AVATAR_URL || undefined })
+      .setTitle(`📰 ${dateLabel} dev digest`)
+      .setURL(repoUrl)
+      .setDescription(yawnResponse.slice(0, 4000))
+      .setColor(0xb39ddb)
+      .setFooter({ text: `${repoFullName} · chore(digests)` })
+      .setTimestamp();
+
+    // 환경변수로 별도 채널 지정 가능 (없으면 기본 채널 사용)
+    const digestChannelId = process.env[DIGEST_CHANNEL_ENV];
+    const targetChannels = digestChannelId ? [digestChannelId] : channelIds;
+
+    for (const channelId of targetChannels) {
+      const channel = await client.channels.fetch(channelId).catch(() => null);
+      if (channel?.isSendable()) {
+        await channel.send({ embeds: [embed] }).catch((e: any) =>
+          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e?.message ?? e),
+        );
+      }
+    }
+
+    console.log(`[DigestWebhook] ${dateLabel} digest 전송 완료 (${targetChannels.length} 채널)`);
+  } catch (e: any) {
+    console.error('[DigestWebhook] handleDigestCommit 예외:', e?.message ?? e);
+  }
+}
+
+function buildYawnDigestSystemPrompt(): string {
+  const envPrompt = process.env.YAWN_SYSTEM_PROMPT ?? process.env.BOT_YAWN_SYSTEM_PROMPT ?? '';
+  const base = envPrompt.trim().replace(/\\n/g, '\n') ||
+    '너는 YawnBot 이야. 활기차고 재치 있는 디스코드 봇. 친절하고 유머러스하게 답해줘.';
+  return (
+    base +
+    '\n\n오늘은 daily dev digest 를 받아서 디스코드 채널에 소개하는 역할이야. ' +
+    '너의 말투로 짧게 한 마디 코멘트 + top 3 entry 각 1줄 코멘트 + 전체 보기 링크 형식으로 작성해. ' +
+    `Discord 메시지이므로 ${MAX_PLAIN_CHARS}자 이내로 작성해. Markdown 링크는 [텍스트](URL) 형식.`
+  );
+}
+
+function buildYawnDigestUserPrompt(digestBody: string): string {
+  return `오늘 dev digest 본문이야. 위 지침대로 디스코드 메시지 작성해줘:\n\n${digestBody}`;
+}


### PR DESCRIPTION
## Summary

- `src/services/digest-webhook.ts` (신규): yawnbot `chore(digests):` commit 감지 → GitHub raw .md fetch → Yawn AI 가공 → Discord embed 전송
  - `isDigestCommit()` — commit message + added paths 기반 감지
  - `handleDigestCommit()` — raw fetch + Yawn 페르소나로 AI 가공 + embed
  - `YAWN_DIGEST_CHANNEL_ID` env: 전용 채널 지정 가능 (없으면 기본 채널 `1490334302003663058`)
  - AI 실패 시 원본 500자 fallback (webhook 중단 없음)
- `src/bot/webhook.ts` (수정): push handler에 digest 분기 추가 (200 먼저 반환 후 async 처리)

**채널**: 기본 채널 `1490334302003663058` 사용. 전용 채널 원하면 Discord에서 채널 만들고 `YAWN_DIGEST_CHANNEL_ID` env secret 추가 (opt-in).

## Test plan

- [ ] `npm run build:yawnbot` 통과 확인
- [ ] `node memo/scripts/sync-task-status.mjs` 상태 drift 없음
- [ ] (사용자) next dev-digest fire 후 Discord에서 Yawn 톤 embed 확인
- [ ] (사용자) AI 실패 시 500자 fallback 동작 확인

Closes TASK-YB-004

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- Discord 봇이 자동으로 다이제스트 커밋을 감지하고 AI 생성 요약본을 Discord 채널로 게시합니다.
- 다이제스트 처리가 비동기식으로 작동하여 웹훅 응답 성능에 영향을 주지 않습니다.
- 처리 실패 시 자동 폴백 메커니즘으로 안정성이 향상되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/46)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->