### PR TITLE
perf(karmolab-tauri): KL-051 — Tauri 빌드/런타임/보안 최적화 묶음

### DIFF
--- a/apps/karmolab-tauri/package-lock.json
+++ b/apps/karmolab-tauri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karmolab-desktop",
-  "version": "0.1.0",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karmolab-desktop",
-      "version": "0.1.0",
+      "version": "0.1.19",
       "devDependencies": {
         "@tauri-apps/cli": "^2",
         "concurrently": "^9.1.2",

--- a/apps/karmolab-tauri/package.json
+++ b/apps/karmolab-tauri/package.json
@@ -7,7 +7,7 @@
     "tauri": "tauri",
     "dev": "concurrently -n static,tauri \"npm run dev:static\" \"npm run dev:tauri\"",
     "dev:static": "node ./scripts/dev-static.mjs 8898 --node-only",
-    "dev:tauri": "wait-on http-get://127.0.0.1:8898/apps/karmolab/ -t 120000 -i 250 && tauri dev",
+    "dev:tauri": "wait-on http-get://127.0.0.1:8898/apps/karmolab/ -t 30000 -i 250 && tauri dev --features dev-tools",
     "build": "tauri build --config src-tauri/tauri.release.conf.json",
     "audit:acl": "node scripts/audit-acl.mjs"
   },

--- a/apps/karmolab-tauri/src-tauri/Cargo.lock
+++ b/apps/karmolab-tauri/src-tauri/Cargo.lock
@@ -739,10 +739,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 

--- a/apps/karmolab-tauri/src-tauri/Cargo.toml
+++ b/apps/karmolab-tauri/src-tauri/Cargo.toml
@@ -9,6 +9,12 @@ edition = "2021"
 name = "karmolab_desktop_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[features]
+# default = release-safe (devtools off — production WebView2 우클릭 「Inspect」 노출 차단).
+# dev: `tauri dev --features dev-tools` (npm `dev:tauri` script 자동 적용).
+default = []
+dev-tools = ["tauri/devtools"]
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
@@ -18,7 +24,8 @@ notify-rust = "4"
 open = "5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri = { version = "2", features = ["tray-icon", "image-png", "devtools"] }
+# devtools = dev-only (KL-051: Cargo features 분기). production release 에 박지 X.
+tauri = { version = "2", features = ["tray-icon", "image-png"] }
 uuid = { version = "1", features = ["v4"] }
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
@@ -26,7 +33,8 @@ tauri-plugin-updater = "2"
 # TASK-LIFE-001-F (sub-F-1: capture + sub-F-2: OCR/분류/frontmatter + sub-F-3: hotkey)
 xcap = "0.0.13"
 image = "0.25"
-chrono = { version = "0.4", features = ["serde"] }
+# Win32 데스크톱 only — wasmbind / oldtime / iana-time-zone 불필요 (KL-051).
+chrono = { version = "0.4", default-features = false, features = ["serde", "clock", "std"] }
 rusty-tesseract = "1"
 # serde_yaml 은 deprecated → 활성 fork serde_yml 사용 (memory feedback_no_legacy.md).
 serde_yml = "0.0.12"
@@ -58,4 +66,14 @@ base64 = "0.22"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winuser", "processthreadsapi", "psapi", "handleapi", "minwindef", "sysinfoapi"] }
+
+# KL-051: production 배포 최적화. cargo 디폴트 (lto=false / codegen-units=16 / strip=false) 가
+# desktop 앱 배포에는 부적합 — fat LTO + 단일 codegen + strip + abort panic 으로 사이즈 + perf 동시 ↑.
+# `[profile.dev]` 미설정 = `tauri dev` 빌드 속도 그대로 (사용자 명시).
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = true
+panic = "abort"
+opt-level = 3
 

--- a/apps/karmolab-tauri/src-tauri/capabilities/default.json
+++ b/apps/karmolab-tauri/src-tauri/capabilities/default.json
@@ -6,8 +6,8 @@
   "remote": {
     "urls": [
       "https://mascari4615.github.io/*",
-      "http://localhost:*/*",
-      "http://127.0.0.1:*/*"
+      "http://127.0.0.1:8898/*",
+      "http://127.0.0.1:8899/*"
     ]
   },
   "permissions": [

--- a/apps/karmolab-tauri/src-tauri/permissions/localdev.toml
+++ b/apps/karmolab-tauri/src-tauri/permissions/localdev.toml
@@ -12,8 +12,6 @@ commands.allow = [
   "localdev_send_stdin",
   "localdev_follow_log",
   "localdev_stop_log_follow",
-  "localdev_npm_install",
   "localdev_npm_install_stream",
-  "localdev_deploy",
   "localdev_deploy_stream",
 ]

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -23,8 +23,8 @@ use quest_writeback::{
     toggle_quest_check,
 };
 use local_dev::{
-    localdev_deploy, localdev_deploy_stream, localdev_follow_log, localdev_get_repo_root,
-    localdev_list_external_pids, localdev_list_tracked, localdev_npm_install,
+    localdev_deploy_stream, localdev_follow_log, localdev_get_repo_root,
+    localdev_list_external_pids, localdev_list_tracked,
     localdev_npm_install_stream, localdev_send_stdin, localdev_set_repo_root, localdev_start,
     localdev_stop, localdev_stop_external, localdev_stop_log_follow, reattach_persisted_pids,
     LocalDevState,
@@ -868,9 +868,7 @@ pub fn run() {
             localdev_send_stdin,
             localdev_follow_log,
             localdev_stop_log_follow,
-            localdev_npm_install,
             localdev_npm_install_stream,
-            localdev_deploy,
             localdev_deploy_stream,
             repofile_open_default,
             repofile_reveal,

--- a/apps/karmolab-tauri/src-tauri/src/local_dev.rs
+++ b/apps/karmolab-tauri/src-tauri/src/local_dev.rs
@@ -325,77 +325,6 @@ fn spawn_detached_process(
     Ok((pid, stdin))
 }
 
-fn run_npm_install_blocking(cwd: &Path) -> Result<String, String> {
-    let mut cmd;
-    #[cfg(windows)]
-    {
-        let mut c = Command::new("cmd.exe");
-        c.arg("/C").arg("npm").arg("install");
-        cmd = c;
-    }
-    #[cfg(not(windows))]
-    {
-        cmd = Command::new("npm");
-        cmd.arg("install");
-    }
-    cmd.current_dir(cwd);
-    cmd.stdin(Stdio::null());
-    apply_no_window(&mut cmd);
-
-    let output = cmd.output().map_err(|e| format!("npm install 실행 실패: {}", e))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        return Err(format!(
-            "npm install 실패 (exit {})\n{}\n{}",
-            output.status,
-            stderr.trim(),
-            stdout.trim()
-        ));
-    }
-    Ok("npm install 완료".into())
-}
-
-fn run_npm_deploy_blocking(cwd: &Path, deploy_args: &[String]) -> Result<String, String> {
-    if deploy_args.is_empty() {
-        return Err("deploy_args가 비어 있습니다.".into());
-    }
-    if !args_are_safe(deploy_args) {
-        return Err("deploy 인자에 허용되지 않은 문자가 있습니다.".into());
-    }
-
-    let mut cmd;
-    #[cfg(windows)]
-    {
-        let mut c = Command::new("cmd.exe");
-        c.arg("/C").arg("npm").args(deploy_args);
-        cmd = c;
-    }
-    #[cfg(not(windows))]
-    {
-        cmd = Command::new("npm");
-        cmd.args(deploy_args);
-    }
-    cmd.current_dir(cwd);
-    cmd.stdin(Stdio::null());
-    apply_no_window(&mut cmd);
-
-    let output = cmd
-        .output()
-        .map_err(|e| format!("npm deploy 스크립트 실행 실패: {}", e))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        return Err(format!(
-            "deploy 실패 (exit {})\n{}\n{}",
-            output.status,
-            stderr.trim(),
-            stdout.trim()
-        ));
-    }
-    Ok("deploy 완료".into())
-}
-
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct LocaldevLogLineEvt {
@@ -1040,44 +969,6 @@ pub fn localdev_send_stdin(
         .flush()
         .map_err(|e| format!("stdin flush 실패: {}", e))?;
     Ok(())
-}
-
-#[tauri::command]
-pub fn localdev_npm_install(profile_id: String, state: State<'_, LocalDevState>) -> Result<String, String> {
-    let repo_str = {
-        let g = state.repo_root.lock().map_err(|e| e.to_string())?;
-        g.clone()
-            .ok_or_else(|| "저장소 루트를 먼저 설정하세요.".to_string())?
-    };
-    let repo = PathBuf::from(&repo_str);
-
-    let profiles = read_profiles(&repo)?;
-    let profile = profile_by_id(&profiles, &profile_id)?;
-    if !profile.npm_install {
-        return Err("이 프로필은 npm install이 비활성화되어 있습니다.".into());
-    }
-
-    let cwd = resolve_cwd(&repo, profile)?;
-    run_npm_install_blocking(&cwd)
-}
-
-#[tauri::command]
-pub fn localdev_deploy(profile_id: String, state: State<'_, LocalDevState>) -> Result<String, String> {
-    let repo_str = {
-        let g = state.repo_root.lock().map_err(|e| e.to_string())?;
-        g.clone()
-            .ok_or_else(|| "저장소 루트를 먼저 설정하세요.".to_string())?
-    };
-    let repo = PathBuf::from(&repo_str);
-
-    let profiles = read_profiles(&repo)?;
-    let profile = profile_by_id(&profiles, &profile_id)?;
-    let Some(ref da) = profile.deploy_args else {
-        return Err("이 프로필에 deploy가 설정되어 있지 않습니다.".into());
-    };
-
-    let cwd = resolve_cwd(&repo, profile)?;
-    run_npm_deploy_blocking(&cwd, da)
 }
 
 #[tauri::command]

--- a/apps/karmolab-tauri/src-tauri/tauri.release.conf.json
+++ b/apps/karmolab-tauri/src-tauri/tauri.release.conf.json
@@ -20,6 +20,11 @@
   },
   "bundle": {
     "createUpdaterArtifacts": true,
+    "targets": ["nsis"],
+    "windows": {
+      "webviewInstallMode": { "type": "skip" },
+      "nsis": { "compression": "lzma" }
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/apps/karmolab/js/widgets/docs/servermonitor-deploy-log-stream.md
+++ b/apps/karmolab/js/widgets/docs/servermonitor-deploy-log-stream.md
@@ -11,7 +11,6 @@
 | 항목 | 내용 |
 |------|------|
 | Rust 커맨드 | `localdev_deploy_stream`, `localdev_npm_install_stream` (`spawn_blocking` + 파이프) |
-| 블로킹 커맨드(유지) | `localdev_deploy`, `localdev_npm_install` — devtools·호환용 |
 | 이벤트 | `localdev-log` (줄), `localdev-log-done` (종료) |
 | WebView | `window.__TAURI__.event.listen` 등록 후 `invoke` (순서 고정) |
 | 권한 | `capabilities/default.json`에 `core:event:allow-listen` |
@@ -46,7 +45,7 @@
 ## 3. 구현과 블로킹 API
 
 - 스트리밍: 파이프 + **stdout/stderr 각각 별도 스레드**에서 `read_line` 후 `app.emit`.
-- 기존 `localdev_deploy` / `localdev_npm_install`은 `output()` 기반으로 그대로 두었다.
+- KL-051: 옛 sync 블로킹 버전 (`localdev_deploy` / `localdev_npm_install`) 은 frontend 호출 0 (dead) → 제거. 모든 호출 = `*_stream` 으로 통일.
 
 ## 4. UX (적용됨)
 

--- a/apps/karmolab/src/widgets/activity.ts
+++ b/apps/karmolab/src/widgets/activity.ts
@@ -946,6 +946,8 @@
           refreshTimer = null;
           return;
         }
+        // KL-051: 트레이 hide 시 IPC + JSON 직렬화 비용 0.
+        if (typeof document !== 'undefined' && document.hidden) return;
         if (isViewingCurrentPeriod()) load(true);
       }, REFRESH_INTERVAL_MS);
     }

--- a/apps/karmolab/src/widgets/quest-log/quest-log.ts
+++ b/apps/karmolab/src/widgets/quest-log/quest-log.ts
@@ -505,6 +505,8 @@
         if (overviewPollTimer != null) { window.clearInterval(overviewPollTimer); overviewPollTimer = null; }
         return;
       }
+      // KL-051: 트레이 hide 시 IPC + memo 6 도메인 walk 비용 0.
+      if (typeof document !== 'undefined' && document.hidden) return;
       void refreshOverview(overviewWrap);
     }, POLL_INTERVAL_OVERVIEW_MS);
   }


### PR DESCRIPTION
## Summary

KarmoLab Tauri 데스크톱 앱 「가능한 가볍게, 가능한 빠르게」 — 설정 정합 묶음.

audit 결과 13 발견 → 4 phase 재분류. 본 PR = **A + B + C2** (의미 정합 큰 묶음).

| 별 시드 | 면적 / 의존 |
|---|---|
| KL-052 — ML stack sidecar 별도 .exe | 큼 / 본 PR 후 |
| KL-053 — strict CSP | frontend 호환성 audit 선결 |
| KL-054 — frontend lazy load | 별 영역 |
| KL-055 — dep 업그레이드 통합 | KL-052 후 |

OCR / voice 「버튼 토글」 의도 = **이미 구현됨** (`life::voice::enable/disable` + tesseract 외부 .exe wrapper). RAM 측면 추가 작업 0.

## Phase A — 빌드/배포 설정 (`6b50b88b`)

- `Cargo.toml [profile.release]` 신설: `lto="fat"` / `codegen-units=1` / `strip=true` / `panic="abort"` / `opt-level=3`
- `tauri devtools` cargo feature 분기: `[features] dev-tools = ["tauri/devtools"]`. release 에서 off, `dev:tauri` 자동 활성
- `chrono default-features=false` (`serde / clock / std`만)
- `tauri.release.conf.json`: `targets: ["nsis"]` + `nsis.compression: "lzma"` + `webviewInstallMode: skip`
- `package.json dev:tauri` timeout 120s → 30s + `--features dev-tools`

`[profile.dev]` 미설정 = `tauri dev` 빌드 속도 그대로 (사용자 명시).

## Phase B — 런타임 정합 (`9549b65b`)

- `local_dev.rs` — sync 블로킹 커맨드 dead 제거 (`localdev_npm_install` / `localdev_deploy` + helper 2개)
  - frontend 호출 = `*_stream` 만 (servermonitor.ts 확인)
  - lib.rs use + invoke_handler + permissions/localdev.toml ACL 동시 정합
- `activity.ts` + `quest-log.ts` — `setInterval` 에 `document.hidden` 가드 (servermonitor 패턴 통일)
  - 트레이 hide 시 IPC + JSON 직렬화 + memo 6 도메인 walk 비용 0
- `servermonitor-deploy-log-stream.md` docs 정합

## Phase C2 — capability 좁히기 (`7884b39f`)

- `capabilities/default.json` localhost wildcard → `127.0.0.1:8898/*` + `127.0.0.1:8899/*` 명시
- 사용자 PC 다른 프로세스가 임의 포트 페이지 띄워 navigate 유도 시 invoke 호출 attack surface 제거

## Lockfile sync (`7cc78802`)

- `package-lock.json` version 0.1.0 → 0.1.19 (`package.json` 과 정합)
- 빌드 검증 중 npm install 으로 자동 동기화 — dep tree 변경 0, 메타데이터만

## 실측 효과 (master HEAD vs 본 PR, 동일 머신 clean build)

| 산출물 | master HEAD | 본 PR | 차이 |
|---|---|---|---|
| `karmolab-desktop.exe` | **27.22 MB** | **16.07 MB** | **−40.9%** (−11.15 MB) |
| NSIS installer | 6.07 MB | 4.60 MB | **−24.2%** (−1.47 MB) |
| MSI bundle | 9.26 MB | 빌드 안 됨 | 빌드 surface 제거 |
| 빌드 시간 (release) | 3m 04s | 7m 33s | +4m29s (LTO fat trade-off) |
| trayed idle IPC/sec | poll 4-5회 | 0 | hidden 가드 |
| dev 서버 wait timeout | 120s | 30s | dev:tauri |

`.exe` 효과 = LTO fat + codegen-units=1 + strip + panic=abort + devtools 제거 + chrono default-features=false 합. NSIS 효과 = LZMA solid 압축 + WebView2 bootstrapper skip + MSI surface 제거.

## Test plan

- [x] `cargo check` (worktree, CARGO_TARGET_DIR 공유) — exit 0
- [x] `npm run build` (apps/karmolab TS) — exit 0
- [x] `npm run verify` (master invariant 게이트) — backend:44 handler:44 perms:44 ACL 정합 ✓
- [x] KL-040 ACL 4-source audit 통과
- [x] CI verify (master invariant) — Draft 진행 중 통과 (재 verify 머지 직전 확인)
- [x] **release 빌드 실측** — `.exe` 16.07 MB / NSIS 4.60 MB / Tauri 산출물 정상 (signing key 단계만 skip)
- [ ] **사용자 시각 검증** — release 빌드 1회 실행 (트레이 hide/show, voice 토글, dashboard 응답성) — 머지 후 다음 release 사용 시점에 자연스럽게

## 정본

- `memo/projects/karmolab/tasks/TASK-KL-051-tauri-build-runtime-optimization.md` (본 PR 정본)
- 별 시드: KL-052 (ML sidecar) / KL-053 (CSP) / KL-054 (frontend lazy) / KL-055 (dep 업그레이드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
