### PR TITLE
chore(karmolab): @ts-nocheck 제거 — chatbot/styles.ts·imagegen/styles.ts (TASK-KL-070)

### DIFF
--- a/apps/karmolab/src/widgets/chatbot/styles.ts
+++ b/apps/karmolab/src/widgets/chatbot/styles.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 (function () {
     Mdd.injectCSS('chatbot', `
         .cb-outer { display:flex; flex-direction:column; flex:1; min-height:0; min-width:0; width:100%; position:relative; }

--- a/apps/karmolab/src/widgets/imagegen/styles.ts
+++ b/apps/karmolab/src/widgets/imagegen/styles.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 (function(){ 'use strict'; if(typeof Mdd!=='undefined') Mdd.injectCSS('imagegen', `
         /* ===== 생성 탭 ===== */
         .ig-layout { display:flex; gap:24px; flex:1; min-height:0; }


### PR DESCRIPTION
## Summary

TASK-KL-070 초기 진행 — CSS 전용 IIFE 두 파일에서 `// @ts-nocheck` 제거.

- `apps/karmolab/src/widgets/chatbot/styles.ts`
- `apps/karmolab/src/widgets/imagegen/styles.ts`

두 파일 모두 `Mdd.injectCSS()` 만 호출하는 wrapper. `Mdd` 는 `src/mdd.ts` 의 top-level `const` (no exports → TS 가 script 로 처리 → 글로벌 바인딩) 이므로 별도 ambient declaration 없이도 typecheck 통과.

## TASK-KL-070 전체 진척

22 파일 중 2개 처리. 나머지는 각각 파일 단위로 typecheck 통과 작업이 필요 (spec hint: 파일 규모가 큰 toolbox.ts 는 별도 단계로 분리 권장).

- spec 가 별도 단계 권장: `toolbox.ts` (1437L, 핵심 shell)
- TASK-KL-069 의존: `adventure.ts`·`terminal.ts`
- IIFE→ES module 리팩터 선행 권장: `chatbot/characters.ts`
- 대형 단일 파일: `gemini.ts`·`chatbot/chatbot.ts`·`imageedit.ts`·`imagegen/imagegen.ts`
- Tierlist 모듈 6 파일 (~3200L): `window.Tierlist` 가 70+ 메서드 노출하는 dynamic namespace — `TierlistNamespace` interface 도출 선행
- 기타: `crypto.ts`·`imagelib.ts`·`imagegen/core.ts`·`randomgen.ts` — 각 파일이 외부 global (`CryptoJS`·`ImageDB`·`Gemini.MODELS`) 선언 필요

## Test plan

- [x] `cd apps/karmolab && npm run typecheck` 통과
- [x] `cd apps/karmolab && npm run build` 통과 (esbuild)
- [x] `npm run verify` 통과 (master invariant 전수)
- [ ] CI verify (push trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)