### PR TITLE
feat(karmolab-tauri): KL-052-A — ML sidecar 워크스페이스 분리 + IPC 스켈레톤 + 프로토콜 명세

### DIFF
--- a/apps/karmolab-tauri/.gitignore
+++ b/apps/karmolab-tauri/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Cargo workspace build output (KL-052: 워크스페이스 단일 target — 메인 + ML sidecar 공유)
+/target
+
 # Tauri updater — private key must never be committed (pubkey lives in tauri.conf.json)
 src-tauri/karmolab-updater.key
 src-tauri/karmolab-updater.key.pub

--- a/apps/karmolab-tauri/Cargo.lock
+++ b/apps/karmolab-tauri/Cargo.lock
@@ -2885,6 +2885,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "karmolab-ml-sidecar"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/apps/karmolab-tauri/Cargo.lock
+++ b/apps/karmolab-tauri/Cargo.lock
@@ -2888,8 +2888,15 @@ dependencies = [
 name = "karmolab-ml-sidecar"
 version = "0.1.0"
 dependencies = [
- "serde",
+ "karmolab-shared",
  "serde_json",
+]
+
+[[package]]
+name = "karmolab-shared"
+version = "0.1.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/apps/karmolab-tauri/Cargo.toml
+++ b/apps/karmolab-tauri/Cargo.toml
@@ -1,14 +1,20 @@
 # Cargo 워크스페이스 — KL-052: ML stack sidecar 분리.
 #
 # 메인 (`src-tauri` = karmolab-desktop, Tauri+UI+IPC) 와 ML sidecar
-# (`src-tauri-ml` = karmolab-ml-sidecar, Whisper/xcap/tesseract) 를 한
-# 워크스페이스로 묶는다. 단일 lockfile + 공유 dep 버전 해석.
+# (`src-tauri-ml` = karmolab-ml-sidecar, Whisper/xcap/tesseract), 그리고
+# IPC 프로토콜 계약 (`src-tauri-shared` = karmolab-shared, serde 타입만) 을
+# 한 워크스페이스로 묶는다. 단일 lockfile + 공유 dep 버전 해석.
+#
+# src-tauri-shared = 메인 ↔ sidecar 프로토콜 단일 정의. 양쪽 path dep →
+# 스키마 drift 0 컴파일타임 강제 (2멤버 구조의 복제-drift / ML-dep 재링크 /
+# include-hack 회피 — KL-052 redirect). serde 만 의존이라 메인이 참조해도
+# ML stack 안 딸려옴 (사이즈 목적 정합).
 #
 # verify.mjs 의 `cargo check --all-targets` 는 cwd=`src-tauri` 에서 호출 →
 # 멤버(현재 패키지) scope 만 체크. sidecar 의 무거운 ML dep 은 `--workspace`
 # 가 아니므로 게이트에서 빌드 X — master-invariant 게이트 속도/그린 유지.
 [workspace]
-members = ["src-tauri", "src-tauri-ml"]
+members = ["src-tauri", "src-tauri-ml", "src-tauri-shared"]
 resolver = "2"
 
 # 워크스페이스에서 [profile.*] 는 *워크스페이스 루트에만* 유효하다.

--- a/apps/karmolab-tauri/Cargo.toml
+++ b/apps/karmolab-tauri/Cargo.toml
@@ -1,0 +1,23 @@
+# Cargo 워크스페이스 — KL-052: ML stack sidecar 분리.
+#
+# 메인 (`src-tauri` = karmolab-desktop, Tauri+UI+IPC) 와 ML sidecar
+# (`src-tauri-ml` = karmolab-ml-sidecar, Whisper/xcap/tesseract) 를 한
+# 워크스페이스로 묶는다. 단일 lockfile + 공유 dep 버전 해석.
+#
+# verify.mjs 의 `cargo check --all-targets` 는 cwd=`src-tauri` 에서 호출 →
+# 멤버(현재 패키지) scope 만 체크. sidecar 의 무거운 ML dep 은 `--workspace`
+# 가 아니므로 게이트에서 빌드 X — master-invariant 게이트 속도/그린 유지.
+[workspace]
+members = ["src-tauri", "src-tauri-ml"]
+resolver = "2"
+
+# 워크스페이스에서 [profile.*] 는 *워크스페이스 루트에만* 유효하다.
+# 멤버 Cargo.toml 의 [profile.*] 는 cargo 가 warn + 무시 → KL-051 의
+# release 최적화(fat LTO / strip / panic=abort)가 조용히 사라지는 회귀가
+# 된다. 그래서 src-tauri/Cargo.toml 에서 이리로 *이관*. (KL-051 정합 유지)
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = true
+panic = "abort"
+opt-level = 3

--- a/apps/karmolab-tauri/src-tauri-ml/Cargo.toml
+++ b/apps/karmolab-tauri/src-tauri-ml/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "karmolab-ml-sidecar"
+version = "0.1.0"
+description = "KarmoLab ML stack sidecar — voice(Whisper) / capture(xcap) / OCR(tesseract). 메인 바이너리에서 분리 (KL-052)."
+authors = ["mascari4615"]
+edition = "2021"
+
+# Tauri externalBin: ["bin/karmolab-life-ml"] (KL-052-D 통합 시 이 바이너리명 사용).
+[[bin]]
+name = "karmolab-life-ml"
+path = "src/main.rs"
+
+[dependencies]
+# KL-052-A 스켈레톤 = IPC 골격만. candle/tokenizers/cpal/hound/xcap/image/
+# rusty-tesseract 등 ML dep 은 각 모듈 마이그 시점에 추가:
+#   - KL-052-B: voice (candle/tokenizers/cpal/hound)
+#   - KL-052-C: capture (xcap/image) + ocr (rusty-tesseract)
+# 스켈레톤 단계에서 무거운 dep 미리 박지 X — -A cargo check 경량 유지.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/apps/karmolab-tauri/src-tauri-ml/Cargo.toml
+++ b/apps/karmolab-tauri/src-tauri-ml/Cargo.toml
@@ -11,10 +11,11 @@ name = "karmolab-life-ml"
 path = "src/main.rs"
 
 [dependencies]
+# IPC 프로토콜 = 워크스페이스 공유 crate (메인과 단일 정의 공유, drift 0).
+karmolab-shared = { path = "../src-tauri-shared" }
 # KL-052-A 스켈레톤 = IPC 골격만. candle/tokenizers/cpal/hound/xcap/image/
 # rusty-tesseract 등 ML dep 은 각 모듈 마이그 시점에 추가:
 #   - KL-052-B: voice (candle/tokenizers/cpal/hound)
 #   - KL-052-C: capture (xcap/image) + ocr (rusty-tesseract)
 # 스켈레톤 단계에서 무거운 dep 미리 박지 X — -A cargo check 경량 유지.
-serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/karmolab-tauri/src-tauri-ml/PROTOCOL.md
+++ b/apps/karmolab-tauri/src-tauri-ml/PROTOCOL.md
@@ -1,0 +1,92 @@
+# KarmoLab ML Sidecar — IPC 프로토콜 명세 (KL-052)
+
+> 정본. `src/protocol.rs` 의 `SidecarCommand` / `SidecarEvent` 가 본 명세의 직렬화 구현.
+> 본 문서는 TASK-KL-052 의 「IPC 프로토콜 명세」 산출물 (KL-052-A).
+
+## 1. 목적
+
+메인 KarmoLab (`src-tauri` = `karmolab-desktop`, Tauri+UI+IPC) 에서 ML stack
+(Whisper 음성 / xcap 캡처 / tesseract OCR) 을 **별도 sidecar `.exe`** 로 분리.
+메인 바이너리 = UI/IPC 만 (15.8MB → ~7–9MB 목표). ML 작업 = sidecar spawn/통신/kill.
+
+## 2. 전송 (transport)
+
+**stdin/stdout JSON line.** 메인이 sidecar(`karmolab-life-ml`) 를 자식 프로세스로
+spawn 하고 stdin/stdout 파이프로 통신.
+
+- 메인 → sidecar : sidecar stdin 에 **한 줄 = 한 명령 JSON** + `\n`.
+- sidecar → 메인 : sidecar stdout 에 **한 줄 = 한 이벤트 JSON** + `\n`.
+- stderr : 사람이 읽는 로그 전용 (프로토콜 X). 메인은 stderr 를 로그로 수집만.
+- 인코딩 : UTF-8. 빈 줄 = 무시.
+
+### 왜 stdin/stdout JSON line (결정 #2)
+
+- 가장 단순 — 소켓 lifecycle(bind/accept/cleanup) / named pipe OS 분기 불필요.
+- 자식 프로세스 죽으면 파이프 EOF 로 자연 감지.
+- 테스트 용이 — `echo '{"cmd":"..."}' | karmolab-life-ml` 로 단독 검증.
+- TASK-KL-052 본문 sketch 와 일치 (line 65 "가장 단순").
+- `tauri-plugin-shell` 의 Sidecar API 도 내부적으로 stdin/stdout — 동일 모델 위에
+  Tauri 통합(KL-052-D)에서 그 API 를 채택할지 결정 (프로토콜 자체는 불변).
+
+## 3. 메시지
+
+### 3.1 메인 → sidecar : `SidecarCommand` (`cmd` 태그)
+
+| `cmd` | 추가 필드 | 의미 |
+|---|---|---|
+| `voice_load` | — | Whisper 모델 메모리 로드 |
+| `voice_transcribe` | `wav`: string (16kHz mono PCM_16 .wav 경로) | 음성 → 텍스트 |
+| `voice_unload` | — | Whisper 모델 언로드 (RAM 회수) |
+| `capture` | — | 화면 캡처 → PNG 파일 경로 |
+| `ocr` | `image`: string (이미지 경로) | 이미지 → 텍스트 |
+| `shutdown` | — | graceful 종료 (메인이 kill 전에 송신) |
+
+예: `{"cmd":"voice_transcribe","wav":"C:\\...\\rec.wav"}`
+
+### 3.2 sidecar → 메인 : `SidecarEvent` (`event` 태그)
+
+| `event` | 추가 필드 | 의미 |
+|---|---|---|
+| `ready` | `protocol_version`: u32 | 부팅 완료. 메인이 버전 호환성 확인 |
+| `loaded` | — | `voice_load` 완료 |
+| `unloaded` | — | `voice_unload` 완료 |
+| `result` | `text`: string | transcribe / ocr 결과 |
+| `captured` | `path`: string | 캡처 PNG 경로 |
+| `error` | `msg`: string | 명령 실패 (sidecar 는 계속 살아있음) |
+
+예: `{"event":"result","text":"안녕하세요"}`
+
+### 3.3 견고성
+
+- 명령 1개 → 응답 이벤트 1개 (요청-응답). `ready` 만 부팅 시 unsolicited.
+- 파싱 실패 / 처리 실패 = `error` 이벤트 후 **sidecar 계속 생존** (다음 명령 처리).
+  메인은 `error` 를 받아도 파이프 유지 — sidecar respawn 불필요.
+- 치명 상황(stdin EOF, write 실패) = sidecar 정상 종료. 메인은 프로세스 exit 감지.
+
+### 3.4 버전 협상
+
+`PROTOCOL_VERSION` (현재 `1`). breaking change 시 bump. 메인은 첫 `ready` 의
+`protocol_version` 이 자신이 아는 범위 밖이면 사용자에게 업데이트 안내.
+
+## 4. KL-052 결정 사항 (TASK-KL-052 § "결정 필요 항목" 자율 결정 — 코드/패턴 한정)
+
+| # | 항목 | 결정 | 근거 |
+|---|---|---|---|
+| 1 | 워크스페이스 구조 | `apps/karmolab-tauri/Cargo.toml` 단일 `[workspace]`, members = `src-tauri` + `src-tauri-ml` | 단일 lockfile + 공유 dep 해석. verify `cargo check`(cwd=src-tauri) 는 멤버 scope → 게이트 그린/속도 유지. `[profile.release]` 는 워크스페이스 루트로 이관(멤버 profile cargo 무시 회귀 방지) |
+| 2 | IPC 모델 | stdin/stdout JSON line | § 2 근거 |
+| 3 | 모델 파일(~3.1GB Whisper safetensors) 위치 | **KL-052-B 에서 확정** (voice 이관 시 현 다운로드 경로 파악 후). 스켈레톤 단계 영향 X | 현재 코드(`life/voice`)의 실제 경로 확인 전 결정 = 추측. -B 에서 자연 결정 |
+| 4 | 다운로드-on-demand vs 항상 패키징 | **default = 항상 패키징** (NSIS externalBin). KL-052-E 에서 사이즈 측정 후 재평가 | 첫 사용 latency 0 + 서명/보안 단순. 사이즈 부담이 실측에서 크면 -E 에서 on-demand 전환 검토 |
+
+## 5. 단계 (TASK-KL-052 § 작업 단계)
+
+- **KL-052-A** ✅ 워크스페이스 분리 + sidecar skeleton + 본 프로토콜 명세
+- KL-052-B : voice (capture+transcribe) sidecar 이관 + 메인 IPC client
+- KL-052-C : OCR(tesseract) + capture(xcap) sidecar 이관
+- KL-052-D : Tauri `externalBin` 통합 + ACL audit (`shell:allow-execute` sidecar 항목)
+- KL-052-E : NSIS installer 통합 + 메인 바이너리 사이즈 before/after 측정 + 회귀 검증
+
+## 6. 미해결 (후속에서 결정)
+
+- keep-alive 정책 : OCR/캡처마다 spawn/kill vs 1 process 상주 (KL-052-C 에서 사용 패턴 보고 결정)
+- 모델 파일 위치 (#3, KL-052-B)
+- 다운로드 정책 최종 (#4, KL-052-E 사이즈 실측 후)

--- a/apps/karmolab-tauri/src-tauri-ml/PROTOCOL.md
+++ b/apps/karmolab-tauri/src-tauri-ml/PROTOCOL.md
@@ -1,6 +1,8 @@
 # KarmoLab ML Sidecar — IPC 프로토콜 명세 (KL-052)
 
-> 정본. `src/protocol.rs` 의 `SidecarCommand` / `SidecarEvent` 가 본 명세의 직렬화 구현.
+> 정본. `src-tauri-shared` crate (`karmolab_shared`) 의 `SidecarCommand` /
+> `SidecarEvent` 가 본 명세의 직렬화 구현 — 메인 + sidecar 가 path dep 으로
+> 공유 (스키마 단일 정의, drift 0 컴파일타임 강제).
 > 본 문서는 TASK-KL-052 의 「IPC 프로토콜 명세」 산출물 (KL-052-A).
 
 ## 1. 목적
@@ -72,7 +74,7 @@ spawn 하고 stdin/stdout 파이프로 통신.
 
 | # | 항목 | 결정 | 근거 |
 |---|---|---|---|
-| 1 | 워크스페이스 구조 | `apps/karmolab-tauri/Cargo.toml` 단일 `[workspace]`, members = `src-tauri` + `src-tauri-ml` | 단일 lockfile + 공유 dep 해석. verify `cargo check`(cwd=src-tauri) 는 멤버 scope → 게이트 그린/속도 유지. `[profile.release]` 는 워크스페이스 루트로 이관(멤버 profile cargo 무시 회귀 방지) |
+| 1 | 워크스페이스 구조 | `apps/karmolab-tauri/Cargo.toml` 단일 `[workspace]`, members = `src-tauri` + `src-tauri-ml` + **`src-tauri-shared`** (3멤버) | 단일 lockfile + 공유 dep 해석. verify `cargo check`(cwd=src-tauri) 는 멤버 scope → 게이트 그린/속도 유지. `[profile.release]` 는 워크스페이스 루트로 이관(멤버 profile cargo 무시 회귀 방지). **`src-tauri-shared`** = IPC 프로토콜 단일 정의 (serde만 의존) — 메인↔sidecar path dep 공유로 KL-052-B 의 스키마 복제-drift / ML-dep 재링크 / include-hack 회피 (사용자 redirect, 2026-05-15) |
 | 2 | IPC 모델 | stdin/stdout JSON line | § 2 근거 |
 | 3 | 모델 파일(~3.1GB Whisper safetensors) 위치 | **KL-052-B 에서 확정** (voice 이관 시 현 다운로드 경로 파악 후). 스켈레톤 단계 영향 X | 현재 코드(`life/voice`)의 실제 경로 확인 전 결정 = 추측. -B 에서 자연 결정 |
 | 4 | 다운로드-on-demand vs 항상 패키징 | **default = 항상 패키징** (NSIS externalBin). KL-052-E 에서 사이즈 측정 후 재평가 | 첫 사용 latency 0 + 서명/보안 단순. 사이즈 부담이 실측에서 크면 -E 에서 on-demand 전환 검토 |

--- a/apps/karmolab-tauri/src-tauri-ml/src/capture.rs
+++ b/apps/karmolab-tauri/src-tauri-ml/src/capture.rs
@@ -1,0 +1,9 @@
+//! 화면 캡처(xcap + image PNG encode). KL-052-C 에서
+//! `src-tauri/src/life/screen.rs` 를 이리로 이관 — 현재 = 스텁.
+
+use crate::protocol::SidecarEvent;
+
+pub fn capture() -> SidecarEvent
+{
+    SidecarEvent::Error { msg: "capture::capture 미구현 (KL-052-C 에서 xcap 이관)".to_string() }
+}

--- a/apps/karmolab-tauri/src-tauri-ml/src/capture.rs
+++ b/apps/karmolab-tauri/src-tauri-ml/src/capture.rs
@@ -1,7 +1,7 @@
 //! 화면 캡처(xcap + image PNG encode). KL-052-C 에서
 //! `src-tauri/src/life/screen.rs` 를 이리로 이관 — 현재 = 스텁.
 
-use crate::protocol::SidecarEvent;
+use karmolab_shared::SidecarEvent;
 
 pub fn capture() -> SidecarEvent
 {

--- a/apps/karmolab-tauri/src-tauri-ml/src/main.rs
+++ b/apps/karmolab-tauri/src-tauri-ml/src/main.rs
@@ -10,12 +10,11 @@
 
 mod capture;
 mod ocr;
-mod protocol;
 mod voice;
 
 use std::io::{self, BufRead, Write};
 
-use protocol::{SidecarCommand, SidecarEvent, PROTOCOL_VERSION};
+use karmolab_shared::{SidecarCommand, SidecarEvent, PROTOCOL_VERSION};
 
 fn main()
 {

--- a/apps/karmolab-tauri/src-tauri-ml/src/main.rs
+++ b/apps/karmolab-tauri/src-tauri-ml/src/main.rs
@@ -1,0 +1,102 @@
+//! KarmoLab ML sidecar (KL-052) — stdin/stdout JSON line 프로토콜 entrypoint.
+//!
+//! 메인 KarmoLab(Tauri) 가 이 바이너리를 spawn. stdin 한 줄 = 한
+//! [`SidecarCommand`], stdout 한 줄 = 한 [`SidecarEvent`].
+//!
+//! 본 파일 = dispatch 골격(KL-052-A). 실제 ML 작업은 후속에서 각 모듈에:
+//!   - voice (Whisper transcribe)  → KL-052-B (`src-tauri/src/life/voice/*` 이관)
+//!   - capture (xcap+image)        → KL-052-C (`src-tauri/src/life/screen.rs` 이관)
+//!   - ocr (rusty-tesseract)       → KL-052-C (`src-tauri/src/life/ocr.rs` 이관)
+
+mod capture;
+mod ocr;
+mod protocol;
+mod voice;
+
+use std::io::{self, BufRead, Write};
+
+use protocol::{SidecarCommand, SidecarEvent, PROTOCOL_VERSION};
+
+fn main()
+{
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+
+    // 부팅 즉시 Ready — 메인이 protocol_version 으로 호환성 확인.
+    emit(&mut out, &SidecarEvent::Ready { protocol_version: PROTOCOL_VERSION });
+
+    let stdin = io::stdin();
+    for line in stdin.lock().lines()
+    {
+        let line = match line
+        {
+            Ok(line) => line,
+            Err(error) =>
+            {
+                emit(&mut out, &SidecarEvent::Error { msg: format!("stdin read 실패: {}", error) });
+                break;
+            }
+        };
+
+        let trimmed = line.trim();
+        if trimmed.is_empty()
+        {
+            continue;
+        }
+
+        let command = match serde_json::from_str::<SidecarCommand>(trimmed)
+        {
+            Ok(command) => command,
+            Err(error) =>
+            {
+                emit(&mut out, &SidecarEvent::Error { msg: format!("command 파싱 실패: {}", error) });
+                continue;
+            }
+        };
+
+        if matches!(command, SidecarCommand::Shutdown)
+        {
+            break;
+        }
+
+        let event = dispatch(command);
+        emit(&mut out, &event);
+    }
+}
+
+/// 한 명령 → 한 응답 이벤트. KL-052-A 단계 = 각 모듈 스텁(미구현 Error).
+fn dispatch(command: SidecarCommand) -> SidecarEvent
+{
+    match command
+    {
+        SidecarCommand::VoiceLoad => voice::load(),
+        SidecarCommand::VoiceTranscribe { wav } => voice::transcribe(&wav),
+        SidecarCommand::VoiceUnload => voice::unload(),
+        SidecarCommand::Capture => capture::capture(),
+        SidecarCommand::Ocr { image } => ocr::run(&image),
+        // Shutdown 은 main 루프에서 이미 break 처리 — 여기 도달 X.
+        SidecarCommand::Shutdown => SidecarEvent::Error
+        {
+            msg: "Shutdown 은 dispatch 대상 아님 (main 루프에서 처리)".to_string(),
+        },
+    }
+}
+
+/// 이벤트 한 개를 JSON line 으로 flush. 직렬화 실패해도 sidecar 죽이지 X
+/// (메인이 다음 명령 계속 보낼 수 있게 — 프로토콜 § 견고성).
+fn emit<W: Write>(out: &mut W, event: &SidecarEvent)
+{
+    match serde_json::to_string(event)
+    {
+        Ok(json) =>
+        {
+            let _ = writeln!(out, "{}", json);
+            let _ = out.flush();
+        }
+        Err(error) =>
+        {
+            let _ = writeln!(out, "{{\"event\":\"error\",\"msg\":\"이벤트 직렬화 실패: {}\"}}", error);
+            let _ = out.flush();
+        }
+    }
+}

--- a/apps/karmolab-tauri/src-tauri-ml/src/ocr.rs
+++ b/apps/karmolab-tauri/src-tauri-ml/src/ocr.rs
@@ -1,7 +1,7 @@
 //! OCR(rusty-tesseract — 외부 tesseract.exe wrapper). KL-052-C 에서
 //! `src-tauri/src/life/ocr.rs` 를 이리로 이관 — 현재 = 스텁.
 
-use crate::protocol::SidecarEvent;
+use karmolab_shared::SidecarEvent;
 
 pub fn run(_image: &str) -> SidecarEvent
 {

--- a/apps/karmolab-tauri/src-tauri-ml/src/ocr.rs
+++ b/apps/karmolab-tauri/src-tauri-ml/src/ocr.rs
@@ -1,0 +1,9 @@
+//! OCR(rusty-tesseract — 외부 tesseract.exe wrapper). KL-052-C 에서
+//! `src-tauri/src/life/ocr.rs` 를 이리로 이관 — 현재 = 스텁.
+
+use crate::protocol::SidecarEvent;
+
+pub fn run(_image: &str) -> SidecarEvent
+{
+    SidecarEvent::Error { msg: "ocr::run 미구현 (KL-052-C 에서 rusty-tesseract 이관)".to_string() }
+}

--- a/apps/karmolab-tauri/src-tauri-ml/src/protocol.rs
+++ b/apps/karmolab-tauri/src-tauri-ml/src/protocol.rs
@@ -1,0 +1,69 @@
+//! KL-052 sidecar IPC 프로토콜 — stdin/stdout JSON line.
+//!
+//! 메인(karmolab-desktop) → sidecar : 한 줄 = 한 [`SidecarCommand`] JSON.
+//! sidecar → 메인 : 한 줄 = 한 [`SidecarEvent`] JSON.
+//!
+//! 정본 명세(다운로드 정책 / keep-alive / 모델 파일 위치 결정 포함) =
+//! `src-tauri-ml/PROTOCOL.md`. 본 모듈 = 그 명세의 직렬화 타입만.
+
+use serde::{Deserialize, Serialize};
+
+/// 메인 → sidecar. `cmd` 태그로 분기 (`{"cmd":"voice_load"}`).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "cmd", rename_all = "snake_case")]
+pub enum SidecarCommand
+{
+    /// Whisper 모델 메모리 로드.
+    VoiceLoad,
+    /// 16kHz mono PCM_16 .wav 파일 경로를 transcribe.
+    VoiceTranscribe
+    {
+        wav: String,
+    },
+    /// Whisper 모델 언로드 (RAM 회수 — life::voice::disable 정합).
+    VoiceUnload,
+    /// 화면 캡처 → PNG 파일 경로 반환.
+    Capture,
+    /// 이미지 파일 OCR.
+    Ocr
+    {
+        image: String,
+    },
+    /// graceful 종료 — 메인이 sidecar kill 전에 보냄.
+    Shutdown,
+}
+
+/// sidecar → 메인. `event` 태그로 분기 (`{"event":"ready",...}`).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum SidecarEvent
+{
+    /// sidecar 부팅 완료 + 프로토콜 버전 (메인이 호환성 확인).
+    Ready
+    {
+        protocol_version: u32,
+    },
+    /// VoiceLoad 완료.
+    Loaded,
+    /// VoiceUnload 완료.
+    Unloaded,
+    /// transcribe / ocr 결과 텍스트.
+    Result
+    {
+        text: String,
+    },
+    /// 캡처 결과 PNG 경로.
+    Captured
+    {
+        path: String,
+    },
+    /// 명령 처리 실패 (치명 X — sidecar 살아있고 다음 명령 계속).
+    Error
+    {
+        msg: String,
+    },
+}
+
+/// 프로토콜 버전 — breaking change 시 bump. 메인이 `Ready.protocol_version`
+/// 으로 호환성 확인 (불일치 = 사용자 update 안내).
+pub const PROTOCOL_VERSION: u32 = 1;

--- a/apps/karmolab-tauri/src-tauri-ml/src/voice.rs
+++ b/apps/karmolab-tauri/src-tauri-ml/src/voice.rs
@@ -4,7 +4,7 @@
 //! 이관 시 `life::voice::enable/disable` 의 RAM 토글(KL-051)은 sidecar
 //! 의 VoiceLoad/VoiceUnload + sidecar process 수명으로 대체된다.
 
-use crate::protocol::SidecarEvent;
+use karmolab_shared::SidecarEvent;
 
 pub fn load() -> SidecarEvent
 {

--- a/apps/karmolab-tauri/src-tauri-ml/src/voice.rs
+++ b/apps/karmolab-tauri/src-tauri-ml/src/voice.rs
@@ -1,0 +1,22 @@
+//! Whisper 음성 transcribe. KL-052-B 에서 `src-tauri/src/life/voice/*`
+//! (candle/tokenizers/cpal/hound) 를 이리로 이관 — 현재 = 스텁.
+//!
+//! 이관 시 `life::voice::enable/disable` 의 RAM 토글(KL-051)은 sidecar
+//! 의 VoiceLoad/VoiceUnload + sidecar process 수명으로 대체된다.
+
+use crate::protocol::SidecarEvent;
+
+pub fn load() -> SidecarEvent
+{
+    SidecarEvent::Error { msg: "voice::load 미구현 (KL-052-B 에서 candle Whisper 이관)".to_string() }
+}
+
+pub fn transcribe(_wav: &str) -> SidecarEvent
+{
+    SidecarEvent::Error { msg: "voice::transcribe 미구현 (KL-052-B)".to_string() }
+}
+
+pub fn unload() -> SidecarEvent
+{
+    SidecarEvent::Error { msg: "voice::unload 미구현 (KL-052-B)".to_string() }
+}

--- a/apps/karmolab-tauri/src-tauri-shared/Cargo.toml
+++ b/apps/karmolab-tauri/src-tauri-shared/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "karmolab-shared"
+version = "0.1.0"
+description = "KarmoLab 메인(karmolab-desktop) ↔ ML sidecar(karmolab-ml-sidecar) IPC 프로토콜 계약 (KL-052). 양쪽이 path dep 으로 참조 — 스키마 단일 정의, 컴파일타임 정합 강제."
+authors = ["mascari4615"]
+edition = "2021"
+
+[lib]
+name = "karmolab_shared"
+path = "src/lib.rs"
+
+[dependencies]
+# 프로토콜 직렬화만 — ML dep(candle/cpal/...) 없음. 메인이 본 crate 를
+# 참조해도 ML stack 이 메인 바이너리에 링크되지 X (KL-052 사이즈 목적 정합).
+serde = { version = "1", features = ["derive"] }

--- a/apps/karmolab-tauri/src-tauri-shared/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri-shared/src/lib.rs
@@ -1,10 +1,14 @@
-//! KL-052 sidecar IPC 프로토콜 — stdin/stdout JSON line.
+//! KL-052 메인 ↔ ML sidecar IPC 프로토콜 계약 — stdin/stdout JSON line.
 //!
 //! 메인(karmolab-desktop) → sidecar : 한 줄 = 한 [`SidecarCommand`] JSON.
 //! sidecar → 메인 : 한 줄 = 한 [`SidecarEvent`] JSON.
 //!
+//! **본 crate 가 프로토콜 단일 정의.** 메인 + sidecar 양쪽이 path dep 으로
+//! 참조 → enum 변경 시 양쪽 동시 컴파일 에러로 스키마 drift 0 강제
+//! (2멤버 구조의 복제-drift / ml-dep-재링크 / include-hack 회피, KL-052 redirect).
+//!
 //! 정본 명세(다운로드 정책 / keep-alive / 모델 파일 위치 결정 포함) =
-//! `src-tauri-ml/PROTOCOL.md`. 본 모듈 = 그 명세의 직렬화 타입만.
+//! `src-tauri-ml/PROTOCOL.md`. 본 crate = 그 명세의 직렬화 타입만.
 
 use serde::{Deserialize, Serialize};
 

--- a/apps/karmolab-tauri/src-tauri/Cargo.toml
+++ b/apps/karmolab-tauri/src-tauri/Cargo.toml
@@ -67,13 +67,9 @@ base64 = "0.22"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winuser", "processthreadsapi", "psapi", "handleapi", "minwindef", "sysinfoapi"] }
 
-# KL-051: production 배포 최적화. cargo 디폴트 (lto=false / codegen-units=16 / strip=false) 가
-# desktop 앱 배포에는 부적합 — fat LTO + 단일 codegen + strip + abort panic 으로 사이즈 + perf 동시 ↑.
-# `[profile.dev]` 미설정 = `tauri dev` 빌드 속도 그대로 (사용자 명시).
-[profile.release]
-lto = "fat"
-codegen-units = 1
-strip = true
-panic = "abort"
-opt-level = 3
+# KL-051 의 production 배포 최적화 (fat LTO / codegen-units=1 / strip /
+# panic=abort / opt-level=3) 는 KL-052 워크스페이스 전환으로 *워크스페이스
+# 루트* (`apps/karmolab-tauri/Cargo.toml` 의 [profile.release]) 로 이관됐다.
+# cargo 는 워크스페이스 멤버의 [profile.*] 를 무시(warn)하므로 여기 두면
+# KL-051 최적화가 조용히 사라진다. 루트에서 정의 — 동작 동일, 회귀 방지.
 


### PR DESCRIPTION
## TASK-KL-052 Step A (autopilot)

메인 KarmoLab 바이너리(15.8MB)에서 ML stack(candle Whisper / xcap / tesseract)을 별도 sidecar `.exe` 로 분리하기 위한 **워크스페이스 + IPC 골격 + 프로토콜 명세**. 실동작 마이그는 -B/-C.

### 변경

- **`apps/karmolab-tauri/Cargo.toml`** — 신규 `[workspace]` (members: `src-tauri` + `src-tauri-ml`, resolver=2). `Cargo.lock` 워크스페이스 루트로 이관 (+8줄, 기존 pin 전부 보존).
- **`[profile.release]` 이관** — KL-051 의 fat LTO/strip/panic=abort/opt=3 를 `src-tauri` → 워크스페이스 루트로 이동. cargo 는 워크스페이스 멤버의 `[profile.*]` 를 무시(warn)하므로 그대로 두면 KL-051 최적화가 **조용히 사라지는 회귀** → 루트 정의로 동작 동일 + 회귀 방지. (이번 PR 의 핵심 hidden trap)
- **`src-tauri-ml/`** — 신규 sidecar crate (bin `karmolab-life-ml`). `protocol.rs` (SidecarCommand/SidecarEvent), `main.rs` stdin/stdout JSON line dispatch 루프, voice/capture/ocr 모듈 스텁(미구현 Error). 스켈레톤 dep = serde/serde_json 만.
- **`src-tauri-ml/PROTOCOL.md`** — IPC 명세 정본 + KL-052 결정 4항목 기록.

### 자율 결정 (TASK § "결정 필요 항목" — 코드/패턴 한정, process 룰 § 근본의 근)

| # | 항목 | 결정 |
|---|---|---|
| 1 | 워크스페이스 구조 | 단일 `[workspace]`, src-tauri + src-tauri-ml 멤버 |
| 2 | IPC 모델 | stdin/stdout JSON line (가장 단순, 테스트 용이, TASK sketch 일치) |
| 3 | 모델 파일(~3.1GB) 위치 | **KL-052-B 에서 확정** (voice 이관 시 현 경로 파악 후) |
| 4 | 다운로드 vs 패키징 | default 패키징, **KL-052-E 사이즈 실측 후 재평가** |

→ 사용자가 PR 리뷰에서 redirect 가능.

### 검증

- `cargo check -p karmolab-ml-sidecar`: 그린 (경고 0).
- `cd src-tauri && cargo check --all-targets` (verify.mjs 동일 명령 = **master invariant 게이트**): **exit 0**. profile/workspace 경고 0 (profile 이관 정상 입증). 기존 dead-code 경고 2개만(본 변경 무관).
- sidecar 는 `--workspace` 아니므로 verify 게이트에서 빌드 X — 게이트 속도/그린 유지 (의도).

### Test plan (사용자/CI)

- [ ] CI `npm run verify` (cargo check + ACL audit) 재확인 — 로컬 exit 0 확인됨.
- [ ] voice/capture/ocr 실동작 = KL-052-B/-C (현 스텁은 미구현 Error 반환, 정상).
- [ ] `.meta` 무관 (Rust 프로젝트, Unity 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)