### PR TITLE
autopilot(KL-071): TypeScript any 정리 제1부 — 타입 안전성

### DIFF
--- a/apps/karmolab/src/widgets/favorites.ts
+++ b/apps/karmolab/src/widgets/favorites.ts
@@ -34,12 +34,12 @@ import { DEFAULT_ITEMS, FAVICON_FALLBACK, type FavoriteGroup, type FavoriteItem 
     function getToolboxToolsGroup(): FavoriteGroup | null {
         const tools = typeof Toolbox !== 'undefined' && Toolbox.getTools ? Toolbox.getTools() : [];
         const items: FavoriteItem[] = tools
-            .filter((t: any) => {
+            .filter((t) => {
                 if (t.hidden) return false;
                 if (t.category === 'desktop' && !Toolbox.isDesktopApp?.()) return false;
                 return true;
             })
-            .map((t: any) => ({ type: 'tool', toolId: t.id, label: t.title, icon: t.icon }));
+            .map((t) => ({ type: 'tool', toolId: t.id, label: t.title, icon: t.icon }));
         return items.length ? { group: 'Toolbox', items } : null;
     }
 

--- a/apps/karmolab/src/widgets/quest-log/quest-log.ts
+++ b/apps/karmolab/src/widgets/quest-log/quest-log.ts
@@ -406,7 +406,7 @@ const _questUnlisten = new WeakMap<HTMLElement, () => void>();
     }
   }
 
-  function escOverview(s: any): string {
+  function escOverview(s: unknown): string {
     return String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' })[c]!);
   }
 
@@ -1613,7 +1613,7 @@ const _questUnlisten = new WeakMap<HTMLElement, () => void>();
       return String(id).replace(/^TASK-[A-Z]+-/, '');
     }
 
-    function esc(s: any): string { return String(s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]!)); }
+    function esc(s: unknown): string { return String(s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]!)); }
 
     function starsHTML(progress: number, large = false): string {
       const filled = progress * 5;

--- a/apps/karmolab/types/global.d.ts
+++ b/apps/karmolab/types/global.d.ts
@@ -104,7 +104,7 @@ declare global {
     } & Record<string, unknown>) => void;
     initTheme: () => void;
     init: () => void;
-    getTools: () => Array<{ id: string }>;
+    getTools: () => Array<{ id: string; hidden?: boolean; category?: string; title?: string; icon?: string }>;
     showToast?: (msg: string, type?: string, detail?: unknown) => void;
     getProgress?: (key: string) => number;
     setProgress?: (key: string, value: number) => void;


### PR DESCRIPTION
🤖 KAR-018-Y autopilot 워커(KlWorker) 자율 산출. commit 0421010a: global.d.ts getTools() 반환타입 확장 + favorites.ts/quest-log.ts any 제거. npm run build(karmolab)+verify(Rust 제외) 통과(워커 보고). 워커가 실제로 일한 첫 실증 PR. quest-log 레거시 함수=KL-071 slice2 권장.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 타입 안정성 개선을 위해 내부 함수의 입력 타입을 강화했습니다.
  * 도구 항목 타입을 확장하여 카테고리, 제목, 아이콘, 숨김 상태 등 추가 메타데이터를 지원하도록 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->