### PR TITLE
fix(karmolab): TASK-KL-042 — hourglass reload() 제거 → 애니메이션 재시작 + stash 복구

### DIFF
--- a/apps/karmolab/src/widgets/hourglass.ts
+++ b/apps/karmolab/src/widgets/hourglass.ts
@@ -14,7 +14,7 @@
           Mdd.linePreset('tool_run', { msg: '모래시계... 졸려요...' });
           container.innerHTML = `
                 <div style="display:flex; flex-direction:column; padding:20px; height:380px; box-sizing:border-box; overflow:hidden;">
-                    <div style="font-size:var(--font-size-xs); color:var(--text-tertiary); margin-bottom:8px;">픽셀 모래가 다 떨어지면 페이지가 새로고침돼요...</div>
+                    <div style="font-size:var(--font-size-xs); color:var(--text-tertiary); margin-bottom:8px;">픽셀 모래가 다 떨어지면 다시 시작돼요...</div>
                     <canvas id="hourglassCanvas" style="flex:1; background:#0a0a0c; border-radius:8px;"></canvas>
                 </div>
             `;
@@ -79,7 +79,10 @@
 
             const allFalled = grid.every((p) => p.y >= rows - 5);
             if (allFalled && grid.length > 0) {
-              setTimeout(() => window.location.reload(), 1500);
+              setTimeout(() => {
+                grid.forEach((p) => { p.y = Math.floor(Math.random() * 30); });
+                animId = requestAnimationFrame(animate);
+              }, 1500);
               return;
             }
 

--- a/apps/karmolab/src/widgets/stash.ts
+++ b/apps/karmolab/src/widgets/stash.ts
@@ -73,13 +73,9 @@
     `
   );
 
-  /**
-   * ⚠ hourglass 제외 — `window.location.reload()` 자기 안에 박혀있어 stash 무한 loop 사고 (2026-05-10).
-   * hourglass 자체 reload 안 빼면 stash 에 못 들어옴. 별 follow-up.
-   */
   const STASH_IDS: string[] = [
     'bounce', 'bubble', 'countdown', 'darkroom', 'eyes', 'folder', 'fontgacha',
-    'hacker', 'moon', 'morse', 'news', 'particle', 'password', 'pet',
+    'hacker', 'hourglass', 'moon', 'morse', 'news', 'particle', 'password', 'pet',
     'reaction', 'shylink', 'speed', 'stone', 'toast', 'ytdownloader'
   ];
 


### PR DESCRIPTION
## Summary

**Root cause**: `hourglass.ts` 의 `window.location.reload()` 가 stash 위젯 안에서 무한 loop 유발 (2026-05-10 사고). 임시 우회 = STASH_IDS 에서 hourglass 제외.

**Fix**:
- `hourglass.ts`: 모래 다 떨어질 때 `window.location.reload()` 폐기 → grid y 위치 초기화 + 1.5s 후 애니메이션 재시작
- `hourglass.ts`: description 텍스트 "새로고침돼요" → "다시 시작돼요"
- `stash.ts`: STASH_IDS 에 'hourglass' 복구 (21 → 22개), 임시 우회 주석 제거

**Verification**: `npm run build` (karmolab) 통과.

## Test plan

- [ ] `npm run verify` 통과 (karmolab build + lint)
- [ ] (사용자) hourglass 단독: 모래 다 떨어지면 1.5s 후 모래가 위로 리셋되어 다시 떨어짐 (페이지 리로드 X)
- [ ] (사용자) stash 안에서 hourglass 정상 표시 + 무한 loop 없음

Closes TASK-KL-042

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 모래시계 위젯이 안정성 개선으로 위젯 목록에 다시 추가되었습니다
  * 애니메이션 모래가 모두 떨어질 때 발생하던 페이지 새로고침 문제가 완전히 해결되었습니다
  * 애니메이션이 자동으로 부드럽게 재시작되어 더 나은 사용 경험을 제공합니다

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/48)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->