### PR TITLE
refactor(tauri): KL-055-A winapi → windows-sys (transitive dedup)

### DIFF
--- a/apps/karmolab-tauri/src-tauri/Cargo.toml
+++ b/apps/karmolab-tauri/src-tauri/Cargo.toml
@@ -55,12 +55,20 @@ tauri-plugin-global-shortcut = "2"
 # TASK-KL-037: adventure dataUrl → 별 PNG 파일 분리 시 base64 디코드.
 base64 = "0.22"
 
+# KL-055-A: winapi 0.3(deprecated) → windows-sys 0.59(공식, 이미 transitive 중복).
+# 단일 Win32 dep 으로 통일 — Cargo.lock 중복 제거.
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winuser", "processthreadsapi", "psapi", "handleapi", "minwindef", "sysinfoapi"] }
+windows-sys = { version = "0.59", features = [
+  "Win32_Foundation",
+  "Win32_System_ProcessStatus",
+  "Win32_System_SystemInformation",
+  "Win32_System_Threading",
+  "Win32_UI_Shell",
+  "Win32_UI_WindowsAndMessaging",
+] }
 
 # KL-051 의 production 배포 최적화 (fat LTO / codegen-units=1 / strip /
 # panic=abort / opt-level=3) 는 KL-052 워크스페이스 전환으로 *워크스페이스
 # 루트* (`apps/karmolab-tauri/Cargo.toml` 의 [profile.release]) 로 이관됐다.
 # cargo 는 워크스페이스 멤버의 [profile.*] 를 무시(warn)하므로 여기 두면
 # KL-051 최적화가 조용히 사라진다. 루트에서 정의 — 동작 동일, 회귀 방지.
-

--- a/apps/karmolab-tauri/src-tauri/src/activity.rs
+++ b/apps/karmolab-tauri/src-tauri/src/activity.rs
@@ -33,12 +33,13 @@ mod platform {
     use std::os::windows::ffi::OsStringExt;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use winapi::shared::minwindef::{DWORD, FALSE};
-    use winapi::um::handleapi::CloseHandle;
-    use winapi::um::processthreadsapi::OpenProcess;
-    use winapi::um::psapi::GetModuleBaseNameW;
-    use winapi::um::winnt::{PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_VM_READ};
-    use winapi::um::winuser::{
+    use windows_sys::Win32::Foundation::{CloseHandle, FALSE};
+    use windows_sys::Win32::System::ProcessStatus::GetModuleBaseNameW;
+    use windows_sys::Win32::System::SystemInformation::GetTickCount;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_VM_READ,
+    };
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
         GetForegroundWindow, GetLastInputInfo, GetWindowTextLengthW, GetWindowTextW,
         GetWindowThreadProcessId, LASTINPUTINFO,
     };
@@ -76,7 +77,7 @@ mod platform {
                 return None;
             }
             // GetTickCount는 wraparound이지만 단기 비교엔 충분.
-            let now_ms = winapi::um::sysinfoapi::GetTickCount() as u64;
+            let now_ms = GetTickCount() as u64;
             let last_ms = info.dwTime as u64;
             Some(now_ms.saturating_sub(last_ms) / 1000)
         }
@@ -84,7 +85,7 @@ mod platform {
 
     unsafe fn foreground_info() -> (String, String) {
         let hwnd = GetForegroundWindow();
-        if hwnd.is_null() {
+        if hwnd == 0 {
             return (String::new(), String::new());
         }
 
@@ -106,14 +107,14 @@ mod platform {
         };
 
         // 프로세스 PID + 실행 파일명
-        let mut pid: DWORD = 0;
+        let mut pid: u32 = 0;
         GetWindowThreadProcessId(hwnd, &mut pid);
         let process = process_name(pid).unwrap_or_default();
 
         (process, title)
     }
 
-    unsafe fn process_name(pid: DWORD) -> Option<String> {
+    unsafe fn process_name(pid: u32) -> Option<String> {
         if pid == 0 {
             return None;
         }
@@ -122,11 +123,11 @@ mod platform {
             FALSE,
             pid,
         );
-        if handle.is_null() {
+        if handle == 0 {
             return None;
         }
         let mut buf: [u16; 260] = [0; 260];
-        let len = GetModuleBaseNameW(handle, std::ptr::null_mut(), buf.as_mut_ptr(), buf.len() as u32);
+        let len = GetModuleBaseNameW(handle, 0, buf.as_mut_ptr(), buf.len() as u32);
         CloseHandle(handle);
         if len == 0 {
             return None;


### PR DESCRIPTION
## Summary

- `winapi 0.3` (deprecated) → `windows-sys 0.59` in `[target.'cfg(windows)'.dependencies]`
- `windows-sys 0.59.0` was already a transitive dep — this promotes it to direct and removes winapi entirely
- `activity.rs`: replace all `winapi::*` imports; `DWORD→u32`, `is_null()→==0`, `null_mut()→0`, inline `GetTickCount` path → imported fn

## Scope

Phase 1 of TASK-KL-055. Phases 2 (notify-rust → tauri-plugin-notification) and 3 (reqwest — already resolved by KL-052 ML sidecar) remain.

## Test plan

- [ ] `cargo check --all-targets` (CI verify gate) — passes
- [ ] Windows: activity tracker samples foreground window/process correctly after migration
- [ ] `cargo tree --duplicates` shows no `windows-sys` version conflict

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7dVdYAX5iYsX2ZZ1h1K7E)_