### PR TITLE
feat(ci): auto-merge PAT → GitHub App 토큰 전환 (TASK-KL-048)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,22 +12,18 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - name: Check PAT availability
-        # PAT_FOR_AUTO_MERGE 누락 시 silent 실패 방지 — visible ::error:: 로 전환.
-        # 누락 원인: 신규 등록 누락 / fine-grained PAT 1년 만료. 정본 TASK-KL-029.
-        env:
-          PAT: ${{ secrets.PAT_FOR_AUTO_MERGE }}
-        run: |
-          if [ -z "$PAT" ]; then
-            echo "::error::secret PAT_FOR_AUTO_MERGE 누락 — auto-merge 차단됨. memo/projects/karmolab/tasks/TASK-KL-029-pat-auto-merge.md § 사용자 액션 참고."
-            exit 1
-          fi
+      - name: Generate GitHub App token
+        # GitHub App 사용 (PAT 대신) — 만료 없음, repo-scoped, 재귀 방지로 pages-deploy.yml / verify.yml 자동 트리거.
+        # App 설정: GitHub Settings → Developer settings → GitHub Apps → KarmoDDrine AutoMerge.
+        # Secrets: GH_APP_ID (App ID), GH_APP_PRIVATE_KEY (PEM private key). 정본 TASK-KL-048.
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Enable auto-merge
-        # PAT 사용 (GITHUB_TOKEN 아님) — GitHub 재귀 방지로 GITHUB_TOKEN 머지는
-        # master push event trigger 차단 → pages-deploy.yml / verify.yml 자동 미작동.
-        # 정본: memo/projects/karmolab/tasks/TASK-KL-029-pat-auto-merge.md.
         run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
         env:
-          GH_TOKEN: ${{ secrets.PAT_FOR_AUTO_MERGE }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- `PAT_FOR_AUTO_MERGE` (1년 만료, 개인 계정 종속) 를 GitHub App 토큰으로 교체
- `actions/create-github-app-token@v1` 으로 `GH_APP_ID` + `GH_APP_PRIVATE_KEY` → 단기 설치 토큰 발급
- `Check PAT availability` 단계 제거 — GitHub App secret 누락 시 `create-github-app-token` action 자체가 명확한 에러 출력

## 사용자 액션 (머지 전 완료 필요)

1. GitHub → Settings → Developer settings → GitHub Apps → **New GitHub App**
   - Name: `KarmoDDrine AutoMerge` (또는 원하는 이름)
   - Webhook: 비활성 (Webhook URL 불필요)
   - Repository permissions: **Contents: Read and write**, **Pull requests: Read and write**
   - Where can this GitHub App be installed: Only on this account
2. **App ID** 메모 (상단에 표시됨)
3. **Private key 발급** → PEM 파일 다운로드
4. App 을 `mascari4615/mascari4615.github.io` 레포에 **install** (App 페이지 → Install App)
5. 레포 Settings → Secrets → Actions 에 2개 secret 등록:
   - `GH_APP_ID`: App ID 숫자
   - `GH_APP_PRIVATE_KEY`: PEM 파일 전체 내용 (`-----BEGIN RSA PRIVATE KEY-----` 포함)

## Test plan

- [ ] 위 사용자 액션 완료 후 머지
- [ ] 다음 PR open 시 `enable-auto-merge` job 성공 + auto-merge 활성화 확인
- [ ] `PAT_FOR_AUTO_MERGE` secret 삭제 (정리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)