### PR TITLE
fix(ci): claude.yml 봇 트리거 에러 수정 — allowed_bots + 인간 전용 @claude 게이트

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -98,10 +98,12 @@ jobs:
 
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      !endsWith(github.actor, '[bot]') && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -140,6 +142,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'coderabbitai[bot]'
           prompt: |
             CodeRabbit이 이 PR에 코드 리뷰를 남겼습니다. 리뷰의 actionable 제안을 검토해 적절한 것만 적용하세요.
 
@@ -168,6 +171,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'copilot-pull-request-reviewer[bot]'
           prompt: |
             GitHub Copilot이 이 PR에 코드 리뷰를 남겼습니다. 리뷰의 actionable 제안을 검토해 적절한 것만 적용하세요.
 


### PR DESCRIPTION
﻿## Summary

- `claude-coderabbit` / `claude-copilot` 잡: `claude-code-action@v1` 신규 보안 체크가 봇 트리거 워크플로를 차단 -> `allowed_bots` 파라미터 추가
- `claude` 잡: CodeRabbit 리뷰 코멘트에 `@claude` 포함시 봇 트리거 -> GitHub 수동 승인 (`action_required`) 요구 -> `!endsWith(github.actor, '[bot]')` 조건 추가

## 원인

- **failure** (kl-039, kl-040): `Workflow initiated by non-human actor: coderabbitai (type: Bot). Add bot to allowed_bots list`
- **action_required** (kl-036~040 등): 봇 @claude 멘션 -> `claude` 잡 트리거 -> GitHub 수동 승인 요구

## Changes

- `claude-coderabbit`: `allowed_bots: coderabbitai[bot]`
- `claude-copilot`: `allowed_bots: copilot-pull-request-reviewer[bot]`
- `claude`: `if` 조건에 `!endsWith(github.actor, '[bot]')` 추가

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **작업/유지보수 (Chores)**
  * 자동화 워크플로우 트리거 조건을 강화하여 의도하지 않은 봇 활성화를 방지했습니다.
  * 코드 리뷰 제안 처리 시 허용된 봇만 선택적으로 적용되도록 제한했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/53)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->