### PR TITLE
feat(karmolab): TASK-KL-056 — Claude 환경 컨트롤 위젯 Step 1 (read skeleton)

### DIFF
--- a/apps/karmolab-tauri/src-tauri/Cargo.lock
+++ b/apps/karmolab-tauri/src-tauri/Cargo.lock
@@ -2877,6 +2877,7 @@ dependencies = [
  "serde_yml",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
@@ -4803,6 +4804,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5835,6 +5860,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.0+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-global-shortcut"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6279,6 +6346,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.0",
 ]
 
 [[package]]

--- a/apps/karmolab-tauri/src-tauri/Cargo.toml
+++ b/apps/karmolab-tauri/src-tauri/Cargo.toml
@@ -22,6 +22,8 @@ tauri = { version = "2", features = ["tray-icon", "image-png", "devtools"] }
 uuid = { version = "1", features = ["v4"] }
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
+# TASK-KL-056: Claude 환경 위젯 wav path 파일 선택 다이얼로그.
+tauri-plugin-dialog = "2"
 
 # TASK-LIFE-001-F (sub-F-1: capture + sub-F-2: OCR/분류/frontmatter + sub-F-3: hotkey)
 xcap = "0.0.13"

--- a/apps/karmolab-tauri/src-tauri/capabilities/default.json
+++ b/apps/karmolab-tauri/src-tauri/capabilities/default.json
@@ -32,6 +32,7 @@
     "allow-task-launcher",
     "allow-terminal",
     "allow-adventure",
+    "allow-claude-env",
     "updater:default"
   ]
 }

--- a/apps/karmolab-tauri/src-tauri/capabilities/default.json
+++ b/apps/karmolab-tauri/src-tauri/capabilities/default.json
@@ -33,6 +33,7 @@
     "allow-terminal",
     "allow-adventure",
     "allow-claude-env",
+    "dialog:allow-open",
     "updater:default"
   ]
 }

--- a/apps/karmolab-tauri/src-tauri/permissions/claude-env.toml
+++ b/apps/karmolab-tauri/src-tauri/permissions/claude-env.toml
@@ -1,6 +1,8 @@
 [[permission]]
 identifier = "allow-claude-env"
-description = "Claude 환경 컨트롤 위젯 (TASK-KL-056) — karmoddrine/memo/dotfiles/claude-hooks 정본의 notify-*.ps1 설정 read/write."
+description = "Claude 환경 컨트롤 위젯 (TASK-KL-056) — karmoddrine/memo/dotfiles/claude-hooks 정본의 notify-*.ps1 설정 read/write + 미리듣기."
 commands.allow = [
   "claude_env_read_notify_config",
+  "claude_env_write_notify_config",
+  "claude_env_preview_sound",
 ]

--- a/apps/karmolab-tauri/src-tauri/permissions/claude-env.toml
+++ b/apps/karmolab-tauri/src-tauri/permissions/claude-env.toml
@@ -1,0 +1,6 @@
+[[permission]]
+identifier = "allow-claude-env"
+description = "Claude 환경 컨트롤 위젯 (TASK-KL-056) — karmoddrine/memo/dotfiles/claude-hooks 정본의 notify-*.ps1 설정 read/write."
+commands.allow = [
+  "claude_env_read_notify_config",
+]

--- a/apps/karmolab-tauri/src-tauri/src/claude_env.rs
+++ b/apps/karmolab-tauri/src-tauri/src/claude_env.rs
@@ -4,15 +4,24 @@
 //! 정본 = `karmoddrine/memo/dotfiles/claude-hooks/notify-{stop,notification}.ps1`.
 //! 변경 흐름: GUI → 정본 .ps1 편집 → `sync-claude-hooks.ps1` 호출 → `~/.claude/hooks/` 배포.
 //!
-//! Step 1 = read 명령만. write / preview / wav drag-drop 은 후속 Step (KL-056 sub).
+//! Step 1 = read 명령 (skeleton).
+//! Step 2 = write + sync (정본 .ps1 한 줄 교체 + sync-claude-hooks.ps1 호출).
+//! Step 3 = 미리듣기 (PowerShell shell-out, mode/sound 즉시 재생).
+//! Step 4 (별 PR / sub TASK) = .wav drag-drop.
 //!
-//! 의존성 0 (regex 없이 std 만). `.ps1` 한 줄 파싱은 `$mode = "..."` / `$wavPath = "..."` /
-//! `[System.Media.SystemSounds]::<Name>.Play()` 세 종류만 잡는 단순 line scanner.
+//! 의존성 0 (regex 없이 std + serde 만). `.ps1` 한 줄 파싱은 `$mode = "..."` /
+//! `$wavPath = "..."` / `[System.Media.SystemSounds]::<Name>.Play()` 세 종류만 잡는 단순 line scanner.
+//!
+//! 사용자 입력 sanitize:
+//! - mode = "system" | "beep" | "wav" whitelist
+//! - system_sound = Asterisk | Beep | Exclamation | Hand | Question whitelist
+//! - wav_path = 절대 경로 + .wav 확장자 + 따옴표/세미콜론/backtick/$ 거부 (PowerShell 인자 escape).
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NotifyHookConfig {
     /// "system" | "beep" | "wav"
     pub mode: String,
@@ -30,17 +39,45 @@ pub struct NotifyConfigDto {
     pub canonical_root: String,
 }
 
-/// `karmoddrine/memo/dotfiles/claude-hooks/` 정본 디렉토리.
-/// USERPROFILE 기준 `repos/karmoddrine/memo/dotfiles/claude-hooks` 시도.
-fn karmoddrine_dotfiles_root() -> Result<PathBuf, String> {
+#[derive(Debug, Deserialize)]
+pub struct NotifyConfigInput {
+    pub stop: NotifyHookConfig,
+    pub notification: NotifyHookConfig,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WriteResultDto {
+    pub canonical_root: String,
+    pub sync_stdout: String,
+    pub sync_stderr: String,
+}
+
+const MODE_WHITELIST: &[&str] = &["system", "beep", "wav"];
+const SYSTEM_SOUND_WHITELIST: &[&str] =
+    &["Asterisk", "Beep", "Exclamation", "Hand", "Question"];
+const HOOK_WHITELIST: &[&str] = &["stop", "notification"];
+
+/// `karmoddrine/memo/dotfiles/` 정본 디렉토리 (sync 스크립트 부모).
+fn karmoddrine_dotfiles_dir() -> Result<PathBuf, String> {
     let userprofile = std::env::var("USERPROFILE")
         .map_err(|_| "USERPROFILE 환경 변수 없음 (Windows 전용)".to_string())?;
-    let root = PathBuf::from(userprofile)
+    let dir = PathBuf::from(userprofile)
         .join("repos")
         .join("karmoddrine")
         .join("memo")
-        .join("dotfiles")
-        .join("claude-hooks");
+        .join("dotfiles");
+    if !dir.exists() {
+        return Err(format!(
+            "dotfiles 디렉토리 없음: {} — karmoddrine 레포 위치 확인.",
+            dir.display()
+        ));
+    }
+    Ok(dir)
+}
+
+/// `karmoddrine/memo/dotfiles/claude-hooks/` 정본 디렉토리.
+fn karmoddrine_dotfiles_root() -> Result<PathBuf, String> {
+    let root = karmoddrine_dotfiles_dir()?.join("claude-hooks");
     if !root.exists() {
         return Err(format!(
             "정본 디렉토리 없음: {} — karmoddrine 레포 위치 확인.",
@@ -73,7 +110,36 @@ fn extract_system_sound(line: &str) -> Option<String> {
     }
 }
 
-fn parse_notify_ps1(path: &PathBuf) -> Result<NotifyHookConfig, String> {
+/// `$key = "..."` 라인을 새 value 로 교체. leading whitespace 보존.
+/// 매칭 실패 시 None.
+fn replace_assignment_value(line: &str, key: &str, new_value: &str) -> Option<String> {
+    let leading_len = line.len() - line.trim_start().len();
+    let leading = &line[..leading_len];
+    let rest = line[leading_len..].strip_prefix(key)?;
+    let after_eq = rest.trim_start().strip_prefix('=')?;
+    let _ = after_eq.trim_start().strip_prefix('"')?;
+    Some(format!("{}{} = \"{}\"", leading, key, new_value))
+}
+
+/// `[System.Media.SystemSounds]::OLD.Play()` 라인의 OLD 를 새 sound 로 교체.
+fn replace_system_sound(line: &str, new_sound: &str) -> Option<String> {
+    let leading_len = line.len() - line.trim_start().len();
+    let leading = &line[..leading_len];
+    let trimmed = &line[leading_len..];
+    let after = trimmed.strip_prefix("[System.Media.SystemSounds]::")?;
+    let dot = after.find('.')?;
+    let old_name = &after[..dot];
+    if old_name.is_empty() || !old_name.chars().all(|c| c.is_ascii_alphabetic()) {
+        return None;
+    }
+    let tail = &after[dot..]; // ".Play()" 그대로
+    Some(format!(
+        "{}[System.Media.SystemSounds]::{}{}",
+        leading, new_sound, tail
+    ))
+}
+
+fn parse_notify_ps1(path: &Path) -> Result<NotifyHookConfig, String> {
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("{} read 실패: {}", path.display(), e))?;
     let mut mode: Option<String> = None;
@@ -100,6 +166,255 @@ fn parse_notify_ps1(path: &PathBuf) -> Result<NotifyHookConfig, String> {
     })
 }
 
+/// 사용자 입력 검증 — 옵션이면 whitelist 확인, wav_path 면 절대 경로 + .wav + 위험 문자 거부.
+fn validate_hook_config(label: &str, hook: &NotifyHookConfig) -> Result<(), String> {
+    if !MODE_WHITELIST.contains(&hook.mode.as_str()) {
+        return Err(format!(
+            "{}.mode 값 무효: {:?} (허용 = {:?})",
+            label, hook.mode, MODE_WHITELIST
+        ));
+    }
+    if let Some(s) = hook.system_sound.as_deref() {
+        if !SYSTEM_SOUND_WHITELIST.contains(&s) {
+            return Err(format!(
+                "{}.system_sound 값 무효: {:?} (허용 = {:?})",
+                label, s, SYSTEM_SOUND_WHITELIST
+            ));
+        }
+    }
+    if let Some(p) = hook.wav_path.as_deref() {
+        validate_wav_path(label, p)?;
+    }
+    Ok(())
+}
+
+fn validate_wav_path(label: &str, raw: &str) -> Result<(), String> {
+    let p = raw.trim();
+    if p.is_empty() {
+        return Ok(()); // 빈 문자열 = wav 모드 미사용. write 시 기존 라인 유지.
+    }
+    // 위험 문자 거부 — .ps1 string literal + PowerShell 인자 escape 두 채널 안전.
+    for ch in p.chars() {
+        if matches!(ch, '"' | '\'' | '`' | '$' | ';' | '\n' | '\r') {
+            return Err(format!(
+                "{}.wav_path 에 허용되지 않은 문자: {:?}",
+                label, ch
+            ));
+        }
+    }
+    // 절대 경로 — Windows 는 X:\ 형식 또는 \\ UNC.
+    let abs = (p.len() >= 3
+        && p.as_bytes()[1] == b':'
+        && (p.as_bytes()[2] == b'\\' || p.as_bytes()[2] == b'/'))
+        || p.starts_with("\\\\");
+    if !abs {
+        return Err(format!(
+            "{}.wav_path 는 Windows 절대 경로여야 함: {:?}",
+            label, p
+        ));
+    }
+    if !p.to_ascii_lowercase().ends_with(".wav") {
+        return Err(format!("{}.wav_path 는 .wav 확장자만 허용: {:?}", label, p));
+    }
+    Ok(())
+}
+
+/// 한 .ps1 파일을 받은 config 로 in-place 편집. 라인 단위 교체, 매칭 안된 라인은 그대로.
+fn write_notify_ps1(path: &Path, hook: &NotifyHookConfig) -> Result<(), String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("{} read 실패: {}", path.display(), e))?;
+    let line_ending = if content.contains("\r\n") { "\r\n" } else { "\n" };
+    let has_final_newline = content.ends_with('\n');
+
+    let mut mode_done = false;
+    let mut sound_done = false;
+    let mut wav_done = false;
+
+    let new_lines: Vec<String> = content
+        .lines()
+        .map(|line| {
+            if !mode_done {
+                if let Some(rep) = replace_assignment_value(line, "$mode", &hook.mode) {
+                    mode_done = true;
+                    return rep;
+                }
+            }
+            if !sound_done {
+                if let Some(new_sound) = hook.system_sound.as_deref() {
+                    if let Some(rep) = replace_system_sound(line, new_sound) {
+                        sound_done = true;
+                        return rep;
+                    }
+                }
+            }
+            if !wav_done {
+                if let Some(new_wav) = hook.wav_path.as_deref() {
+                    if !new_wav.trim().is_empty() {
+                        if let Some(rep) = replace_assignment_value(line, "$wavPath", new_wav) {
+                            wav_done = true;
+                            return rep;
+                        }
+                    }
+                }
+            }
+            line.to_string()
+        })
+        .collect();
+
+    if !mode_done {
+        return Err(format!(
+            "{} 에 $mode 줄이 없음 — 정본 형식 회귀 의심.",
+            path.display()
+        ));
+    }
+
+    let mut joined = new_lines.join(line_ending);
+    if has_final_newline {
+        joined.push_str(line_ending);
+    }
+    std::fs::write(path, joined).map_err(|e| format!("{} write 실패: {}", path.display(), e))?;
+    Ok(())
+}
+
+/// `sync-claude-hooks.ps1` 호출 → (stdout, stderr).
+fn run_sync_claude_hooks() -> Result<(String, String), String> {
+    let script = karmoddrine_dotfiles_dir()?.join("sync-claude-hooks.ps1");
+    if !script.exists() {
+        return Err(format!("sync 스크립트 없음: {}", script.display()));
+    }
+    let script_str = script.to_string_lossy().into_owned();
+    let mut cmd = Command::new("powershell");
+    cmd.args([
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        &script_str,
+    ]);
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| format!("sync-claude-hooks.ps1 spawn 실패: {}", e))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    if !output.status.success() {
+        return Err(format!(
+            "sync-claude-hooks.ps1 exit {} — stderr: {}",
+            output.status, stderr
+        ));
+    }
+    Ok((stdout, stderr))
+}
+
+fn write_notify_config_blocking(input: NotifyConfigInput) -> Result<WriteResultDto, String> {
+    validate_hook_config("stop", &input.stop)?;
+    validate_hook_config("notification", &input.notification)?;
+    let root = karmoddrine_dotfiles_root()?;
+    write_notify_ps1(&root.join("notify-stop.ps1"), &input.stop)?;
+    write_notify_ps1(&root.join("notify-notification.ps1"), &input.notification)?;
+    let (sync_stdout, sync_stderr) = run_sync_claude_hooks()?;
+    Ok(WriteResultDto {
+        canonical_root: root.to_string_lossy().into_owned(),
+        sync_stdout,
+        sync_stderr,
+    })
+}
+
+fn preview_sound_blocking(
+    hook: &str,
+    mode: &str,
+    system_sound: Option<&str>,
+    wav_path: Option<&str>,
+) -> Result<(), String> {
+    if !HOOK_WHITELIST.contains(&hook) {
+        return Err(format!(
+            "hook 값 무효: {:?} (허용 = {:?})",
+            hook, HOOK_WHITELIST
+        ));
+    }
+    if !MODE_WHITELIST.contains(&mode) {
+        return Err(format!(
+            "mode 값 무효: {:?} (허용 = {:?})",
+            mode, MODE_WHITELIST
+        ));
+    }
+
+    let ps_command: String = match mode {
+        "system" => {
+            let sound = system_sound.unwrap_or("Asterisk");
+            if !SYSTEM_SOUND_WHITELIST.contains(&sound) {
+                return Err(format!(
+                    "system_sound 값 무효: {:?} (허용 = {:?})",
+                    sound, SYSTEM_SOUND_WHITELIST
+                ));
+            }
+            format!(
+                "[System.Media.SystemSounds]::{}.Play(); Start-Sleep -Milliseconds 400",
+                sound
+            )
+        }
+        "beep" => {
+            // hook 별 톤 차이는 정본 .ps1 의 의도를 그대로 재현.
+            // notify-stop.ps1: [console]::Beep(880, 150)
+            // notify-notification.ps1: [console]::Beep(1200, 100) × 2 (80ms 간격)
+            match hook {
+                "stop" => "[console]::Beep(880, 150)".to_string(),
+                "notification" => {
+                    "[console]::Beep(1200, 100); Start-Sleep -Milliseconds 80; [console]::Beep(1200, 100)"
+                        .to_string()
+                }
+                _ => unreachable!("hook whitelist 체크 이후"),
+            }
+        }
+        "wav" => {
+            let path = wav_path.unwrap_or("").trim();
+            if path.is_empty() {
+                return Err("wav 모드 미리듣기에는 wav_path 가 필요합니다.".to_string());
+            }
+            validate_wav_path(hook, path)?;
+            // PowerShell single-quoted string — 내부 ' 는 위에서 reject. 안전.
+            format!(
+                "$p='{}'; if(Test-Path $p){{(New-Object System.Media.SoundPlayer $p).PlaySync()}} else {{ throw \"파일 없음: $p\" }}",
+                path
+            )
+        }
+        _ => unreachable!("mode whitelist 체크 이후"),
+    };
+
+    let mut cmd = Command::new("powershell");
+    cmd.args([
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        &ps_command,
+    ]);
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| format!("preview powershell spawn 실패: {}", e))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        return Err(format!(
+            "preview exit {} — stderr: {}",
+            output.status, stderr
+        ));
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub fn claude_env_read_notify_config() -> Result<NotifyConfigDto, String> {
     let root = karmoddrine_dotfiles_root()?;
@@ -110,6 +425,33 @@ pub fn claude_env_read_notify_config() -> Result<NotifyConfigDto, String> {
         notification,
         canonical_root: root.to_string_lossy().into_owned(),
     })
+}
+
+/// 정본 .ps1 두 개를 받은 config 로 편집 + `sync-claude-hooks.ps1` 호출.
+/// IO 무거움 (.ps1 R/W + external PowerShell spawn) — async + spawn_blocking (KL-043 룰).
+#[tauri::command]
+pub async fn claude_env_write_notify_config(
+    config: NotifyConfigInput,
+) -> Result<WriteResultDto, String> {
+    tauri::async_runtime::spawn_blocking(move || write_notify_config_blocking(config))
+        .await
+        .map_err(|e| format!("write spawn_blocking join 실패: {}", e))?
+}
+
+/// mode/sound 미리듣기 — 사용자가 저장 전에 「어떻게 들리는지」 확인용.
+/// PowerShell shell-out — async + spawn_blocking.
+#[tauri::command]
+pub async fn claude_env_preview_sound(
+    hook: String,
+    mode: String,
+    system_sound: Option<String>,
+    wav_path: Option<String>,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        preview_sound_blocking(&hook, &mode, system_sound.as_deref(), wav_path.as_deref())
+    })
+    .await
+    .map_err(|e| format!("preview spawn_blocking join 실패: {}", e))?
 }
 
 #[cfg(test)]
@@ -140,5 +482,111 @@ mod tests {
             Some("Exclamation".to_string())
         );
         assert_eq!(extract_system_sound("Start-Sleep -Milliseconds 400"), None);
+    }
+
+    #[test]
+    fn replace_assignment_preserves_indent_and_changes_value() {
+        assert_eq!(
+            replace_assignment_value(r#"$mode = "system""#, "$mode", "beep"),
+            Some(r#"$mode = "beep"#.to_string() + "\"")
+        );
+        assert_eq!(
+            replace_assignment_value(
+                r#"    $wavPath = "C:\old\path.wav""#,
+                "$wavPath",
+                r"C:\new\sound.wav"
+            ),
+            Some(r#"    $wavPath = "C:\new\sound.wav""#.to_string())
+        );
+        assert_eq!(
+            replace_assignment_value("Start-Sleep", "$mode", "beep"),
+            None
+        );
+    }
+
+    #[test]
+    fn replace_system_sound_swaps_name_preserves_indent_and_play() {
+        assert_eq!(
+            replace_system_sound(
+                "        [System.Media.SystemSounds]::Asterisk.Play()",
+                "Exclamation"
+            ),
+            Some("        [System.Media.SystemSounds]::Exclamation.Play()".to_string())
+        );
+        assert_eq!(
+            replace_system_sound("[System.Media.SystemSounds]::Hand.Play()", "Question"),
+            Some("[System.Media.SystemSounds]::Question.Play()".to_string())
+        );
+        assert_eq!(replace_system_sound("Start-Sleep -Milliseconds 400", "Beep"), None);
+    }
+
+    #[test]
+    fn validate_wav_path_rejects_dangerous_chars() {
+        assert!(validate_wav_path("stop", r"C:\ok\sound.wav").is_ok());
+        assert!(validate_wav_path("stop", "").is_ok()); // empty = unused
+        assert!(validate_wav_path("stop", r#"C:\bad"path.wav"#).is_err());
+        assert!(validate_wav_path("stop", "C:\\bad`path.wav").is_err());
+        assert!(validate_wav_path("stop", "C:\\bad;path.wav").is_err());
+        assert!(validate_wav_path("stop", "C:\\bad$path.wav").is_err());
+        assert!(validate_wav_path("stop", "relative\\bar.wav").is_err());
+        assert!(validate_wav_path("stop", r"C:\not-wav.mp3").is_err());
+    }
+
+    #[test]
+    fn validate_hook_config_rejects_invalid_whitelist() {
+        let bad_mode = NotifyHookConfig {
+            mode: "yelling".into(),
+            system_sound: None,
+            wav_path: None,
+        };
+        assert!(validate_hook_config("stop", &bad_mode).is_err());
+
+        let bad_sound = NotifyHookConfig {
+            mode: "system".into(),
+            system_sound: Some("CustomLoud".into()),
+            wav_path: None,
+        };
+        assert!(validate_hook_config("stop", &bad_sound).is_err());
+
+        let ok = NotifyHookConfig {
+            mode: "wav".into(),
+            system_sound: Some("Asterisk".into()),
+            wav_path: Some(r"C:\Users\masca\.claude\hooks\sounds\stop.wav".into()),
+        };
+        assert!(validate_hook_config("stop", &ok).is_ok());
+    }
+
+    #[test]
+    fn write_notify_ps1_replaces_three_lines_round_trip() {
+        let dir = std::env::temp_dir().join(format!(
+            "kl-056-write-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("notify-stop.ps1");
+        std::fs::write(
+            &path,
+            "# header\n$mode = \"system\"\n[System.Media.SystemSounds]::Asterisk.Play()\n$wavPath = \"C:\\old.wav\"\n",
+        )
+        .unwrap();
+
+        let cfg = NotifyHookConfig {
+            mode: "wav".into(),
+            system_sound: Some("Exclamation".into()),
+            wav_path: Some(r"C:\new.wav".into()),
+        };
+        write_notify_ps1(&path, &cfg).unwrap();
+        let result = std::fs::read_to_string(&path).unwrap();
+        assert!(result.contains("$mode = \"wav\""));
+        assert!(result.contains("[System.Media.SystemSounds]::Exclamation.Play()"));
+        assert!(result.contains(r#"$wavPath = "C:\new.wav""#));
+        // round-trip parse
+        let parsed = parse_notify_ps1(&path).unwrap();
+        assert_eq!(parsed.mode, "wav");
+        assert_eq!(parsed.system_sound.as_deref(), Some("Exclamation"));
+        assert_eq!(parsed.wav_path.as_deref(), Some(r"C:\new.wav"));
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
     }
 }

--- a/apps/karmolab-tauri/src-tauri/src/claude_env.rs
+++ b/apps/karmolab-tauri/src-tauri/src/claude_env.rs
@@ -283,14 +283,22 @@ fn run_sync_claude_hooks() -> Result<(String, String), String> {
         return Err(format!("sync 스크립트 없음: {}", script.display()));
     }
     let script_str = script.to_string_lossy().into_owned();
+    // PowerShell 5.1 (한국어 Windows) 의 default stdout encoding = 시스템 코드페이지(cp949).
+    // Rust 는 UTF-8 로 디코드하므로 sync 스크립트의 한글 Write-Host 가 깨진다
+    // (`복사 1, 동일 12` → `????`). -File 대신 -Command 로 OutputEncoding 을 UTF-8
+    // 강제 후 script 호출 (정본 스크립트 본문은 안 건드림 — 다른 호출처와 분리).
+    let ps_command = format!(
+        "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8; & '{}'",
+        script_str.replace('\'', "''")
+    );
     let mut cmd = Command::new("powershell");
     cmd.args([
         "-NoProfile",
         "-NonInteractive",
         "-ExecutionPolicy",
         "Bypass",
-        "-File",
-        &script_str,
+        "-Command",
+        &ps_command,
     ]);
     #[cfg(target_os = "windows")]
     {

--- a/apps/karmolab-tauri/src-tauri/src/claude_env.rs
+++ b/apps/karmolab-tauri/src-tauri/src/claude_env.rs
@@ -140,8 +140,9 @@ fn replace_system_sound(line: &str, new_sound: &str) -> Option<String> {
 }
 
 fn parse_notify_ps1(path: &Path) -> Result<NotifyHookConfig, String> {
-    let content = std::fs::read_to_string(path)
+    let raw = std::fs::read_to_string(path)
         .map_err(|e| format!("{} read 실패: {}", path.display(), e))?;
+    let content = raw.strip_prefix(PS1_BOM).unwrap_or(raw.as_str());
     let mut mode: Option<String> = None;
     let mut system_sound: Option<String> = None;
     let mut wav_path: Option<String> = None;
@@ -220,9 +221,18 @@ fn validate_wav_path(label: &str, raw: &str) -> Result<(), String> {
 }
 
 /// 한 .ps1 파일을 받은 config 로 in-place 편집. 라인 단위 교체, 매칭 안된 라인은 그대로.
+/// UTF-8 BOM. PowerShell 5.1 (한국어 Windows) 은 BOM 없는 .ps1 을 시스템
+/// 코드페이지(cp949)로 읽어 파일 안 한글 `$wavPath` 가 깨진다 (Test-Path
+/// False → hook 무음). BOM 이 있으면 PS5.1 이 UTF-8 로 읽는다 (TASK-KL-056).
+const PS1_BOM: &str = "\u{FEFF}";
+
 fn write_notify_ps1(path: &Path, hook: &NotifyHookConfig) -> Result<(), String> {
-    let content = std::fs::read_to_string(path)
+    let raw = std::fs::read_to_string(path)
         .map_err(|e| format!("{} read 실패: {}", path.display(), e))?;
+    // 기존 BOM 은 일단 제거하고 처리 — write 시 무조건 다시 prepend (정본에
+    // BOM 이 없던 경우에도 PS5.1 안전 보장. read_to_string 의 BOM 보존 동작에
+    // 의존하지 않음).
+    let content = raw.strip_prefix(PS1_BOM).unwrap_or(raw.as_str());
     let line_ending = if content.contains("\r\n") { "\r\n" } else { "\n" };
     let has_final_newline = content.ends_with('\n');
 
@@ -268,7 +278,8 @@ fn write_notify_ps1(path: &Path, hook: &NotifyHookConfig) -> Result<(), String> 
         ));
     }
 
-    let mut joined = new_lines.join(line_ending);
+    let mut joined = String::from(PS1_BOM);
+    joined.push_str(&new_lines.join(line_ending));
     if has_final_newline {
         joined.push_str(line_ending);
     }
@@ -595,6 +606,45 @@ mod tests {
         assert_eq!(parsed.wav_path.as_deref(), Some(r"C:\new.wav"));
 
         let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn write_notify_ps1_always_prepends_utf8_bom() {
+        let dir = std::env::temp_dir().join(format!("kl-056-bom-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+
+        // 케이스 1: BOM 없는 정본 → write 후 BOM 붙어야 함 (PS5.1 한글 깨짐 방지).
+        let no_bom = dir.join("no-bom.ps1");
+        std::fs::write(&no_bom, "$mode = \"wav\"\n$wavPath = \"C:\\a.wav\"\n").unwrap();
+        let cfg = NotifyHookConfig {
+            mode: "wav".into(),
+            system_sound: None,
+            wav_path: Some(r"C:\korean\피팟.wav".into()),
+        };
+        write_notify_ps1(&no_bom, &cfg).unwrap();
+        let bytes = std::fs::read(&no_bom).unwrap();
+        assert_eq!(&bytes[0..3], &[0xEF, 0xBB, 0xBF], "BOM 없던 파일에 BOM 추가돼야");
+
+        // 케이스 2: 이미 BOM 있는 정본 → write 후에도 BOM 1개만 (중복 X).
+        let with_bom = dir.join("with-bom.ps1");
+        std::fs::write(
+            &with_bom,
+            "\u{FEFF}$mode = \"system\"\n[System.Media.SystemSounds]::Asterisk.Play()\n",
+        )
+        .unwrap();
+        write_notify_ps1(&with_bom, &cfg).unwrap();
+        let bytes2 = std::fs::read(&with_bom).unwrap();
+        assert_eq!(&bytes2[0..3], &[0xEF, 0xBB, 0xBF]);
+        assert_ne!(&bytes2[3..6], &[0xEF, 0xBB, 0xBF], "BOM 중복 안 됨");
+
+        // 한글 wav_path 가 round-trip 으로 보존 (BOM strip 후 파싱).
+        let parsed = parse_notify_ps1(&no_bom).unwrap();
+        assert_eq!(parsed.wav_path.as_deref(), Some(r"C:\korean\피팟.wav"));
+        assert_eq!(parsed.mode, "wav");
+
+        let _ = std::fs::remove_file(&no_bom);
+        let _ = std::fs::remove_file(&with_bom);
         let _ = std::fs::remove_dir(&dir);
     }
 }

--- a/apps/karmolab-tauri/src-tauri/src/claude_env.rs
+++ b/apps/karmolab-tauri/src-tauri/src/claude_env.rs
@@ -1,0 +1,144 @@
+//! Claude 환경 컨트롤 위젯 — TASK-KL-056.
+//!
+//! v1 = Claude Code Stop/Notification hook 의 사운드 알림 설정을 GUI 로 노출.
+//! 정본 = `karmoddrine/memo/dotfiles/claude-hooks/notify-{stop,notification}.ps1`.
+//! 변경 흐름: GUI → 정본 .ps1 편집 → `sync-claude-hooks.ps1` 호출 → `~/.claude/hooks/` 배포.
+//!
+//! Step 1 = read 명령만. write / preview / wav drag-drop 은 후속 Step (KL-056 sub).
+//!
+//! 의존성 0 (regex 없이 std 만). `.ps1` 한 줄 파싱은 `$mode = "..."` / `$wavPath = "..."` /
+//! `[System.Media.SystemSounds]::<Name>.Play()` 세 종류만 잡는 단순 line scanner.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NotifyHookConfig {
+    /// "system" | "beep" | "wav"
+    pub mode: String,
+    /// `$mode = "system"` 일 때 의미. Asterisk / Beep / Exclamation / Hand / Question.
+    pub system_sound: Option<String>,
+    /// `$mode = "wav"` 일 때 의미.
+    pub wav_path: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NotifyConfigDto {
+    pub stop: NotifyHookConfig,
+    pub notification: NotifyHookConfig,
+    /// 정본 디렉토리 (UI 표시용 — 사용자가 「어디서 편집되는지」 보기 위함).
+    pub canonical_root: String,
+}
+
+/// `karmoddrine/memo/dotfiles/claude-hooks/` 정본 디렉토리.
+/// USERPROFILE 기준 `repos/karmoddrine/memo/dotfiles/claude-hooks` 시도.
+fn karmoddrine_dotfiles_root() -> Result<PathBuf, String> {
+    let userprofile = std::env::var("USERPROFILE")
+        .map_err(|_| "USERPROFILE 환경 변수 없음 (Windows 전용)".to_string())?;
+    let root = PathBuf::from(userprofile)
+        .join("repos")
+        .join("karmoddrine")
+        .join("memo")
+        .join("dotfiles")
+        .join("claude-hooks");
+    if !root.exists() {
+        return Err(format!(
+            "정본 디렉토리 없음: {} — karmoddrine 레포 위치 확인.",
+            root.display()
+        ));
+    }
+    Ok(root)
+}
+
+/// `$key = "value"` 형식에서 value 추출. value 안에 escaped quote 없다고 가정.
+fn extract_assignment_value(line: &str, key: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix(key)?;
+    let after_eq = rest.trim_start().strip_prefix('=')?;
+    let after_quote = after_eq.trim_start().strip_prefix('"')?;
+    let end = after_quote.find('"')?;
+    Some(after_quote[..end].to_string())
+}
+
+/// `[System.Media.SystemSounds]::<Name>.Play()` 의 Name 추출.
+fn extract_system_sound(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    let after = trimmed.strip_prefix("[System.Media.SystemSounds]::")?;
+    let dot = after.find('.')?;
+    let name = &after[..dot];
+    if !name.is_empty() && name.chars().all(|c| c.is_ascii_alphabetic()) {
+        Some(name.to_string())
+    } else {
+        None
+    }
+}
+
+fn parse_notify_ps1(path: &PathBuf) -> Result<NotifyHookConfig, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("{} read 실패: {}", path.display(), e))?;
+    let mut mode: Option<String> = None;
+    let mut system_sound: Option<String> = None;
+    let mut wav_path: Option<String> = None;
+
+    for line in content.lines() {
+        if mode.is_none() {
+            mode = extract_assignment_value(line, "$mode");
+        }
+        if wav_path.is_none() {
+            wav_path = extract_assignment_value(line, "$wavPath");
+        }
+        if system_sound.is_none() {
+            system_sound = extract_system_sound(line);
+        }
+    }
+
+    let mode = mode.ok_or_else(|| format!("$mode 줄을 찾지 못함: {}", path.display()))?;
+    Ok(NotifyHookConfig {
+        mode,
+        system_sound,
+        wav_path,
+    })
+}
+
+#[tauri::command]
+pub fn claude_env_read_notify_config() -> Result<NotifyConfigDto, String> {
+    let root = karmoddrine_dotfiles_root()?;
+    let stop = parse_notify_ps1(&root.join("notify-stop.ps1"))?;
+    let notification = parse_notify_ps1(&root.join("notify-notification.ps1"))?;
+    Ok(NotifyConfigDto {
+        stop,
+        notification,
+        canonical_root: root.to_string_lossy().into_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_assignment_picks_first_quoted_value() {
+        assert_eq!(
+            extract_assignment_value(r#"$mode = "system""#, "$mode"),
+            Some("system".to_string())
+        );
+        assert_eq!(
+            extract_assignment_value(r#"    $wavPath = "C:\Users\foo\bar.wav""#, "$wavPath"),
+            Some(r"C:\Users\foo\bar.wav".to_string())
+        );
+        assert_eq!(extract_assignment_value(r#"$other = "x""#, "$mode"), None);
+    }
+
+    #[test]
+    fn extract_system_sound_picks_play_name() {
+        assert_eq!(
+            extract_system_sound("        [System.Media.SystemSounds]::Asterisk.Play()"),
+            Some("Asterisk".to_string())
+        );
+        assert_eq!(
+            extract_system_sound("[System.Media.SystemSounds]::Exclamation.Play()"),
+            Some("Exclamation".to_string())
+        );
+        assert_eq!(extract_system_sound("Start-Sleep -Milliseconds 400"), None);
+    }
+}

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod activity;
 mod adventure;
+mod claude_env;
 mod questlog_hub;
 mod life;
 mod local_dev;
@@ -14,6 +15,7 @@ use activity::{activity_list_days, activity_query_day, activity_status, Activity
 use adventure::{
     adventure_claude_complete, adventure_commit_summary, adventure_save_image, adventure_save_raw,
 };
+use claude_env::claude_env_read_notify_config;
 use questlog_hub::get_questlog_hub;
 use life::life_screen_capture;
 use quest_index::get_quest_tree;
@@ -899,7 +901,8 @@ pub fn run() {
             adventure_claude_complete,
             adventure_save_raw,
             adventure_save_image,
-            adventure_commit_summary
+            adventure_commit_summary,
+            claude_env_read_notify_config
         ])
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -15,7 +15,9 @@ use activity::{activity_list_days, activity_query_day, activity_status, Activity
 use adventure::{
     adventure_claude_complete, adventure_commit_summary, adventure_save_image, adventure_save_raw,
 };
-use claude_env::claude_env_read_notify_config;
+use claude_env::{
+    claude_env_preview_sound, claude_env_read_notify_config, claude_env_write_notify_config,
+};
 use questlog_hub::get_questlog_hub;
 use life::life_screen_capture;
 use quest_index::get_quest_tree;
@@ -902,7 +904,9 @@ pub fn run() {
             adventure_save_raw,
             adventure_save_image,
             adventure_commit_summary,
-            claude_env_read_notify_config
+            claude_env_read_notify_config,
+            claude_env_write_notify_config,
+            claude_env_preview_sound
         ])
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -908,6 +908,7 @@ pub fn run() {
             claude_env_write_notify_config,
             claude_env_preview_sound
         ])
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
             if let Some(w) = app.get_webview_window("main") {

--- a/apps/karmolab/build.mjs
+++ b/apps/karmolab/build.mjs
@@ -66,6 +66,7 @@ const entryPoints = [
   'src/widgets/darkroom.ts',
   'src/widgets/dashboard.ts',
   'src/widgets/activity.ts',
+  'src/widgets/claude-env.ts',
   'src/widgets/devtools.ts',
   'src/widgets/eyes.ts',
   'src/widgets/favorites.ts',

--- a/apps/karmolab/src/widgets-lazy-meta.ts
+++ b/apps/karmolab/src/widgets-lazy-meta.ts
@@ -169,6 +169,15 @@ window.KARMOLAB_LAZY_META = [
     icon: '<rect x="3" y="4" width="18" height="16" rx="2" ry="2" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M7 9l3 3-3 3M12 15h5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>',
     lazyScriptPaths: ['terminal/terminal']
   },
+  {
+    id: 'claude-env',
+    title: 'Claude 환경',
+    category: 'desktop',
+    desc: 'Claude Code Stop/Notification hook 사운드 알림 GUI — memo/dotfiles 정본 (v1: read 만, Step 2+: write + sync + preview + wav drag-drop)',
+    layout: 'form',
+    icon: '<path d="M3 11l3-3 3 3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><path d="M6 8v8a3 3 0 003 3h6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><circle cx="18" cy="19" r="2" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="6" r="2" fill="none" stroke="currentColor" stroke-width="1.6"/>',
+    lazyScriptPaths: ['claude-env']
+  },
 
   /* ───── 잡동사니 (Stash) — TASK-KL-034 ─────
    * 사이드바 hide (hidden: true). 「잡동사니」 위젯 안에서 inline render + 자동 작동.

--- a/apps/karmolab/src/widgets/claude-env.ts
+++ b/apps/karmolab/src/widgets/claude-env.ts
@@ -171,6 +171,12 @@
     wavInput.placeholder = 'C:\\Users\\…\\hooks\\sounds\\stop.wav';
     wavInput.spellcheck = false;
     wavControl.appendChild(wavInput);
+    const wavBrowse = document.createElement('button');
+    wavBrowse.type = 'button';
+    wavBrowse.className = 'claude-env-browse';
+    wavBrowse.title = '.wav 파일 선택';
+    wavBrowse.textContent = '찾아보기';
+    wavControl.appendChild(wavBrowse);
     const wavPlay = document.createElement('button');
     wavPlay.type = 'button';
     wavPlay.className = 'claude-env-play';
@@ -223,6 +229,39 @@
     beepPlay.addEventListener('click', () => preview('beep'));
     wavPlay.addEventListener('click', () => preview('wav'));
 
+    // 「찾아보기」 — OS 파일 다이얼로그로 .wav 선택. 선택 시 path 입력 + mode=wav 자동 전환.
+    wavBrowse.addEventListener('click', function () {
+      const dialog = (window as unknown as { __TAURI__?: { dialog?: { open?: unknown } } })
+        .__TAURI__?.dialog;
+      const openFn =
+        dialog && typeof dialog.open === 'function'
+          ? (dialog.open as (opts: unknown) => Promise<unknown>)
+          : null;
+      if (!openFn) {
+        setLog(`${name} 파일 선택 불가 — Tauri dialog 없음 (데스크톱 앱 전용).`, true);
+        return;
+      }
+      void openFn({
+        multiple: false,
+        directory: false,
+        filters: [{ name: 'WAV 사운드', extensions: ['wav'] }]
+      })
+        .then(function (selected) {
+          if (typeof selected !== 'string' || selected.length === 0) {
+            return; // 취소
+          }
+          wavInput.value = selected;
+          for (const r of radios) {
+            r.checked = r.value === 'wav';
+          }
+        })
+        .catch(function (e: unknown) {
+          const msg = e instanceof Error ? e.message : String(e);
+          setLog(`${name} 파일 선택 실패: ${msg}`, true);
+          Toolbox.showToast?.('Claude 환경 파일 선택 실패', 'error', e);
+        });
+    });
+
     return { el: sec, form };
   }
 
@@ -246,6 +285,8 @@
         .claude-env-input { font-family: ui-monospace, monospace; }
         .claude-env-play { padding: 4px 10px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-tertiary); color: var(--text-primary); font-size: var(--font-size-sm); cursor: pointer; line-height: 1; }
         .claude-env-play:hover { background: var(--bg-quaternary, var(--bg-tertiary)); border-color: var(--accent); }
+        .claude-env-browse { padding: 4px 10px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-tertiary); color: var(--text-secondary); font-size: var(--font-size-xs); cursor: pointer; line-height: 1; white-space: nowrap; }
+        .claude-env-browse:hover { background: var(--bg-quaternary, var(--bg-tertiary)); border-color: var(--accent); color: var(--text-primary); }
         .claude-env-hint { flex: 1; color: var(--text-tertiary); font-size: var(--font-size-xs); font-family: ui-monospace, monospace; }
         .claude-env-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
         .claude-env-save { padding: 6px 16px; border: 1px solid var(--accent, var(--border)); border-radius: var(--radius-sm); background: var(--accent, var(--bg-tertiary)); color: var(--accent-fg, var(--text-primary)); font-size: var(--font-size-sm); font-weight: 600; cursor: pointer; }

--- a/apps/karmolab/src/widgets/claude-env.ts
+++ b/apps/karmolab/src/widgets/claude-env.ts
@@ -1,0 +1,156 @@
+/**
+ * Claude 환경 컨트롤 위젯 — TASK-KL-056.
+ *
+ * v1 Step 1 = read 흐름만. Claude Code Stop/Notification hook 의 사운드 알림 설정
+ * (memo/dotfiles/claude-hooks/notify-*.ps1) 의 현재 상태를 GUI 에 표시.
+ *
+ * 후속 Step:
+ *   2 = write + sync (정본 편집 → sync-claude-hooks.ps1 호출)
+ *   3 = 미리듣기 (PowerShell shell-out)
+ *   4 = .wav drag-drop
+ *
+ * Stop 과 Notification 의 차이:
+ *   Stop = Claude 응답 끝날 때마다 — 일반 알림 (Asterisk 기본)
+ *   Notification = 권한 요청 / 60s idle 등 사용자 행동 필요 시 — 강조 (Exclamation 기본)
+ */
+(function (): void {
+  'use strict';
+
+  type NotifyHookConfig = {
+    mode: string;
+    system_sound?: string | null;
+    wav_path?: string | null;
+  };
+
+  type NotifyConfigDto = {
+    stop: NotifyHookConfig;
+    notification: NotifyHookConfig;
+    canonical_root: string;
+  };
+
+  function desktopInvoke(cmd: string, args?: unknown): Promise<unknown> {
+    const core = window.__TAURI__?.core;
+    const fn = core && typeof core.invoke === 'function' ? core.invoke : null;
+    if (!fn) {
+      return Promise.reject(
+        new Error('Tauri invoke 없음 — KarmoLab 데스크톱 앱에서만 사용 가능합니다.')
+      );
+    }
+    return fn(cmd, args);
+  }
+
+  function buildHookCard(name: string, label: string, hook: NotifyHookConfig): HTMLElement {
+    const sec = document.createElement('section');
+    sec.className = 'claude-env-section';
+
+    const h = document.createElement('h3');
+    h.className = 'claude-env-section-title';
+    h.textContent = label;
+    sec.appendChild(h);
+
+    const dl = document.createElement('dl');
+    dl.className = 'claude-env-dl';
+
+    const rows: ReadonlyArray<readonly [string, string]> = [
+      ['mode', hook.mode],
+      ['system sound', hook.system_sound || '(none)'],
+      ['wav path', hook.wav_path || '(none)']
+    ];
+    for (const [key, value] of rows) {
+      const dt = document.createElement('dt');
+      dt.textContent = key;
+      const dd = document.createElement('dd');
+      dd.textContent = value;
+      dl.appendChild(dt);
+      dl.appendChild(dd);
+    }
+    sec.appendChild(dl);
+
+    sec.dataset.hook = name;
+    return sec;
+  }
+
+  function build(container: HTMLElement): void {
+    Mdd.injectCSS(
+      'claude-env',
+      `
+        .claude-env-root { max-width: 640px; }
+        .claude-env-intro { font-size: var(--font-size-sm); color: var(--text-tertiary); margin: 0 0 8px 0; line-height: 1.5; }
+        .claude-env-canonical { font-size: var(--font-size-xs); color: var(--text-tertiary); margin: 0 0 20px 0; font-family: ui-monospace, monospace; word-break: break-all; }
+        .claude-env-section { margin-bottom: 24px; padding: 16px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--bg-secondary); }
+        .claude-env-section-title { font-size: 14px; font-weight: 600; color: var(--text-primary); margin: 0 0 12px 0; }
+        .claude-env-dl { display: grid; grid-template-columns: max-content 1fr; gap: 4px 16px; margin: 0; font-size: var(--font-size-sm); }
+        .claude-env-dl dt { color: var(--text-secondary); font-weight: 600; }
+        .claude-env-dl dd { margin: 0; color: var(--text-primary); font-family: ui-monospace, monospace; word-break: break-all; }
+        .claude-env-log { margin-top: 12px; padding: 12px 14px; border-radius: var(--radius-md); background: var(--bg-tertiary); border: 1px solid var(--border); font-size: var(--font-size-xs); font-family: ui-monospace, monospace; color: var(--text-secondary); white-space: pre-wrap; word-break: break-word; }
+        .claude-env-log-err { border-color: var(--error-subtle); color: var(--error); }
+      `
+    );
+
+    container.innerHTML = '';
+    const root = document.createElement('div');
+    root.className = 'claude-env-root';
+
+    const intro = document.createElement('p');
+    intro.className = 'claude-env-intro';
+    intro.textContent =
+      'Claude Code 의 Stop / Notification hook 사운드 알림 설정. ' +
+      'v1 Step 1 = 현재 상태 read 만 (편집은 후속 Step 에서).';
+    root.appendChild(intro);
+
+    const canonical = document.createElement('p');
+    canonical.className = 'claude-env-canonical';
+    canonical.textContent = '정본 위치: (loading…)';
+    root.appendChild(canonical);
+
+    const stopSlot = document.createElement('div');
+    stopSlot.dataset.slot = 'stop';
+    root.appendChild(stopSlot);
+
+    const notifSlot = document.createElement('div');
+    notifSlot.dataset.slot = 'notification';
+    root.appendChild(notifSlot);
+
+    const log = document.createElement('div');
+    log.className = 'claude-env-log';
+    log.textContent = 'loading…';
+    root.appendChild(log);
+
+    container.appendChild(root);
+
+    const isApp = typeof Toolbox.isDesktopApp === 'function' && Toolbox.isDesktopApp();
+    if (!isApp) {
+      log.className = 'claude-env-log claude-env-log-err';
+      log.textContent = '웹 브라우저에서는 사용할 수 없습니다. KarmoLab Tauri 앱으로 열어 주세요.';
+      canonical.textContent = '';
+      return;
+    }
+
+    void desktopInvoke('claude_env_read_notify_config')
+      .then(function (res) {
+        const config = res as NotifyConfigDto;
+        canonical.textContent = '정본 위치: ' + config.canonical_root;
+        stopSlot.replaceChildren(buildHookCard('stop', 'Stop hook (응답 끝)', config.stop));
+        notifSlot.replaceChildren(
+          buildHookCard('notification', 'Notification hook (권한 요청 / idle)', config.notification)
+        );
+        log.textContent = 'read OK — Step 2 (write + sync) 부터 GUI 편집 활성.';
+      })
+      .catch(function (e: unknown) {
+        log.className = 'claude-env-log claude-env-log-err';
+        const errMsg = e instanceof Error ? e.message : String(e);
+        log.textContent = 'read 실패: ' + errMsg;
+        Toolbox.showToast?.('Claude 환경 read 실패', 'error', e);
+      });
+  }
+
+  Toolbox.register({
+    id: 'claude-env',
+    title: 'Claude 환경',
+    category: 'desktop',
+    desc: 'Claude Code Stop/Notification hook 의 사운드 알림 GUI (memo/dotfiles 정본 read; v1 Step 1)',
+    layout: 'form',
+    icon: '<path d="M3 11l3-3 3 3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><path d="M6 8v8a3 3 0 003 3h6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><circle cx="18" cy="19" r="2" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="6" r="2" fill="none" stroke="currentColor" stroke-width="1.6"/>',
+    tabs: [{ id: 'claude-env-main', label: '패널', build }]
+  });
+})();

--- a/apps/karmolab/src/widgets/claude-env.ts
+++ b/apps/karmolab/src/widgets/claude-env.ts
@@ -1,13 +1,12 @@
 /**
  * Claude 환경 컨트롤 위젯 — TASK-KL-056.
  *
- * v1 Step 1 = read 흐름만. Claude Code Stop/Notification hook 의 사운드 알림 설정
- * (memo/dotfiles/claude-hooks/notify-*.ps1) 의 현재 상태를 GUI 에 표시.
+ * v1 Step 2 + 3 = read + write/sync + 미리듣기.
+ * Stop/Notification hook 각각 mode (system/beep/wav) + system sound + wav path 편집,
+ * 저장 시 정본 (memo/dotfiles/claude-hooks/notify-*.ps1) 편집 + sync-claude-hooks.ps1 호출.
  *
  * 후속 Step:
- *   2 = write + sync (정본 편집 → sync-claude-hooks.ps1 호출)
- *   3 = 미리듣기 (PowerShell shell-out)
- *   4 = .wav drag-drop
+ *   4 = .wav drag-drop (sub TASK 시드 — 별 PR)
  *
  * Stop 과 Notification 의 차이:
  *   Stop = Claude 응답 끝날 때마다 — 일반 알림 (Asterisk 기본)
@@ -15,6 +14,11 @@
  */
 (function (): void {
   'use strict';
+
+  type NotifyMode = 'system' | 'beep' | 'wav';
+  const MODES: ReadonlyArray<NotifyMode> = ['system', 'beep', 'wav'];
+  const SYSTEM_SOUNDS = ['Asterisk', 'Beep', 'Exclamation', 'Hand', 'Question'] as const;
+  type SystemSound = (typeof SYSTEM_SOUNDS)[number];
 
   type NotifyHookConfig = {
     mode: string;
@@ -28,6 +32,12 @@
     canonical_root: string;
   };
 
+  type WriteResultDto = {
+    canonical_root: string;
+    sync_stdout: string;
+    sync_stderr: string;
+  };
+
   function desktopInvoke(cmd: string, args?: unknown): Promise<unknown> {
     const core = window.__TAURI__?.core;
     const fn = core && typeof core.invoke === 'function' ? core.invoke : null;
@@ -39,50 +49,208 @@
     return fn(cmd, args);
   }
 
-  function buildHookCard(name: string, label: string, hook: NotifyHookConfig): HTMLElement {
+  type HookForm = {
+    name: 'stop' | 'notification';
+    getMode: () => NotifyMode;
+    getSystemSound: () => SystemSound;
+    getWavPath: () => string;
+    snapshot: () => NotifyHookConfig;
+    populate: (hook: NotifyHookConfig) => void;
+  };
+
+  function normalizeMode(raw: string | null | undefined): NotifyMode {
+    return MODES.find((m) => m === raw) ?? 'system';
+  }
+
+  function normalizeSystemSound(raw: string | null | undefined): SystemSound {
+    return SYSTEM_SOUNDS.find((s) => s === raw) ?? 'Asterisk';
+  }
+
+  function buildHookCard(
+    name: 'stop' | 'notification',
+    label: string,
+    setLog: (text: string, isErr: boolean) => void
+  ): { el: HTMLElement; form: HookForm } {
     const sec = document.createElement('section');
     sec.className = 'claude-env-section';
+    sec.dataset.hook = name;
 
     const h = document.createElement('h3');
     h.className = 'claude-env-section-title';
     h.textContent = label;
     sec.appendChild(h);
 
-    const dl = document.createElement('dl');
-    dl.className = 'claude-env-dl';
-
-    const rows: ReadonlyArray<readonly [string, string]> = [
-      ['mode', hook.mode],
-      ['system sound', hook.system_sound || '(none)'],
-      ['wav path', hook.wav_path || '(none)']
-    ];
-    for (const [key, value] of rows) {
-      const dt = document.createElement('dt');
-      dt.textContent = key;
-      const dd = document.createElement('dd');
-      dd.textContent = value;
-      dl.appendChild(dt);
-      dl.appendChild(dd);
+    // mode radio row
+    const modeRow = document.createElement('div');
+    modeRow.className = 'claude-env-row';
+    const modeLabel = document.createElement('span');
+    modeLabel.className = 'claude-env-field-label';
+    modeLabel.textContent = 'mode';
+    modeRow.appendChild(modeLabel);
+    const modeGroup = document.createElement('div');
+    modeGroup.className = 'claude-env-radio-group';
+    const radios: HTMLInputElement[] = [];
+    for (const m of MODES) {
+      const wrap = document.createElement('label');
+      wrap.className = 'claude-env-radio';
+      const radio = document.createElement('input');
+      radio.type = 'radio';
+      radio.name = `claude-env-mode-${name}`;
+      radio.value = m;
+      radios.push(radio);
+      wrap.appendChild(radio);
+      const txt = document.createElement('span');
+      txt.textContent = m;
+      wrap.appendChild(txt);
+      modeGroup.appendChild(wrap);
     }
-    sec.appendChild(dl);
+    modeRow.appendChild(modeGroup);
+    sec.appendChild(modeRow);
 
-    sec.dataset.hook = name;
-    return sec;
+    // system sound row (dropdown + ▶)
+    const sysRow = document.createElement('div');
+    sysRow.className = 'claude-env-row';
+    const sysLabel = document.createElement('span');
+    sysLabel.className = 'claude-env-field-label';
+    sysLabel.textContent = 'system sound';
+    sysRow.appendChild(sysLabel);
+    const sysControl = document.createElement('div');
+    sysControl.className = 'claude-env-input-row';
+    const sysSelect = document.createElement('select');
+    sysSelect.className = 'claude-env-select';
+    for (const s of SYSTEM_SOUNDS) {
+      const opt = document.createElement('option');
+      opt.value = s;
+      opt.textContent = s;
+      sysSelect.appendChild(opt);
+    }
+    sysControl.appendChild(sysSelect);
+    const sysPlay = document.createElement('button');
+    sysPlay.type = 'button';
+    sysPlay.className = 'claude-env-play';
+    sysPlay.title = 'system 사운드 미리듣기';
+    sysPlay.textContent = '▶';
+    sysControl.appendChild(sysPlay);
+    sysRow.appendChild(sysControl);
+    sec.appendChild(sysRow);
+
+    // beep row (▶ only — 톤은 정본 .ps1 의 hook 별 값으로 고정)
+    const beepRow = document.createElement('div');
+    beepRow.className = 'claude-env-row';
+    const beepLabel = document.createElement('span');
+    beepLabel.className = 'claude-env-field-label';
+    beepLabel.textContent = 'beep';
+    beepRow.appendChild(beepLabel);
+    const beepControl = document.createElement('div');
+    beepControl.className = 'claude-env-input-row';
+    const beepHint = document.createElement('span');
+    beepHint.className = 'claude-env-hint';
+    beepHint.textContent = name === 'stop' ? '880 Hz · 150 ms' : '1200 Hz · 100 ms ×2';
+    beepControl.appendChild(beepHint);
+    const beepPlay = document.createElement('button');
+    beepPlay.type = 'button';
+    beepPlay.className = 'claude-env-play';
+    beepPlay.title = 'beep 미리듣기';
+    beepPlay.textContent = '▶';
+    beepControl.appendChild(beepPlay);
+    beepRow.appendChild(beepControl);
+    sec.appendChild(beepRow);
+
+    // wav row (text input + ▶)
+    const wavRow = document.createElement('div');
+    wavRow.className = 'claude-env-row';
+    const wavLabel = document.createElement('span');
+    wavLabel.className = 'claude-env-field-label';
+    wavLabel.textContent = 'wav path';
+    wavRow.appendChild(wavLabel);
+    const wavControl = document.createElement('div');
+    wavControl.className = 'claude-env-input-row';
+    const wavInput = document.createElement('input');
+    wavInput.type = 'text';
+    wavInput.className = 'claude-env-input';
+    wavInput.placeholder = 'C:\\Users\\…\\hooks\\sounds\\stop.wav';
+    wavInput.spellcheck = false;
+    wavControl.appendChild(wavInput);
+    const wavPlay = document.createElement('button');
+    wavPlay.type = 'button';
+    wavPlay.className = 'claude-env-play';
+    wavPlay.title = '.wav 미리듣기';
+    wavPlay.textContent = '▶';
+    wavControl.appendChild(wavPlay);
+    wavRow.appendChild(wavControl);
+    sec.appendChild(wavRow);
+
+    const form: HookForm = {
+      name,
+      getMode: () => {
+        const checked = radios.find((r) => r.checked);
+        return normalizeMode(checked?.value);
+      },
+      getSystemSound: () => normalizeSystemSound(sysSelect.value),
+      getWavPath: () => wavInput.value.trim(),
+      snapshot: () => ({
+        mode: form.getMode(),
+        system_sound: form.getSystemSound(),
+        wav_path: form.getWavPath() || null
+      }),
+      populate: (hook) => {
+        const mode = normalizeMode(hook.mode);
+        for (const r of radios) {
+          r.checked = r.value === mode;
+        }
+        sysSelect.value = normalizeSystemSound(hook.system_sound);
+        wavInput.value = hook.wav_path ?? '';
+      }
+    };
+
+    // 미리듣기 버튼들 — 클릭 시 입력 즉시 invoke (저장 안 함).
+    function preview(mode: NotifyMode): void {
+      const snap = form.snapshot();
+      // 미리듣기 인자: 호출 시점 mode 가 클릭 출처 (▶ 버튼 위치).
+      const args: Record<string, unknown> = {
+        hook: name,
+        mode,
+        systemSound: snap.system_sound,
+        wavPath: snap.wav_path
+      };
+      void desktopInvoke('claude_env_preview_sound', args).catch((e: unknown) => {
+        const msg = e instanceof Error ? e.message : String(e);
+        setLog(`${name} ${mode} 미리듣기 실패: ${msg}`, true);
+        Toolbox.showToast?.('Claude 환경 미리듣기 실패', 'error', e);
+      });
+    }
+    sysPlay.addEventListener('click', () => preview('system'));
+    beepPlay.addEventListener('click', () => preview('beep'));
+    wavPlay.addEventListener('click', () => preview('wav'));
+
+    return { el: sec, form };
   }
 
   function build(container: HTMLElement): void {
     Mdd.injectCSS(
       'claude-env',
       `
-        .claude-env-root { max-width: 640px; }
+        .claude-env-root { max-width: 680px; }
         .claude-env-intro { font-size: var(--font-size-sm); color: var(--text-tertiary); margin: 0 0 8px 0; line-height: 1.5; }
         .claude-env-canonical { font-size: var(--font-size-xs); color: var(--text-tertiary); margin: 0 0 20px 0; font-family: ui-monospace, monospace; word-break: break-all; }
         .claude-env-section { margin-bottom: 24px; padding: 16px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--bg-secondary); }
         .claude-env-section-title { font-size: 14px; font-weight: 600; color: var(--text-primary); margin: 0 0 12px 0; }
-        .claude-env-dl { display: grid; grid-template-columns: max-content 1fr; gap: 4px 16px; margin: 0; font-size: var(--font-size-sm); }
-        .claude-env-dl dt { color: var(--text-secondary); font-weight: 600; }
-        .claude-env-dl dd { margin: 0; color: var(--text-primary); font-family: ui-monospace, monospace; word-break: break-all; }
-        .claude-env-log { margin-top: 12px; padding: 12px 14px; border-radius: var(--radius-md); background: var(--bg-tertiary); border: 1px solid var(--border); font-size: var(--font-size-xs); font-family: ui-monospace, monospace; color: var(--text-secondary); white-space: pre-wrap; word-break: break-word; }
+        .claude-env-row { display: grid; grid-template-columns: 110px 1fr; gap: 12px; align-items: center; margin-bottom: 10px; }
+        .claude-env-row:last-child { margin-bottom: 0; }
+        .claude-env-field-label { font-size: var(--font-size-sm); color: var(--text-secondary); font-weight: 600; }
+        .claude-env-radio-group { display: flex; gap: 12px; flex-wrap: wrap; }
+        .claude-env-radio { display: inline-flex; align-items: center; gap: 4px; font-size: var(--font-size-sm); color: var(--text-primary); cursor: pointer; }
+        .claude-env-radio input { margin: 0; cursor: pointer; }
+        .claude-env-input-row { display: flex; gap: 6px; align-items: center; }
+        .claude-env-select, .claude-env-input { flex: 1; min-width: 0; padding: 4px 8px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-primary); color: var(--text-primary); font-size: var(--font-size-sm); font-family: inherit; }
+        .claude-env-input { font-family: ui-monospace, monospace; }
+        .claude-env-play { padding: 4px 10px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-tertiary); color: var(--text-primary); font-size: var(--font-size-sm); cursor: pointer; line-height: 1; }
+        .claude-env-play:hover { background: var(--bg-quaternary, var(--bg-tertiary)); border-color: var(--accent); }
+        .claude-env-hint { flex: 1; color: var(--text-tertiary); font-size: var(--font-size-xs); font-family: ui-monospace, monospace; }
+        .claude-env-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
+        .claude-env-save { padding: 6px 16px; border: 1px solid var(--accent, var(--border)); border-radius: var(--radius-sm); background: var(--accent, var(--bg-tertiary)); color: var(--accent-fg, var(--text-primary)); font-size: var(--font-size-sm); font-weight: 600; cursor: pointer; }
+        .claude-env-save[disabled] { opacity: 0.5; cursor: progress; }
+        .claude-env-log { margin-top: 12px; padding: 12px 14px; border-radius: var(--radius-md); background: var(--bg-tertiary); border: 1px solid var(--border); font-size: var(--font-size-xs); font-family: ui-monospace, monospace; color: var(--text-secondary); white-space: pre-wrap; word-break: break-word; max-height: 200px; overflow-y: auto; }
         .claude-env-log-err { border-color: var(--error-subtle); color: var(--error); }
       `
     );
@@ -94,8 +262,8 @@
     const intro = document.createElement('p');
     intro.className = 'claude-env-intro';
     intro.textContent =
-      'Claude Code 의 Stop / Notification hook 사운드 알림 설정. ' +
-      'v1 Step 1 = 현재 상태 read 만 (편집은 후속 Step 에서).';
+      'Claude Code 의 Stop / Notification hook 사운드 알림. ' +
+      '저장하면 memo/dotfiles/claude-hooks/notify-*.ps1 정본을 편집한 뒤 sync-claude-hooks.ps1 가 ~/.claude/hooks/ 로 배포합니다.';
     root.appendChild(intro);
 
     const canonical = document.createElement('p');
@@ -103,52 +271,110 @@
     canonical.textContent = '정본 위치: (loading…)';
     root.appendChild(canonical);
 
-    const stopSlot = document.createElement('div');
-    stopSlot.dataset.slot = 'stop';
-    root.appendChild(stopSlot);
-
-    const notifSlot = document.createElement('div');
-    notifSlot.dataset.slot = 'notification';
-    root.appendChild(notifSlot);
-
     const log = document.createElement('div');
     log.className = 'claude-env-log';
     log.textContent = 'loading…';
+    function setLog(text: string, isErr: boolean): void {
+      log.className = 'claude-env-log' + (isErr ? ' claude-env-log-err' : '');
+      log.textContent = text;
+    }
+
+    const stopBuild = buildHookCard('stop', 'Stop hook (응답 끝)', setLog);
+    const notifBuild = buildHookCard(
+      'notification',
+      'Notification hook (권한 요청 / idle)',
+      setLog
+    );
+    root.appendChild(stopBuild.el);
+    root.appendChild(notifBuild.el);
+
+    const actions = document.createElement('div');
+    actions.className = 'claude-env-actions';
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.className = 'claude-env-save';
+    saveBtn.textContent = '저장 + sync 실행';
+    actions.appendChild(saveBtn);
+    root.appendChild(actions);
     root.appendChild(log);
 
     container.appendChild(root);
 
     const isApp = typeof Toolbox.isDesktopApp === 'function' && Toolbox.isDesktopApp();
     if (!isApp) {
-      log.className = 'claude-env-log claude-env-log-err';
-      log.textContent = '웹 브라우저에서는 사용할 수 없습니다. KarmoLab Tauri 앱으로 열어 주세요.';
+      setLog('웹 브라우저에서는 사용할 수 없습니다. KarmoLab Tauri 앱으로 열어 주세요.', true);
       canonical.textContent = '';
+      saveBtn.disabled = true;
       return;
     }
 
-    void desktopInvoke('claude_env_read_notify_config')
-      .then(function (res) {
-        const config = res as NotifyConfigDto;
-        canonical.textContent = '정본 위치: ' + config.canonical_root;
-        stopSlot.replaceChildren(buildHookCard('stop', 'Stop hook (응답 끝)', config.stop));
-        notifSlot.replaceChildren(
-          buildHookCard('notification', 'Notification hook (권한 요청 / idle)', config.notification)
-        );
-        log.textContent = 'read OK — Step 2 (write + sync) 부터 GUI 편집 활성.';
-      })
-      .catch(function (e: unknown) {
-        log.className = 'claude-env-log claude-env-log-err';
-        const errMsg = e instanceof Error ? e.message : String(e);
-        log.textContent = 'read 실패: ' + errMsg;
-        Toolbox.showToast?.('Claude 환경 read 실패', 'error', e);
-      });
+    function loadConfig(): void {
+      saveBtn.disabled = true;
+      saveBtn.textContent = '읽는 중…';
+      setLog('loading…', false);
+      void desktopInvoke('claude_env_read_notify_config')
+        .then(function (res) {
+          const config = res as NotifyConfigDto;
+          canonical.textContent = '정본 위치: ' + config.canonical_root;
+          stopBuild.form.populate(config.stop);
+          notifBuild.form.populate(config.notification);
+          setLog('read OK — 편집 후 [저장 + sync 실행] 으로 정본 반영. 미리듣기는 ▶.', false);
+          saveBtn.textContent = '저장 + sync 실행';
+          saveBtn.disabled = false;
+        })
+        .catch(function (e: unknown) {
+          const errMsg = e instanceof Error ? e.message : String(e);
+          setLog('read 실패: ' + errMsg, true);
+          Toolbox.showToast?.('Claude 환경 read 실패', 'error', e);
+          saveBtn.textContent = '저장 + sync 실행';
+        });
+    }
+
+    saveBtn.addEventListener('click', function () {
+      saveBtn.disabled = true;
+      saveBtn.textContent = '저장 + sync 실행 중…';
+      setLog('write + sync 중…', false);
+      const payload = {
+        config: {
+          stop: stopBuild.form.snapshot(),
+          notification: notifBuild.form.snapshot()
+        }
+      };
+      void desktopInvoke('claude_env_write_notify_config', payload)
+        .then(function (res) {
+          const result = res as WriteResultDto;
+          const lines: string[] = [
+            'write + sync OK.',
+            '',
+            '— sync stdout —',
+            result.sync_stdout.trim() || '(empty)'
+          ];
+          if (result.sync_stderr.trim().length > 0) {
+            lines.push('', '— sync stderr —', result.sync_stderr.trim());
+          }
+          lines.push('', '* 새 세션부터 효과 (Claude Code hook reload 정책).');
+          setLog(lines.join('\n'), false);
+          Toolbox.showToast?.('Claude 환경 저장 + sync 완료', 'success');
+          saveBtn.textContent = '저장 + sync 실행';
+          saveBtn.disabled = false;
+        })
+        .catch(function (e: unknown) {
+          const errMsg = e instanceof Error ? e.message : String(e);
+          setLog('write/sync 실패: ' + errMsg, true);
+          Toolbox.showToast?.('Claude 환경 저장 실패', 'error', e);
+          saveBtn.textContent = '저장 + sync 실행';
+          saveBtn.disabled = false;
+        });
+    });
+
+    loadConfig();
   }
 
   Toolbox.register({
     id: 'claude-env',
     title: 'Claude 환경',
     category: 'desktop',
-    desc: 'Claude Code Stop/Notification hook 의 사운드 알림 GUI (memo/dotfiles 정본 read; v1 Step 1)',
+    desc: 'Claude Code Stop/Notification hook 사운드 알림 GUI (memo/dotfiles 정본 편집 + sync; v1 Step 2/3)',
     layout: 'form',
     icon: '<path d="M3 11l3-3 3 3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><path d="M6 8v8a3 3 0 003 3h6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><circle cx="18" cy="19" r="2" fill="none" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="6" r="2" fill="none" stroke="currentColor" stroke-width="1.6"/>',
     tabs: [{ id: 'claude-env-main', label: '패널', build }]


### PR DESCRIPTION
## Summary

KarmoLab Tauri 앱에 **Claude 환경 컨트롤 위젯** 신설 — TASK-KL-056. v1 = Claude Code Stop/Notification hook 의 사운드 알림 설정을 GUI 로 노출 (직전 작업으로 박은 `karmoddrine/memo/dotfiles/claude-hooks/notify-*.ps1` 의 `$mode` 직접 편집 방식을 GUI 화).

**Step 1 (본 PR)** = read 흐름만:
- Rust `claude_env_read_notify_config` 명령 — std 만으로 `.ps1` line scan (`$mode` / `$wavPath` / `[System.Media.SystemSounds]::<Name>.Play`).
- 위젯 = Stop / Notification 카드 2개 + 정본 경로 표시.

**ACL 4-source 동시 수정 (KL-040 룰)**:
- `apps/karmolab-tauri/src-tauri/src/claude_env.rs` (신규) — `#[tauri::command]`
- `apps/karmolab-tauri/src-tauri/src/lib.rs` — `mod` + `use` + `generate_handler!`
- `apps/karmolab-tauri/src-tauri/permissions/claude-env.toml` (신규) — `allow-claude-env` 그룹
- `apps/karmolab-tauri/src-tauri/capabilities/default.json` — `allow-claude-env` 추가

ACL audit: `backend:47 handler:47 perms:47 모두 정합`.

**위젯**:
- `apps/karmolab/src/widgets/claude-env.ts` (신규) — `devtools.ts` 패턴 흉내, `Toolbox.register(category=desktop, layout=form)`.
- `apps/karmolab/src/widgets-lazy-meta.ts` — terminal 옆 desktop 카테고리 entry.

## 후속 Step (별 PR)

- Step 2 = write + sync (정본 편집 → `sync-claude-hooks.ps1` 호출)
- Step 3 = 미리듣기 (PowerShell shell-out)
- Step 4 = .wav drag-drop

**미래 vector** (각각 별 sub TASK 시드 권장):
- dotfiles sync 상태 패널
- hook 활성화 토글
- discoveries 뷰어
- daily-stats 차트
- settings.json visual editor

## Test plan

- [ ] verify CI (cargo check + 4 sub-app build + lint + typos) 통과
- [ ] KarmoLab 데스크톱 앱에서 「Claude 환경」 위젯 열기 → Stop/Notification 카드에 현재 mode + system sound + wav path 표시
- [ ] 정본 경로 = `$USERPROFILE/repos/karmoddrine/memo/dotfiles/claude-hooks/` 표시
- [ ] 웹 브라우저 (mascari4615.github.io/karmolab/) 진입 시 「데스크톱 앱에서만 사용 가능」 안내 표시
- [ ] notify-stop.ps1 의 `\$mode` 를 수동 변경 → 위젯 refresh 시 변경 반영

## 룰 정합

- `memo/rules/process.md` § 「Claude 환경 설정 = memo/dotfiles 정본 + sync 경유」 (직전 turn 신설) — GUI 가 직접 `~/.claude/` 박지 X, 정본 read.
- `apps/karmolab-tauri` ACL 4-source audit (KL-040) — 4곳 동시 수정 + audit 통과.
- KarmoLab README — TASK 단위 시작 / 한 커밋 한 주제 / Step 1/2/3 패턴.

🤖 Generated with [Claude Code](https://claude.com/claude-code)