### PR TITLE
ci(kl-057): pages-deploy trigger를 paths allow-list로 전환

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -4,10 +4,15 @@ on:
     branches:
       - main
       - master
-    paths-ignore:
-      - .gitignore
-      - README.md
-      - LICENSE
+    # allow-list: pages-deploy 가 실제 빌드 입력으로 쓰는 dir 만 트리거.
+    # 새 sub-app / root 파일 추가돼도 기본 미트리거 (default safe).
+    # 의존 누락 발견 시 본 목록 갱신 (TASK-KL-057).
+    paths:
+      - apps/blog/**
+      - apps/karmolab/**
+      - apps/karmolab-react-src/**
+      - packages/karmolab-ai/**
+      - .github/workflows/pages-deploy.yml
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## 변경 요약

`pages-deploy.yml` 의 trigger 를 `paths-ignore` (deny-list) 에서 `paths` (allow-list) 로 전환. pages-deploy 가 실제 빌드 입력으로 쓰는 dir 만 명시.

```yaml
paths:
  - apps/blog/**
  - apps/karmolab/**
  - apps/karmolab-react-src/**
  - packages/karmolab-ai/**
  - .github/workflows/pages-deploy.yml
```

## 관련 이슈

관련 이슈: TASK-KL-057 (`memo/projects/karmolab/tasks/TASK-KL-057-*.md`)

## 변경 유형

- [x] `chore` — 빌드, 의존성, CI 관련

## 영향 범위

- [x] CI/CD 워크플로 (`.github/workflows/`)

## 검증

워크플로 yaml 단일 파일 변경 — 빌드 동작 자체는 변경 X (trigger 조건만).

- [x] yaml 문법 — 기존 `on:.push:.paths-ignore:` 자리에 `paths:` 만 교체
- [ ] master 머지 후 검증 1 — sub-app 외 영역만 변경한 commit (예: `apps/karmolab-tauri/**` 또는 `memo/**`) → Actions 탭 `Build and Deploy` 미발동 확인
- [ ] master 머지 후 검증 2 — 블로그 영역 (`apps/blog/_posts/**` 등) 변경 commit → `Build and Deploy` 발동 + GitHub Pages 재배포 확인
- [ ] master 머지 후 검증 3 — `packages/karmolab-ai/**` 변경 commit → `Build and Deploy` 발동 확인 (karmolab workspace 의존)

## 근거 — 진짜 root

### `paths-ignore` (deny-list) 의 함정

기존 `paths-ignore` 가 3 항목 (`.gitignore` / `README.md` / `LICENSE`) 만 제외. 결과적으로 monorepo 의 모든 sub-app (`apps/karmolab-tauri` / `chat-overlay` / `karmo-web-extension` / `discord-bots`), `memo/`, `scripts/`, `tools/`, root 파일들 변경 시에도 Jekyll 빌드 트리거 → GitHub Pages 재배포.

deny-list 확장도 root 안 됨:
- 새 sub-app / 새 root 파일 추가될 때마다 갱신 (미래 부담 ↑)
- `apps/**` 로 박으면 `apps/blog` / `apps/karmolab` / `apps/karmolab-react-src` 까지 ignore (의도 X)
- sibling exclude (`apps/!(blog|karmolab|karmolab-react-src)/**`) 는 GitHub Actions paths-ignore 미지원

### `paths` (allow-list) 가 정합

pages-deploy 의 build steps 가 실제로 의존하는 dir 는 *고정 셋*. 그 셋만 trigger 에 박는 게 root.

- `apps/blog/**` — Jekyll source (`_posts/`, `_sass/`, `_javascript/`, `_config.yml`, `Gemfile`, `package.json`, scripts, rollup, purgecss)
- `apps/karmolab/**` — TypeScript build → site `/apps/karmolab/` cohost
- `apps/karmolab-react-src/**` — React/Vite build → site `/apps/karmolab-react-src/` cohost
- `packages/karmolab-ai/**` — `apps/karmolab/package.json` 이 `"karmolab-ai": "file:../../packages/karmolab-ai"` 로 workspace 의존
- `.github/workflows/pages-deploy.yml` — workflow 자체 변경 시 정합 검증

이외 *모두 무관* (별 배포 채널 / 무관 영역).

### 효과

- **default safe** — 새 sub-app (`apps/foo-new/`) 추가돼도 기본 미트리거. allow-list 갱신 안 하면 안 돔
- deny-list 의 「뭘 빼야 하나」 끝없는 추적 / 누락 위험 해소
- 「한 곳에 정의」 정신 — workflow trigger = 의존 paths 정의

### 별 사안

「master 직접 push 흐름 공식화」 (사용자 발화 「main 바로 푸시」) 는 *Jekyll trigger root 와 별개*. 별 시드 [[TASK-KL-058]] 로 분리.

## AI 사용 여부

- [x] AI 보조 — Claude Opus 4.7 (1M context). 의존성 추적 (apps/karmolab → packages/karmolab-ai workspace ref) 및 root 분석 보조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)