### PR TITLE
docs(kl-036): adventure widget README + CLAUDE.md Vertex rule exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,7 @@ master 브랜치는 항상 다음을 만족:
 9. **The `production` branch** is for releases only; normal development goes to `master`/`main` — but `master`/`main` 도 PR 거쳐 머지 (`§ Git Workflow` 참조). 직접 push 는 1~3줄 chore 등 예외만.
 10. **공통 작업 원칙 (레거시 금지 / 마이그레이션 자기소멸 / 커밋 전 확인 / 커밋 전 테스트 / 한 commit 한 주제 / 푸시는 지시 시에만)** — 단일 출처: `karmoddrine/memo/UMBRELLA.md` § 공통 작업 원칙 — 모든 레포. 본 레포에도 동일 적용. 충돌 시 K 가 우선.
 11. **Vertex AI is preferred over AI Studio** — the user has Vertex AI credits. When both surfaces support the same capability (text generation, embeddings), default to Vertex. Use `KARMOLAB_AI_SURFACE=vertex` as the standard. AI Studio is a fallback only. Do not propose AI Studio as the primary option. When adding new AI features, implement both surfaces via `karmolab-ai` and respect the surface env var.
+    - **KL-032 예외 (무한 텍스트 어드벤처)**: 사용자 발화 「Max x20 활용」 시드 → Claude (Max OAuth) default. provider abstraction + 위젯 토글로 Vertex 도 선택 가능 (`apps/karmolab/src/widgets/adventure/provider/`).
 12. **새 로컬 서버·dev 프로세스는 KarmoLab Server Monitor (`devProfiles`) 등록 우선** — 사용자는 `apps/karmolab-tauri` 데스크톱 앱을 상시 띄워두고 그 안의 **서버 모니터** 위젯에서 시작/종료/로그 스트림/deploy 를 한다. 새 봇·로컬 서버·dev runner 를 추가할 때는 **반드시 `apps/karmolab/data/servermonitor-config.json` 의 `devProfiles` (그리고 같은 `id` 로 `localMonitors`) 에 등록을 함께 제안**한다. 사용자가 외울 터미널 명령이 늘어나면 안 됨.
     - 허용 `program`: `npm`, `npx`, `bundle`, `ruby`, `node`. 그 외 바이너리 (`cloudflared`, `python`, `cargo` 등) 는 `package.json` script 로 한 번 감싼 뒤 등록.
     - `cwd` 는 레포 루트 기준 상대 경로만. `..` 금지. Rust 측에서 canonicalize 후 루트 prefix 검증함.

--- a/apps/karmolab/src/widgets/adventure/README.md
+++ b/apps/karmolab/src/widgets/adventure/README.md
@@ -1,0 +1,93 @@
+# Adventure Widget — 무한 텍스트 어드벤처
+
+KarmoLab 내 텍스트 RPG 위젯. 출처 TASK: `TASK-KL-032-infinite-text-adventure.md`.
+
+---
+
+## 사용자 흐름
+
+1. **설정** (⚙ 아이콘): Vertex API key + Project ID 입력 (Vertex 사용 시)
+2. **Cast 선택**: 동행할 NPC 슬러그 선택 (alisa / ling / yon / timeto / fourth / …)
+3. **모험 시작**: `시작` 버튼 → 내레이터(Timeto) 오프닝 + 선택지
+4. **턴 진행**: 선택지 클릭 or 자유 텍스트 입력 → LLM 응답 + 이미지 생성 (η — Imagen 4)
+5. **종료**: `[END]` 토큰 또는 수동 종료 → 요약 다이얼로그
+6. **저장**: ζ — Tauri `adventure_save_raw` → `memo/projects/karmolab/raw/adventures/{slug}.json`
+   - 브라우저 fallback: `localStorage` (`kl_adventure_session_{slug}`)
+7. **정수 추출** (θ, 미구현): 정수(精髓) → wiki public 커밋 흐름
+
+---
+
+## Provider 토글
+
+| Provider | 모델 | Auth | 기본 |
+|---|---|---|---|
+| **Claude** | Sonnet 4.6 / Opus 4.7 / Haiku 4.5 | Max OAuth (Tauri 세션) | **★** |
+| **Vertex** | Gemini 2.5 Pro / Flash / Flash-Lite | API key + Project ID (설정 패널) | |
+
+선택 저장: `Toolbox.setPref('adv_provider_id')`. 코드: `src/widgets/adventure/provider/factory.ts`.
+
+> **Vertex 우선 룰 예외 (KL-036)**: 이 위젯은 사용자 발화 「Max x20 활용」 시드 → Claude (Max OAuth) default.
+> Vertex도 toggle 가능 (provider abstraction). `CLAUDE.md` §11 참고.
+
+---
+
+## NPC 토큰
+
+LLM 출력 내 토큰을 파서가 추출·처리:
+
+| 토큰 | 동작 |
+|---|---|
+| `[NPC:slug]` | 해당 캐릭터 이름·초상화 표시 |
+| `[SCENE:title]` | 장면 제목 오버레이 |
+| `[END]` | 모험 종료 → 요약 다이얼로그 |
+
+NPC 목록 소스: `KarmoWorld.bindings.chatbot.characters[]` (전역).
+코드: `src/widgets/adventure/npc-context.ts` + `src/widgets/adventure/prompt.ts`.
+
+---
+
+## 데이터 흐름
+
+```
+LLM 응답
+  → parseTurnResponse() (prompt.ts)
+  → AdventureTurnRecord {ts, userText, assistantText, parsed, imageRefs, providerId, modelId}
+  → saveSession() (storage.ts)
+      Tauri: adventure_save_raw → memo/projects/karmolab/raw/adventures/{slug}.json  (private)
+      fallback: localStorage kl_adventure_session_{slug}
+```
+
+정수 추출 (θ, 미구현): raw JSON → `adv_commit_summary` Tauri command → wiki public commit.
+
+---
+
+## Tauri Commands (ζ 이후)
+
+| Command | 역할 |
+|---|---|
+| `adventure_claude_complete` | Claude Max OAuth subprocess via Rust (async + spawn_blocking) |
+| `adventure_save_raw` | raw JSON 저장 → `memo/.../raw/adventures/` |
+| `adventure_commit_summary` | git fetch + commit + push (정수 추출 흐름) |
+
+---
+
+## 개발 페이즈 레이블
+
+`α` provider 추상화 · `β` wiki 연동 · `γ` UI 개선 · `δ` 턴 루프 · `ε` NPC chatbot · `ζ` Tauri save · `η` imagegen · `θ` 정수 추출 · `κ` sampling
+
+---
+
+## 주요 파일
+
+| 파일 | 역할 |
+|---|---|
+| `adventure.ts` | 진입점 — UI shell, cast picker, provider toggle |
+| `turn-loop.ts` | 턴 state machine — history + runTurn() |
+| `prompt.ts` | system instruction 빌더 + LLM 응답 파서 |
+| `storage.ts` | 세션 저장/불러오기 (Tauri / localStorage) |
+| `npc-context.ts` | NPC 캐릭터 컨텍스트 로더 |
+| `imagegen.ts` | Vertex Imagen 4 이미지 생성 |
+| `settings.ts` | 설정 패널 (API key, model) |
+| `provider/factory.ts` | provider 팩토리 + 선호 저장 |
+| `provider/ClaudeProvider.ts` | Claude via Tauri command |
+| `provider/VertexProvider.ts` | Gemini via browser fetch |


### PR DESCRIPTION
## Summary

- `apps/karmolab/src/widgets/adventure/README.md` (신설): 무한 텍스트 어드벤처 위젯 사용 가이드
  - 사용자 흐름 (설정 → cast → 턴 → 저장)
  - Provider 토글 표 (Claude Max OAuth vs Vertex Gemini)
  - NPC 토큰 포맷 (`[NPC:slug]`, `[SCENE:title]`, `[END]`)
  - 데이터 흐름 (raw JSON → Tauri save → 정수 추출 θ)
  - Tauri commands 목록 (ζ 이후)
  - 개발 페이즈 레이블 (α–κ)
  - 주요 파일 표
- `CLAUDE.md` #11 (Vertex 우선 룰): KL-032 예외 1줄 추가
  - 무한 텍스트 어드벤처 = 사용자 발화 「Max x20 활용」 시드 → Claude default (예외)
  - provider toggle로 Vertex 선택 가능 명시

## Test plan

- [ ] `npm run verify` 통과 (docs only, no code change)
- [ ] README 파일 내용 확인 (provider 토글 / NPC 토큰 / 데이터 흐름 섹션)

Closes TASK-KL-036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서

* Adventure Widget의 사용 흐름, 제공자 선택(Claude/Vertex), 데이터 저장에 관한 완전한 설명서 추가
* Max x20 기능 사용 시 제공자 기본값 및 전환 옵션에 대한 가이드 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/47)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->