### PR TITLE
perf(karmolab): lazy-load marked.min.js; docs → lazy widget (KL-054-B)

### DIFF
--- a/apps/karmolab/index.html
+++ b/apps/karmolab/index.html
@@ -3,7 +3,7 @@ layout: none
 permalink: /karmolab/
 ---
 <!--
-    로컬 테스트 (Jekyll 빌드 없이):
+    로컈 테스트 (Jekyll 빌드 없이):
     1. 블로그 루트에서 python -m http.server 8899
     2. http://localhost:8899/apps/karmolab/index.html 접속
     * 상단에 프론트매터 텍스트가 보이지만 JS/CSS/기능은 정상 동작함
@@ -14,17 +14,17 @@ permalink: /karmolab/
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>KarmoLab</title>
-    <meta name="description" content="AI 챗봇, 이미지 생성·편집, 암호화, 랜덤 생성기 등 유틸리티와 미니게임을 모은 KarmoLab. 삶을 섞고 술을 바꿀 시간.">
+    <meta name="description" content="AI 챗봇, 이미지 생성·편집, 암호화, 랜덤 생성기 등 유톸리티와 미니게임을 모은 KarmoLab. 삶을 섯고 술을 바꾼 시간.">
     <link rel="canonical" href="https://mascari4615.github.io/karmolab/">
     <meta property="og:type" content="website">
     <meta property="og:title" content="KarmoLab">
-    <meta property="og:description" content="AI 챗봇, 이미지 생성·편집, 암호화, 랜덤 생성기 등 유틸리티와 미니게임을 모은 KarmoLab. 삶을 섞고 술을 바꿀 시간.">
+    <meta property="og:description" content="AI 챗봇, 이미지 생성·편집, 암호화, 랜덤 생성기 등 유톸리티와 미니게임을 모은 KarmoLab. 삶을 섯고 술을 바꾼 시간.">
     <meta property="og:url" content="https://mascari4615.github.io/karmolab/">
     <meta property="og:image" content="https://mascari4615.github.io/apps/karmolab/img/favicon.ico">
     <meta property="og:locale" content="ko_KR">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="KarmoLab">
-    <meta name="twitter:description" content="AI 챗봇, 이미지 생성·편집, 암호화, 랜덤 생성기 등 유틸리티와 미니게임을 모은 KarmoLab. 삶을 섞고 술을 바꿀 시간.">
+    <meta name="twitter:description" content="AI 챗봇, 이미지 생성·편집, 암호화, 랜덤 생성기 등 유톸리티와 미니게임을 모은 KarmoLab. 삶을 섯고 술을 바꾼 시간.">
     <link rel="icon" href="/apps/karmolab/img/favicon.ico">
     <script src="/apps/karmolab/js/vendor/crypto-js.min.js" defer></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -49,7 +49,6 @@ permalink: /karmolab/
   if(el&&url)el.href=url;
 })();
     </script>
-    <script src="/apps/karmolab/js/vendor/marked.min.js" defer></script>
     <script src="/apps/karmolab/js/vendor/prism.min.js" defer></script>
     <script src="/apps/karmolab/js/vendor/prism-autoloader.min.js" defer></script>
     <script>

--- a/apps/karmolab/src/widgets-lazy-meta.ts
+++ b/apps/karmolab/src/widgets-lazy-meta.ts
@@ -7,6 +7,15 @@ import type { KarmoLabLazyWidgetStub } from '../types/karmolab';
 
 window.KARMOLAB_LAZY_META = [
   {
+    id: 'docs',
+    title: '문서',
+    category: 'tool',
+    desc: 'KarmoLab 소개·로드맵·가이드 + 캐릭터·시스템 위키 — 사이드바 그룹 내비게이션, 본문 + 목차',
+    layout: 'wide',
+    icon: '<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>',
+    lazyScriptPaths: ['../vendor/marked.min', 'docs/docs']
+  },
+  {
     id: 'life',
     title: 'Life 채널',
     category: 'tool',
@@ -196,7 +205,7 @@ window.KARMOLAB_LAZY_META = [
   { id: 'news', title: '뉴스', category: 'play', desc: '가짜 뉴스 헤드라인을 생성합니다', hidden: true, layout: 'form', icon: '', lazyScriptPaths: ['news'] },
   { id: 'particle', title: '파티클', category: 'play', desc: '마우스로 파티클을 움직이고 클릭으로 폭발시킵니다', hidden: true, layout: 'form', icon: '', lazyScriptPaths: ['particle'] },
   { id: 'password', title: '비번', category: 'tool', desc: '랜덤 비밀번호를 생성합니다', hidden: true, layout: 'form', icon: '', lazyScriptPaths: ['password'] },
-  { id: 'pet', title: '쓰다듬기', category: 'play', desc: '고양이를 쓰다듬고 호감도를 올립니다', hidden: true, layout: 'form', icon: '', lazyScriptPaths: ['pet'] },
+  { id: 'pet', title: '쓰다듬기', category: 'play', desc: '고양이를 쓰다듬고 호감도를 울립니다', hidden: true, layout: 'form', icon: '', lazyScriptPaths: ['pet'] },
   { id: 'reaction', title: '반응속도', category: 'play', desc: '반응 속도를 측정합니다', hidden: true, layout: 'form', icon: '', lazyScriptPaths: ['reaction'] },
   { id: 'shylink', title: '어그로', category: 'play', desc: '움직이는 링크를 잡는 미니게임', hidden: true, layout: 'form', icon: '', lazyScriptPaths: ['shylink'] },
   { id: 'speed', title: '속도측정', category: 'play', desc: '드래그 속도를 측정합니다', hidden: true, layout: 'form', icon: '', lazyScriptPaths: ['speed'] },

--- a/apps/karmolab/src/widgets-manifest.ts
+++ b/apps/karmolab/src/widgets-manifest.ts
@@ -13,7 +13,6 @@ window.KARMOLAB_WIDGETS_BOOT = [
   'linktree/linktree',
   'user',
   'dashboard',
-  'docs/docs',
   'servermonitor',
   'activity',
   'devtools',

--- a/apps/karmolab/src/widgets/docs/docs.ts
+++ b/apps/karmolab/src/widgets/docs/docs.ts
@@ -60,7 +60,7 @@
       let n = 0;
       for (const el of elements) {
         if (!(el instanceof HTMLElement)) continue;
-        const text = (el.textContent || '').replace(/\uFEFF/g, '').trim();
+        const text = (el.textContent || '').replace(/﻿/g, '').trim();
         if (!text) continue;
         const id = 'kl-mmd-' + Date.now() + '-' + ++n;
         const { svg, bindFunctions } = await render.call(mm, id, text);
@@ -469,7 +469,7 @@
   function renderMarkdown(container: HTMLElement, md: string): void {
     const body = document.createElement('div');
     body.className = 'docs-body';
-    md = md.replace(/^\uFEFF/, '');
+    md = md.replace(/^﻿/, '');
 
     if (typeof marked === 'undefined') {
       container.innerHTML = '<p class="docs-body" style="color:var(--error)">marked.js 로드 실패. 새로고침해주세요.</p>';
@@ -550,7 +550,7 @@
     }
   }
 
-  // ── TASK-KL-015-B: 통합 문서 위젯 ─────────────────────────────────────────────────────────
+  // ── TASK-KL-015-B: 통합 문서 위젯 ──────────────────────────────────────────────────────
   // docs.ts 가 자체 사이드바 (그룹 헤더 + 동적 항목) + 본문 + TOC 그림. Toolbox tabs 단일.
   // 「프로젝트 문서」 그룹 = 외부 md/GitHub raw (현 hardcode).
   // 「캐릭터/시스템/개념/lore」 그룹 = `world/wiki/manifest.json` 동적 walk (sub-A 의 sync 결과).
@@ -568,15 +568,15 @@
 
   const EXTERNAL_DOCS: ExternalDoc[] = [
     { id: 'docs-intro', label: '소개', source: { kind: 'local', path: 'intro.md' }, mddPreset: 'tool_run', mddMsg: '문서 페이지예요!' },
-    { id: 'docs-roadmap', label: '로드맵', source: { kind: 'local', path: 'roadmap.md' }, mddPreset: 'daily_start', mddMsg: '로드맵이랑 기획이에요~' },
-    { id: 'docs-guide', label: '가이드', source: { kind: 'local', path: 'guide.md' }, mddPreset: 'tool_run', mddMsg: '사용법을 알려줄게요~' },
-    { id: 'docs-karmolab-ai', label: 'KarmoLabAI', source: { kind: 'local', path: 'karmolab-ai.md' }, mddPreset: 'tool_run', mddMsg: 'karmolab-ai 패키지 쓰는 법이에요.' },
-    { id: 'docs-discord-yawnbot', label: 'Discord·욘봇', source: { kind: 'local', path: 'discord-yawnbot.md' }, mddPreset: 'tool_run', mddMsg: '욘 봇 음성·DAVE·기능 요약·TODO 한곳이에요.' },
+    { id: 'docs-roadmap', label: '로드맵', source: { kind: 'local', path: 'roadmap.md' }, mddPreset: 'daily_start', mddMsg: '로드맵이랑 기획이어요~' },
+    { id: 'docs-guide', label: '가이드', source: { kind: 'local', path: 'guide.md' }, mddPreset: 'tool_run', mddMsg: '사용법을 알려줌게~' },
+    { id: 'docs-karmolab-ai', label: 'KarmoLabAI', source: { kind: 'local', path: 'karmolab-ai.md' }, mddPreset: 'tool_run', mddMsg: 'karmolab-ai 패키지 쓰는 법이어요.' },
+    { id: 'docs-discord-yawnbot', label: 'Discord·욕봇', source: { kind: 'local', path: 'discord-yawnbot.md' }, mddPreset: 'tool_run', mddMsg: '욕 봇 음성·DAVE·기능 요약·TODO 한곳이어요.' },
     { id: 'docs-discord-bots-readme', label: 'discord-bots · README', source: { kind: 'github', path: 'apps/discord-bots/README.md' }, mddPreset: 'tool_run', mddMsg: 'discord-bots 워크스페이스 README (GitHub).' },
     { id: 'docs-tauri-readme', label: 'Tauri · README', source: { kind: 'github', path: 'apps/karmolab-tauri/README.md' }, mddPreset: 'tool_run', mddMsg: '데스크톱 앱 폴더 README (GitHub).' },
-    { id: 'docs-project-commands', label: '프로젝트 명령', source: { kind: 'local', path: 'project-commands-guide.md' }, mddPreset: 'tool_run', mddMsg: '블로그·KarmoLab·앱 전체 명령을 모아 뒀어요. 복사해서 쓰기 좋게!' },
-    { id: 'docs-local-dev', label: '데스크톱·로컬', source: { kind: 'local', path: 'local-dev-runner.md' }, mddPreset: 'tool_run', mddMsg: 'Tauri 앱에서만 쓰는 로컬 데브 러너 안내예요.' },
-    { id: 'docs-servermonitor-deploy-log-design', label: '로컬 · deploy 로그', source: { kind: 'local', path: 'servermonitor-deploy-log-stream.md' }, mddPreset: 'tool_run', mddMsg: '서버 모니터 deploy·npm i 로그 스트림 — 이벤트·커맨드는 본문 참고.' },
+    { id: 'docs-project-commands', label: '프로젝트 명령', source: { kind: 'local', path: 'project-commands-guide.md' }, mddPreset: 'tool_run', mddMsg: '블로그·KarmoLab·앱 전체 명령을 모아 띠어요. 복사해서 쓰기 좋게!' },
+    { id: 'docs-local-dev', label: '데스크톱·로컈', source: { kind: 'local', path: 'local-dev-runner.md' }, mddPreset: 'tool_run', mddMsg: 'Tauri 앱에서만 쓰는 로컈 데브 러너 안내예요.' },
+    { id: 'docs-servermonitor-deploy-log-design', label: '로컈 · deploy 로그', source: { kind: 'local', path: 'servermonitor-deploy-log-stream.md' }, mddPreset: 'tool_run', mddMsg: '서버 모니터 deploy·npm i 로그 스트림 — 이벤트·커맨드는 본문 참고.' },
   ];
 
   type RelTarget = string | { target: string; label?: string };
@@ -653,7 +653,7 @@
       parts.push('');
     }
     // character 의 관계 그래프 — relationships 가 있으면 mermaid 자동 생성.
-    // marked fence 인식 우회: 직접 <div class="mermaid"> 인라인 HTML — mermaid lib 가 .mermaid 셀렉터 자동 잡음.
+    // marked fence 인식 우회: 직접 <div class="mermaid"> 인라인 HTML — mermaid lib 가 .mermaid 셀렉터 자동 잊음.
     if (dirName === 'characters' && item.relationships && item.relationships.length > 0) {
       const mmdLines: string[] = ['graph LR'];
       const selfId = sanitizeMermaidId(item.slug);
@@ -823,19 +823,6 @@
       });
   }
 
-  Toolbox.register({
-    id: 'docs',
-    title: '문서',
-    desc: 'KarmoLab 소개·로드맵·가이드 + 캐릭터·시스템 위키 — 사이드바 그룹 내비게이션, 본문 + 목차',
-    layout: 'wide',
-    icon: '<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>',
-    tabs: [
-      {
-        id: 'docs',
-        label: '문서',
-        build: buildDocsShell,
-      },
-    ],
-  });
+  Toolbox.register({ ...Toolbox.getLazyWidgetPublicMeta('docs'), tabs: [{ id: 'docs', label: '문서', build: buildDocsShell }] });
 
 })();


### PR DESCRIPTION
## Summary

- `marked.min.js` (37KB) removed from `index.html` eager-load; startup parse/exec budget freed
- `docs` widget migrated from `KARMOLAB_WIDGETS_BOOT` → `KARMOLAB_LAZY_META` with `lazyScriptPaths: ['../vendor/marked.min', 'docs/docs']`
  - marked is now loaded on-demand, guaranteed available before docs renders markdown
  - `Toolbox.register` updated to `getLazyWidgetPublicMeta('docs')` pattern (consistent with all lazy widgets)

## Investigation notes

- `marked` usage grep: **only `docs/docs.ts`** uses `window.marked` (chatbot/markdown.ts and world/*.ts do NOT)
- `gemini.js`, `prism.min.js`, `randomgen-*`: deferred to future sub-tasks (see TASK-KL-054-C backlog)
  - `gemini.js`: cannot lazy-load — `user.ts:490` calls `Gemini.buildApiKeyUI()` without undefined guard
  - `prism`: requires inline script refactor (DOMContentLoaded path) before lazy-load is safe

## Test plan

- [ ] KL-054-C (사용자 시각 검증): docs widget 첫 클릭 시 marked.min.js fetch 발생 확인
- [ ] startup Network 탭 — marked.min.js 요청 0 (첫 클릭 전)
- [ ] docs 위젯 마크다운 렌더, 목차, mermaid 다이어그램 정상 동작
- [ ] 다른 boot 위젯(user, dashboard, servermonitor 등) 영향 없음 확인

TASK-KL-054 / autopilot cloud-kl

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7dVdYAX5iYsX2ZZ1h1K7E)_