### PR TITLE
fix(yawnbot): /health 라우트 추가 — PR #57 후속 (봇 살아있는데 noise alert)

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
@@ -9,6 +9,15 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
   const app = express();
   app.use(express.json());
 
+  app.get('/health', (_req, res) => {
+    res.status(200).json({
+      ok: client.isReady(),
+      uptime_sec: Math.floor(process.uptime()),
+      ws_status: client.ws.status,
+      ready_at: client.readyAt?.toISOString() ?? null,
+    });
+  });
+
   app.post('/webhook/github', async (req, res) => {
     try {
       const event = req.headers['x-github-event'];


### PR DESCRIPTION
## 요약

PR #57 (yawnbot-health watcher) 머지 후 진단 결과:

| 사실 | 출처 |
|---|---|
| \`yawnbot-prod\` 서비스 **Running** | `Yawnbot NSSM Logs` workflow |
| node.exe PID 9304 alive 2026-05-13 23:25 KST ~ 현재 (~36시간) | Get-Process |
| \`/health\` 404 = Express default | Health Watcher curl |
| **yawnbot 코드에 \`/health\` 라우트 자체 없음** | webhook.ts grep |

→ **봇 죽음 X**. /health endpoint 가 한 번도 존재한 적 없어서 watcher cron `*/5` 가 매번 false alert. PR #57 머지 직후 Health Watcher 임시 disable (alert spam 방지).

## 변경

`src/bot/webhook.ts` `createGithubWebhookApp` 에 `GET /health` 1개 추가:

```ts
app.get('/health', (_req, res) => {
  res.status(200).json({
    ok: client.isReady(),
    uptime_sec: Math.floor(process.uptime()),
    ws_status: client.ws.status,
    ready_at: client.readyAt?.toISOString() ?? null,
  });
});
```

- `client.isReady()` — Discord gateway 실제 ready 인지 (process up 만 보지 X)
- `ws.status` — gateway 연결 상태 (READY=0 등)
- `process.uptime()` / `readyAt` — 가동 시각

## 「설계 자가 검토」 룰 (오늘 신설) 의 첫 자기 위반 케이스

`memo/rules/process.md § 황금의 정신 — 설계 / 고안 시 자가 검토` (2026-05-15 추가) 가 명시한 패턴:

> 새 해결안 / 워크플로우 / 인프라 / 시스템 고안 직후 → stop & self-review 1 사이클. 「이건 그냥 진행」 X.

PR #57 watcher 가 `/health` 존재 가정만 하고 yawnbot 코드 확인 안 함 → 36시간 동안 false alert 셋업. 본 PR 가 그 갭 메움.

## 머지 후 사용자 액션 (Claude 자율 가능)

1. PR 머지 → 자동 deploy (deploy-yawnbot workflow trigger)
2. yawnbot service nssm restart (또는 자동 deploy 안에서)
3. `gh workflow enable "Yawnbot Health Watcher"`
4. `gh workflow run "Yawnbot Health Watcher"` → 200 확인

## Test plan

- [ ] verify (master invariant) CI pass — webhook.ts 변경은 yawnbot package 내부, master invariant scope 밖이라 무영향 예상
- [ ] typos check pass
- [ ] 머지 후 deploy → /health 200 + JSON body 확인
- [ ] Health Watcher re-enable → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)