### PR TITLE
feat(yawnbot-ops): health watcher + nssm 진단/재시작 workflow 3종

### DIFF
--- a/.github/workflows/yawnbot-health.yml
+++ b/.github/workflows/yawnbot-health.yml
@@ -1,0 +1,77 @@
+name: Yawnbot Health Watcher
+
+# TASK-YB-020 사후 인프라 — yawnbot prod health endpoint 외부 감시.
+# 「monitoring 주체 ≠ monitoring 대상」 원칙: github-hosted ubuntu runner 사용
+# (self-hosted runner = prod 노트북 = 감시 대상이라 같이 죽음).
+# alert 채널 = 봇 의존 X Discord Incoming Webhook URL (secret).
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'   # GH Actions schedule 실 발동 5~15분 지연 — yawnbot 분단위 SLA 아님, 충분.
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: yawnbot-health-watcher
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    env:
+      HEALTH_URL: 'https://yawnbot.mascari4615.com/health'
+      ALERT_WEBHOOK: ${{ secrets.YAWNBOT_HEALTH_ALERT_WEBHOOK_URL }}
+
+    steps:
+      - name: HTTP probe
+        id: probe
+        run: |
+          set +e
+          # -m 10 = 10초 타임아웃 (네트워크 일시 지연 흡수)
+          BODY=$(curl -sS -m 10 -w "\nHTTP_CODE:%{http_code}\n" "$HEALTH_URL" 2>&1)
+          CURL_EXIT=$?
+          HTTP_CODE=$(echo "$BODY" | grep -oP 'HTTP_CODE:\K[0-9]+' | tail -1)
+          if [ -z "$HTTP_CODE" ]; then HTTP_CODE="000"; fi
+
+          echo "::group::Response"
+          echo "$BODY"
+          echo "::endgroup::"
+
+          echo "curl_exit=$CURL_EXIT" >> "$GITHUB_OUTPUT"
+          echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+
+          if [ "$CURL_EXIT" -ne 0 ] || [ "$HTTP_CODE" != "200" ]; then
+            echo "status=fail" >> "$GITHUB_OUTPUT"
+            echo "::warning::yawnbot health probe FAIL (curl_exit=$CURL_EXIT http_code=$HTTP_CODE)"
+          else
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Alert on failure
+        if: steps.probe.outputs.status == 'fail'
+        run: |
+          if [ -z "$ALERT_WEBHOOK" ]; then
+            echo "::warning::YAWNBOT_HEALTH_ALERT_WEBHOOK_URL secret 미설정 — alert skip (probe 는 fail 검출)"
+            exit 0
+          fi
+          TS=$(date -Iseconds)
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          PAYLOAD=$(jq -nc \
+            --arg url "$HEALTH_URL" \
+            --arg ts "$TS" \
+            --arg http "${{ steps.probe.outputs.http_code }}" \
+            --arg curl "${{ steps.probe.outputs.curl_exit }}" \
+            --arg run_url "$RUN_URL" \
+            '{
+              username: "Yawnbot Health Watcher",
+              embeds: [{
+                title: "yawnbot health check FAIL",
+                description: ("URL: " + $url + "\nHTTP code: " + $http + "\ncurl exit: " + $curl + "\ntime: " + $ts),
+                color: 15158332,
+                fields: [{ name: "Workflow run", value: $run_url, inline: false }]
+              }]
+            }')
+          curl -fsS -m 10 -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$ALERT_WEBHOOK"

--- a/.github/workflows/yawnbot-nssm-logs.yml
+++ b/.github/workflows/yawnbot-nssm-logs.yml
@@ -1,0 +1,112 @@
+name: Yawnbot NSSM Logs
+
+# TASK 2 (세션) — yawnbot prod 죽음 원인 파악.
+# self-hosted runner (karmo-laptop-yawnbot, deploy-discord-bots.yml 와 동일) 에서
+# nssm 서비스 상태 + AppExit 정책 + stdout/stderr tail 회수.
+# workflow_dispatch only — push 트리거 X (보안: ops workflow 는 명시 트리거만).
+
+on:
+  workflow_dispatch:
+    inputs:
+      tail_lines:
+        description: 'stdout/stderr tail line count'
+        required: false
+        default: '300'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: yawnbot-nssm-ops
+  cancel-in-progress: false
+
+jobs:
+  fetch:
+    runs-on: [self-hosted, windows, laptop, yawnbot]
+    timeout-minutes: 5
+
+    steps:
+      - name: Resolve nssm.exe path
+        id: nssm
+        shell: 'powershell -ExecutionPolicy Bypass -File {0}'
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # deploy-discord-bots.yml § "NSSM restart yawnbot-prod" 와 동일 fallback 패턴
+          $cmd = Get-Command nssm.exe -ErrorAction SilentlyContinue
+          $nssm = if ($cmd) { $cmd.Source } else { $null }
+          if (-not $nssm) {
+            $candidates = @(
+              "C:\Users\masca\AppData\Local\Microsoft\WinGet\Packages\NSSM.NSSM_*\nssm*\win64\nssm.exe",
+              "$env:LOCALAPPDATA\Microsoft\WinGet\Packages\NSSM.NSSM_*\nssm*\win64\nssm.exe",
+              "$env:ProgramData\Microsoft\WinGet\Packages\NSSM.NSSM_*\nssm*\win64\nssm.exe",
+              "C:\ProgramData\chocolatey\bin\nssm.exe"
+            )
+            foreach ($pat in $candidates) {
+              $found = Get-Item $pat -ErrorAction SilentlyContinue | Select-Object -First 1
+              if ($found) { $nssm = $found.FullName; break }
+            }
+          }
+          if (-not $nssm) { throw "nssm.exe 못 찾음" }
+          Write-Host "Using nssm: $nssm"
+          "nssm=$nssm" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Service + process status
+        shell: 'powershell -ExecutionPolicy Bypass -File {0}'
+        run: |
+          $ErrorActionPreference = 'Continue'
+          Write-Host "=== Get-Service yawnbot-prod ==="
+          Get-Service yawnbot-prod -ErrorAction SilentlyContinue | Format-List Status, StartType, DisplayName, ServiceName
+          Write-Host ""
+          Write-Host "=== Process check (node) ==="
+          Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.Name -like "*node*" } | Format-Table Id, Name, StartTime, Path -AutoSize
+
+      - name: NSSM detail
+        shell: 'powershell -ExecutionPolicy Bypass -File {0}'
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $nssm = '${{ steps.nssm.outputs.nssm }}'
+          Write-Host "=== nssm status ==="
+          & $nssm status yawnbot-prod
+          Write-Host ""
+          Write-Host "=== AppExit Default ==="
+          & $nssm get yawnbot-prod AppExit Default
+          Write-Host ""
+          Write-Host "=== AppRestartDelay ==="
+          & $nssm get yawnbot-prod AppRestartDelay
+          Write-Host ""
+          Write-Host "=== AppThrottle ==="
+          & $nssm get yawnbot-prod AppThrottle
+          Write-Host ""
+          Write-Host "=== AppStdout ==="
+          & $nssm get yawnbot-prod AppStdout
+          Write-Host ""
+          Write-Host "=== AppStderr ==="
+          & $nssm get yawnbot-prod AppStderr
+
+      - name: Stdout tail
+        shell: 'powershell -ExecutionPolicy Bypass -File {0}'
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $nssm = '${{ steps.nssm.outputs.nssm }}'
+          $tailLines = [int]'${{ inputs.tail_lines }}'
+          $stdoutPath = (& $nssm get yawnbot-prod AppStdout | Out-String).Trim()
+          if ($stdoutPath -and (Test-Path -LiteralPath $stdoutPath)) {
+            Write-Host "=== AppStdout last $tailLines lines: $stdoutPath ==="
+            Get-Content -LiteralPath $stdoutPath -Tail $tailLines
+          } else {
+            Write-Host "AppStdout path missing or empty: '$stdoutPath'"
+          }
+
+      - name: Stderr tail
+        shell: 'powershell -ExecutionPolicy Bypass -File {0}'
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $nssm = '${{ steps.nssm.outputs.nssm }}'
+          $tailLines = [int]'${{ inputs.tail_lines }}'
+          $stderrPath = (& $nssm get yawnbot-prod AppStderr | Out-String).Trim()
+          if ($stderrPath -and (Test-Path -LiteralPath $stderrPath)) {
+            Write-Host "=== AppStderr last $tailLines lines: $stderrPath ==="
+            Get-Content -LiteralPath $stderrPath -Tail $tailLines
+          } else {
+            Write-Host "AppStderr path missing or empty: '$stderrPath'"
+          }

--- a/.github/workflows/yawnbot-set-restart-policy.yml
+++ b/.github/workflows/yawnbot-set-restart-policy.yml
@@ -1,0 +1,84 @@
+name: Yawnbot NSSM Restart Policy
+
+# TASK 3 (세션) — NSSM AppExit Restart 정책 박기.
+# 봇 프로세스가 죽으면 NSSM 가 자동으로 재기동 (AppRestartDelay 후).
+# AppThrottle = 빠른 종료 (loop) 시 throttle — 무한 재시작 loop 방지.
+# self-hosted runner 에서 nssm set 즉시 적용 — service 재시작 필요 X.
+
+on:
+  workflow_dispatch:
+    inputs:
+      restart_delay_ms:
+        description: 'AppRestartDelay (ms) — exit 후 restart 까지 지연'
+        required: false
+        default: '5000'
+      throttle_ms:
+        description: 'AppThrottle (ms) — 이 시간 내 빠른 종료 시 loop 방지'
+        required: false
+        default: '1500'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: yawnbot-nssm-ops
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    runs-on: [self-hosted, windows, laptop, yawnbot]
+    timeout-minutes: 3
+
+    steps:
+      - name: Resolve nssm.exe path
+        id: nssm
+        shell: 'powershell -ExecutionPolicy Bypass -File {0}'
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $cmd = Get-Command nssm.exe -ErrorAction SilentlyContinue
+          $nssm = if ($cmd) { $cmd.Source } else { $null }
+          if (-not $nssm) {
+            $candidates = @(
+              "C:\Users\masca\AppData\Local\Microsoft\WinGet\Packages\NSSM.NSSM_*\nssm*\win64\nssm.exe",
+              "$env:LOCALAPPDATA\Microsoft\WinGet\Packages\NSSM.NSSM_*\nssm*\win64\nssm.exe",
+              "$env:ProgramData\Microsoft\WinGet\Packages\NSSM.NSSM_*\nssm*\win64\nssm.exe",
+              "C:\ProgramData\chocolatey\bin\nssm.exe"
+            )
+            foreach ($pat in $candidates) {
+              $found = Get-Item $pat -ErrorAction SilentlyContinue | Select-Object -First 1
+              if ($found) { $nssm = $found.FullName; break }
+            }
+          }
+          if (-not $nssm) { throw "nssm.exe 못 찾음" }
+          Write-Host "Using nssm: $nssm"
+          "nssm=$nssm" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Apply restart policy
+        shell: 'powershell -ExecutionPolicy Bypass -File {0}'
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $nssm = '${{ steps.nssm.outputs.nssm }}'
+          $delay = '${{ inputs.restart_delay_ms }}'
+          $throttle = '${{ inputs.throttle_ms }}'
+
+          Write-Host "=== Before ==="
+          & $nssm get yawnbot-prod AppExit Default
+          & $nssm get yawnbot-prod AppRestartDelay
+          & $nssm get yawnbot-prod AppThrottle
+
+          Write-Host ""
+          Write-Host "=== Applying ==="
+          & $nssm set yawnbot-prod AppExit Default Restart
+          if ($LASTEXITCODE -ne 0) { throw "AppExit Default Restart failed (exit $LASTEXITCODE)" }
+          & $nssm set yawnbot-prod AppRestartDelay $delay
+          if ($LASTEXITCODE -ne 0) { throw "AppRestartDelay $delay failed" }
+          & $nssm set yawnbot-prod AppThrottle $throttle
+          if ($LASTEXITCODE -ne 0) { throw "AppThrottle $throttle failed" }
+
+          Write-Host ""
+          Write-Host "=== After ==="
+          & $nssm get yawnbot-prod AppExit Default
+          & $nssm get yawnbot-prod AppRestartDelay
+          & $nssm get yawnbot-prod AppThrottle
+          Write-Host ""
+          Write-Host "NSSM restart policy applied. 다음 exit 부터 자동 재기동."


### PR DESCRIPTION
## 요약

yawnbot prod 죽음 사후 인프라 — 「예방 + 알림」 3 세트.

**배경**: 2026-05-13 deploy 후 prod 가 죽었는데 며칠 몰랐음. 「monitoring 주체 = monitoring 대상」 순환 의존 (yawnbot 이 자기 죽음을 알리려 했는데 yawnbot 이 죽음).

## 변경 파일

| Workflow | Runner | Trigger | 역할 |
|---|---|---|---|
| `yawnbot-health.yml` | github-hosted ubuntu | `*/5 * * * *` cron + manual | `/health` HTTP probe, fail 시 Discord webhook alert |
| `yawnbot-nssm-logs.yml` | self-hosted (karmo-laptop-yawnbot) | manual | service status + AppExit + stdout/stderr tail 회수 |
| `yawnbot-set-restart-policy.yml` | self-hosted | manual | NSSM `AppExit Restart` + `AppRestartDelay` + `AppThrottle` 박기 |

「monitoring 주체 ≠ monitoring 대상」 격리: watcher 는 github-hosted (prod 노트북 죽어도 살아있음), ops 는 self-hosted (prod 머신에서만 실행 가능).

## 머지 후 사용자 액션

1. **Discord webhook URL 생성** (★ 사용자 GUI):
   - `#yawnbot-health` 새 채널 (격리 추천) 또는 ops-report 채널
   - 채널 설정 → Integrations → Webhooks → New Webhook → URL 복사
2. **Secret 등록** (Claude 자율 가능, URL 받으면):
   ```
   gh secret set YAWNBOT_HEALTH_ALERT_WEBHOOK_URL --repo mascari4615/mascari4615.github.io
   ```
3. **workflow_dispatch trigger**:
   - `yawnbot-nssm-logs.yml` — yawnbot 죽음 원인 회수 (5/13 deploy 직후 stack trace)
   - `yawnbot-set-restart-policy.yml` — 자동 재시작 정책 박기
   - `yawnbot-health.yml` — alert 채널 작동 검증

## 관련

- 세션 TASK: 원인 파악 + 자동 재시작 + 외부 알림 ★ 3 세트
- Follow-up 시드 (memo): TASK-YB-020~024 (deep health / heartbeat / logging / metrics / hosting)
- 룰: `memo/rules/process.md` § 황금의 정신 — 설계 / 고안 시 자가 검토 (2026-05-15 추가, 본 사건 직후)

## Test plan

- [ ] verify (master invariant) CI pass — workflow 파일 추가는 verify scope 안 들어가서 무영향 예상
- [ ] typos check pass
- [ ] PR 머지 후 secret 등록
- [ ] workflow_dispatch 로 3개 다 trigger 검증 (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **운영**
  * Yawnbot 헬스 체크 자동화 추가 (5분 간격 엔드포인트 모니터링 및 실패 시 Discord 알림)
  * Yawnbot 서비스 상태 및 로그 조회 기능 추가
  * Yawnbot 서비스 재시작 정책 설정 기능 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/57)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->