### PR TITLE
fix(yawnbot): /health deep health — TASK-YB-020 Step 2 (503 분기 + watcher 이중검증)

### DIFF
--- a/.github/workflows/yawnbot-health.yml
+++ b/.github/workflows/yawnbot-health.yml
@@ -40,12 +40,17 @@ jobs:
           echo "$BODY"
           echo "::endgroup::"
 
+          # YB-020 Step 2 — status code 뿐 아니라 body 의 ok:true 도 검증.
+          # gateway disconnected = HTTP 503 (code 로 잡힘) + body ok:false (이중 방어).
+          BODY_OK=$(echo "$BODY" | grep -oE '"ok"[[:space:]]*:[[:space:]]*(true|false)' | grep -oE '(true|false)' | tail -1)
+
           echo "curl_exit=$CURL_EXIT" >> "$GITHUB_OUTPUT"
           echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+          echo "body_ok=$BODY_OK" >> "$GITHUB_OUTPUT"
 
-          if [ "$CURL_EXIT" -ne 0 ] || [ "$HTTP_CODE" != "200" ]; then
+          if [ "$CURL_EXIT" -ne 0 ] || [ "$HTTP_CODE" != "200" ] || [ "$BODY_OK" != "true" ]; then
             echo "status=fail" >> "$GITHUB_OUTPUT"
-            echo "::warning::yawnbot health probe FAIL (curl_exit=$CURL_EXIT http_code=$HTTP_CODE)"
+            echo "::warning::yawnbot health probe FAIL (curl_exit=$CURL_EXIT http_code=$HTTP_CODE body_ok=$BODY_OK)"
           else
             echo "status=ok" >> "$GITHUB_OUTPUT"
           fi
@@ -64,12 +69,13 @@ jobs:
             --arg ts "$TS" \
             --arg http "${{ steps.probe.outputs.http_code }}" \
             --arg curl "${{ steps.probe.outputs.curl_exit }}" \
+            --arg body_ok "${{ steps.probe.outputs.body_ok }}" \
             --arg run_url "$RUN_URL" \
             '{
               username: "Yawnbot Health Watcher",
               embeds: [{
                 title: "yawnbot health check FAIL",
-                description: ("URL: " + $url + "\nHTTP code: " + $http + "\ncurl exit: " + $curl + "\ntime: " + $ts),
+                description: ("URL: " + $url + "\nHTTP code: " + $http + "\ncurl exit: " + $curl + "\nbody ok: " + $body_ok + "\ntime: " + $ts),
                 color: 15158332,
                 fields: [{ name: "Workflow run", value: $run_url, inline: false }]
               }]

--- a/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { EmbedBuilder } from 'discord.js';
+import { EmbedBuilder, Status } from 'discord.js';
 import type { Client } from 'discord.js';
 import type { GameDataService } from '../services/gamedata';
 import { getChannelsForRepo } from '../services/webhook-routes';
@@ -9,12 +9,27 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
   const app = express();
   app.use(express.json());
 
+  // YB-020 Step 2 — gateway 가 살아있어도 dispatch 가 멈춘 zombie 상태 관측용.
+  // discord.js 는 op0 dispatch 마다 'raw' emit. 503 판정엔 안 쓰고 (조용한
+  // 시간대 false disconnected 위험) observability 신호로만 노출.
+  let lastDispatchAt: number | null = null;
+  client.on('raw', () => {
+    lastDispatchAt = Date.now();
+  });
+
   app.get('/health', (_req, res) => {
-    res.status(200).json({
-      ok: client.isReady(),
+    const gatewayUp = client.isReady() && client.ws.status === Status.Ready;
+    res.status(gatewayUp ? 200 : 503).json({
+      ok: gatewayUp,
+      gateway: gatewayUp ? 'connected' : 'disconnected',
       uptime_sec: Math.floor(process.uptime()),
       ws_status: client.ws.status,
+      ws_ping_ms: client.ws.ping,
       ready_at: client.readyAt?.toISOString() ?? null,
+      last_dispatch_at: lastDispatchAt ? new Date(lastDispatchAt).toISOString() : null,
+      deps: {
+        game_data_users: Object.keys(gameData.users ?? {}).length,
+      },
     });
   });
 


### PR DESCRIPTION
## 요약

TASK-YB-020 **Step 2** (Step 1 = PR #60 — /health 라우트 신설). YB-020 완전 close.

PR #60 의 /health 는 항상 HTTP 200 (process up 신호만). 본 PR 는 **gateway 실연결 상태를 status code 로 반영** + watcher 가 status + body 이중검증.

## 변경

### `webhook.ts`

| 항목 | Step 1 (PR #60) | Step 2 (본 PR) |
|---|---|---|
| status code | 항상 200 | gateway up → 200 / down → **503** |
| gateway 판정 | `client.isReady()` | `isReady() && ws.status === Status.Ready` |
| body | ok/uptime/ws_status/ready_at | + `gateway`, `ws_ping_ms`, `last_dispatch_at`, `deps.game_data_users` |

`last_dispatch_at` = `client.on('raw')` 로 op0 dispatch 시각 추적. **503 판정엔 미사용** — 조용한 시간대 (메시지·presence 변화 0) false disconnected 위험. zombie connection 은 discord.js v14 가 heartbeat ack 끊김 시 `ws.status` 를 Ready 아니게 만들어 자동 재연결 → 503 분기가 이미 커버. `last_dispatch_at` 은 순수 observability.

### `yawnbot-health.yml`

- HTTP code 뿐 아니라 body 의 `"ok":true` 도 검증 (`body_ok`). 503 + ok:false 양쪽으로 disconnected 검출 (이중 방어 — TASK 완료조건 「status code + body 둘 다 검증」).
- alert embed 에 `body ok` 필드 추가.

## 「설계 자가 검토」 적용

- **lastDispatchAt 을 503 판정에 쓸까?** → 조용한 시간대 false positive. discord.js v14 의 zombie 자동 처리 (ws.status) 가 근본 신호. lastDispatchAt 은 observability only 가 맞음 ✓
- **raw event v14 타입?** → `tsc -p tsconfig.json --noEmit` EXIT:0 실측 (discord.js ^14.26.0, Status.Ready=0) ✓
- **TASK 완료조건 3개 전부?** → JSON body deep ✓ / gateway 끊김 503 ✓ / watcher status+body 이중검증 ✓

## Test plan

- [ ] verify (master invariant) CI pass — yawnbot 패키지 내부, verify scope 밖 무영향 예상 (typecheck 로컬 EXIT:0 선검증)
- [ ] typos check pass
- [ ] 머지 → auto-deploy → `/health` 200 + 새 body 필드 확인
- [ ] Health Watcher dispatch → SUCCESS (gateway connected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 헬스체크의 HTTP 응답 body에 포함된 상태 값을 검증하는 기능을 추가하여 더욱 정확한 상태 판정 구현
  * 헬스체크 실패 시 Discord 알림 메시지에 상세한 검증 결과 정보를 포함하도록 개선

* **Refactor**
  * 헬스체크 API 응답 포맷을 확장하여 게이트웨이 연결 상태, 네트워크 지연 시간, 마지막 활동 시각 등의 추가적인 모니터링 정보 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/63)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->