### PR TITLE
feat(KAR-018-LT-W1+WIRE): chat=state — buildWorkerPrompt + production wire (Phase 1+2)

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-cadence-worker.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-cadence-worker.test.ts
@@ -94,6 +94,48 @@ describe('buildWorkerPrompt (순수)', () => {
     expect(p).toMatch(/merge.*master.*force.*금지|force-push/);
     expect(p).toContain('MISSION');
   });
+
+  // KAR-018-LT-W1 — chat=state substrate
+  it('channelContext 주어지면 CHANNEL 블록 포함', () => {
+    const p = buildWorkerPrompt(
+      { id: 'TASK-WM-119', file: 'x.md' },
+      'MISSION',
+      undefined, undefined, undefined,
+      '[KarWorker] TASK-X 점유 해제·재대기 (exit 1)\n[WmSupport] TASK-Y 점유 해제·재대기 (exit 1)',
+    );
+    expect(p).toContain('<<<CHANNEL');
+    expect(p).toContain('CHANNEL');
+    expect(p).toContain('[KarWorker] TASK-X');
+    expect(p).toContain('같은 사유·결론 반복');
+  });
+
+  it('channelContext undefined/빈 문자열이면 CHANNEL 블록 부재 (5입력 호환)', () => {
+    const p1 = buildWorkerPrompt({ id: 'TASK-X', file: 'x.md' }, 'MISSION');
+    expect(p1).not.toContain('CHANNEL');
+    const p2 = buildWorkerPrompt(
+      { id: 'TASK-X', file: 'x.md' },
+      'MISSION',
+      undefined, undefined, undefined,
+      '   ',  // whitespace only
+    );
+    expect(p2).not.toContain('CHANNEL');
+  });
+
+  it('channelContext 3000자 cap (prompt 폭주 가드)', () => {
+    const huge = 'X'.repeat(5000);
+    const p = buildWorkerPrompt(
+      { id: 'TASK-X', file: 'x.md' },
+      'MISSION',
+      undefined, undefined, undefined,
+      huge,
+    );
+    const channelStart = p.indexOf('<<<CHANNEL');
+    const channelEnd = p.indexOf('\nCHANNEL', channelStart);
+    expect(channelStart).toBeGreaterThan(-1);
+    expect(channelEnd).toBeGreaterThan(channelStart);
+    const blockBody = p.slice(channelStart + '<<<CHANNEL\n'.length, channelEnd);
+    expect(blockBody.length).toBeLessThanOrEqual(3000);
+  });
 });
 
 const W: WorkerCore = { coreId: 'wm-worker', domain: 'WM', machine: 'any', label: '🛠 WmWorker' };

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-cadence-worker.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-cadence-worker.ts
@@ -33,6 +33,7 @@ import {
   type CoreSpeakFn,
 } from './agent-cadence-state';
 import { loadSkinPersona } from './agent-cadence-skin';
+import { fetchTeamBusContext as defaultFetchTeamBusContext } from './team-bus-fetcher';
 
 // ── WorkerCore ───────────────────────────────────────────────
 export interface WorkerCore {
@@ -436,23 +437,23 @@ export async function runWorkerConsumerOnce(
     let specText: string | undefined;
     try { specText = fs.readFileSync(path.join(memoRoot, chosen.file), 'utf-8'); } catch { specText = undefined; }
 
-    // KAR-018-LT-W1: chat=state inject. fetch 실패·미주입 = undefined → 5입력
-    // 호환(블록 미포함). Phase 1 = deps 통과로 면적 0(LT-W1-WIRE 가 wire).
+    // KAR-018-LT-W1: chat=state inject. deps 미주입 = module-level fallback
+    // (LT-W1-WIRE: main.ts startup 이 setTeamBusContextFetcher 로 wire).
+    // fetch 실패·wire 안 됨 = undefined → 5입력 호환(블록 미포함).
+    const fetchCtx = deps.fetchTeamBusContext ?? defaultFetchTeamBusContext;
     let channelContext: string | undefined;
-    if (deps.fetchTeamBusContext) {
-      try {
-        channelContext = await deps.fetchTeamBusContext(20);
-      } catch (e) {
-        // chat=state fetch 실패 = silent X (drift trace 1줄). 워커는 5입력
-        // fallback 으로 계속 — 채팅 read 만 누락, TASK 실행 자체는 진행.
-        appendTrace(env, {
-          ts: new Date().toISOString(),
-          type: 'drift',
-          core: w.coreId,
-          reason: `team-bus-fetch-fail: ${String(e).replace(/\s+/g, ' ').slice(0, 200)}`,
-        });
-        channelContext = undefined;
-      }
+    try {
+      channelContext = await fetchCtx(20);
+    } catch (e) {
+      // chat=state fetch 실패 = silent X (drift trace 1줄). 워커는 5입력
+      // fallback 으로 계속 — 채팅 read 만 누락, TASK 실행 자체는 진행.
+      appendTrace(env, {
+        ts: new Date().toISOString(),
+        type: 'drift',
+        core: w.coreId,
+        reason: `team-bus-fetch-fail: ${String(e).replace(/\s+/g, ' ').slice(0, 200)}`,
+      });
+      channelContext = undefined;
     }
 
     const req: Tier3Request = {

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-cadence-worker.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-cadence-worker.ts
@@ -92,6 +92,10 @@ export function detectDecisionNeeded(
 
 /**
  * 워커 tier3 지시 프롬프트 (순수). autopilot 안전 룰셋.
+ *
+ * channelContext (KAR-018-LT-W1) = #team-bus 최근 발언. 빈 문자열·undefined
+ * 면 블록 미포함(5입력 호환). 워커가 자기·동료 직전 발언을 read 하여 같은
+ * 사유 반복 announce 를 cite/dedupe 하라는 chat=state substrate 진입.
  */
 export function buildWorkerPrompt(
   task: { id: string; file: string },
@@ -99,6 +103,7 @@ export function buildWorkerPrompt(
   specText?: string,
   worktreeBranch?: string,
   decisionsText?: string,
+  channelContext?: string,
 ): string {
   const specBlock = specText
     ? [
@@ -109,6 +114,17 @@ export function buildWorkerPrompt(
         '',
       ]
     : [`[스펙 파일] ${task.file} (내용 임베드 실패 — cwd 내 단서로 진단)`, ''];
+  const channelBlock = channelContext && channelContext.trim()
+    ? [
+        `[팀 최근 채팅 — 너·동료들의 직전 발언. 같은 사유·결론 반복 X.`,
+        `이미 누군가 같은 (TASK·에러) announce 했으면 그 사실을 cite 하고`,
+        `다른 가설/접근으로 진입하거나 멈춰라. 새 정보·관점이면 응답·반응.]`,
+        '<<<CHANNEL',
+        channelContext.trim().slice(0, 3000),
+        'CHANNEL',
+        '',
+      ]
+    : [];
   const step2 = worktreeBranch
     ? [
         `2. 너는 *이미* 격리 worktree(현재 cwd) 안, 브랜치 \`${worktreeBranch}\``,
@@ -131,6 +147,7 @@ export function buildWorkerPrompt(
     `(룰·TASK 정본)는 여기 없음. 스펙은 아래 [TASK 스펙] 본문이 정본.`,
     '',
     ...(decisionsText ? [decisionsText, ''] : []),
+    ...channelBlock,
     ...specBlock,
     '[절차]',
     `1. 위 [TASK 스펙] 본문 + cwd 내 코드·정본 정독. 진단 우선(가설 박기 X).`,
@@ -236,6 +253,12 @@ export interface WorkerConsumerDeps {
   notify?: NotifyFn;
   speak?: CoreSpeakFn;
   voice?: (prompt: string) => Promise<string>;
+  /**
+   * #team-bus 최근 N 발언 fetch (KAR-018-LT-W1). 미주입 = chat=state 비활성
+   * (현행 5입력 호환). 실패 시 undefined 반환(silent X — 호출 측이 fallback).
+   * Phase 2 (LT-W1-WIRE) 가 main.ts startup 에서 wire.
+   */
+  fetchTeamBusContext?: (limit: number) => Promise<string | undefined>;
   missionText?: string;
 }
 
@@ -413,6 +436,25 @@ export async function runWorkerConsumerOnce(
     let specText: string | undefined;
     try { specText = fs.readFileSync(path.join(memoRoot, chosen.file), 'utf-8'); } catch { specText = undefined; }
 
+    // KAR-018-LT-W1: chat=state inject. fetch 실패·미주입 = undefined → 5입력
+    // 호환(블록 미포함). Phase 1 = deps 통과로 면적 0(LT-W1-WIRE 가 wire).
+    let channelContext: string | undefined;
+    if (deps.fetchTeamBusContext) {
+      try {
+        channelContext = await deps.fetchTeamBusContext(20);
+      } catch (e) {
+        // chat=state fetch 실패 = silent X (drift trace 1줄). 워커는 5입력
+        // fallback 으로 계속 — 채팅 read 만 누락, TASK 실행 자체는 진행.
+        appendTrace(env, {
+          ts: new Date().toISOString(),
+          type: 'drift',
+          core: w.coreId,
+          reason: `team-bus-fetch-fail: ${String(e).replace(/\s+/g, ' ').slice(0, 200)}`,
+        });
+        channelContext = undefined;
+      }
+    }
+
     const req: Tier3Request = {
       core: w.coreId,
       machine: w.machine,
@@ -422,6 +464,7 @@ export async function runWorkerConsumerOnce(
         specText,
         wt?.branch,
         formatDecisionsBlock(getDecisionsForTask(memoRoot, chosen.id)) || undefined,
+        channelContext,
       ),
       repoCwd: wt?.cwd,
     };

--- a/apps/discord-bots/apps/yawnbot/src/bot/team-bus-fetcher.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/team-bus-fetcher.ts
@@ -1,0 +1,35 @@
+/**
+ * team-bus-fetcher — #team-bus 최근 발언 fetch 의 모듈-레벨 setter/getter
+ * (KAR-018-LT-W1-WIRE).
+ *
+ * 패턴 = music-player 의 setMusicDiscordClient(line 226) 동형. main.ts 가
+ * Discord client / channel resolver 를 들고 있으므로, startup 에서 setter
+ * 호출 → cadence-worker.ts 가 import 해서 사용. 평행 인프라 X.
+ *
+ * Phase 1 (LT-W1) = WorkerConsumerDeps.fetchTeamBusContext seam.
+ * Phase 2 (본 모듈) = production wire. deps 미주입 시 module-level fallback.
+ */
+export type TeamBusContextFetcher =
+  (limit: number) => Promise<string | undefined>;
+
+let provider: TeamBusContextFetcher | null = null;
+
+/**
+ * main.ts 가 startup(clientReady) 에서 호출. null 전달 = wire 해제(shutdown).
+ */
+export function setTeamBusContextFetcher(
+  fn: TeamBusContextFetcher | null,
+): void {
+  provider = fn;
+}
+
+/**
+ * 워커가 호출. wire 안 됐으면 undefined(채팅 input 누락 = 5입력 fallback).
+ * 실패 시 throw — 호출 측(processWorker) drift trace 잡고 fallback.
+ */
+export async function fetchTeamBusContext(
+  limit: number,
+): Promise<string | undefined> {
+  if (!provider) return undefined;
+  return provider(limit);
+}

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -46,6 +46,7 @@ import {
 import { startPresenceRotation, stopPresenceRotation } from './bot/presence-rotation';
 import { handleAssistantMessage } from './bot/assistant-handler';
 import { isTeamRoomMessage, setBudgetReserve, agentChannelId } from './bot/team-room';
+import { setTeamBusContextFetcher } from './bot/team-bus-fetcher';
 import { isOwnAgentWebhook, sendAsSkin } from './bot/agent-webhook';
 import { buildGovernanceReserve, setTeamBusNotify } from './bot/governance-adapter';
 import { setProposalAnnouncer } from './bot/proposal-adapter';
@@ -278,6 +279,22 @@ mountLocalWebhook(app, client as any);
 
 client.once('clientReady', async () => {
   setMusicDiscordClient(client);
+  // KAR-018-LT-W1-WIRE: 워커 prompt 에 #team-bus 최근 발언 inject seam wire.
+  // 워커 spawn 시점에 lazily 호출 — agentChannelId() 는 provisioning 완료
+  // 후에도 fresh(channelIdFor 가 매번 resolver). wire 안 되면 cadence-worker
+  // 의 fallback = undefined → 5입력 호환.
+  setTeamBusContextFetcher(async (limit) => {
+    const id = agentChannelId();
+    if (!id) return undefined;
+    const ch = await client.channels.fetch(id);
+    if (!ch || !ch.isTextBased()) return undefined;
+    const msgs = await ch.messages.fetch({ limit });
+    return Array.from(msgs.values())
+      .reverse()
+      .map((m) => `[${m.author?.username || '?'}] ${(m.content || '').slice(0, 300)}`)
+      .filter((s) => s.trim().length > 0)
+      .join('\n');
+  });
   console.log(`\n  ⚔️  YawnBot (Node.js)`);
   console.log(`  ─────────────────────────`);
   console.log(`  로그인: ${client.user?.tag}`);
@@ -658,6 +675,7 @@ async function gracefulShutdown(reason: string): Promise<void> {
     await reportShutdown(opsCtx, reason);
   }
   setMusicDiscordClient(null);
+  setTeamBusContextFetcher(null);
   stopPresenceRotation();
   stopHeartbeat();
   stopCharacterStateSnapshot();


### PR DESCRIPTION
## Summary

KAR-018-LT 부모의 워커 측 substrate 결손 fix Phase 1.

- `buildWorkerPrompt` 5→6 입력. 6번째 `channelContext` 가 `#team-bus` 최근 발언 inject. undefined/빈 = 5입력 호환 (회귀 0).
- `WorkerConsumerDeps.fetchTeamBusContext?(limit)` deps seam. **Phase 2 = LT-W1-WIRE (별 시드)** 가 main.ts startup 에서 Discord `channel.messages.fetch` wire.
- fetch 실패 = silent X (drift trace + 5입력 fallback).
- 3000자 cap (prompt 폭주 가드).

## 진단 (코드 실증)

`buildWorkerPrompt` 시그니처는 5입력 = `task / mission / spec / worktree / decisions` — **채팅 input 0**. 12시간 24회 반복 announce (KarWorker/WmSupport/KlWorker — 같은 `Claude CLI 종료 코드 1`) 의 코드-레벨 결손.

워커가 자기·동료 직전 발언을 read 못 함 → 30분 cooldown 후 다시 announce → cite·반응·합의 0 = "채팅 = state" 비전 미달.

자세한 진단 = `memo/tasks/TASK-KAR-018-LT-W1-워커-chat-state-prompt-inject.md`.

## Substrate-first 체크

- 새 인프라 X — 기존 `WorkerConsumerDeps` 패턴 확장 (`speak`/`voice`/`notify` 와 동형).
- 새 데이터 원장 X — Phase 2 가 Discord REST 또는 기존 `agent-worker-raw.jsonl` 선택.
- `buildWorkerPrompt` 어셈블리 패턴 그대로 (`decisionsText` 옆 `channelBlock`, `specBlock` 동일 `<<<` 패턴).

## ⚠ Phase 1 단독 머지 = 실효 0

`fetchTeamBusContext` 미주입 (Phase 1) = channelContext undefined = 5입력 호환 = 워커 prompt 변화 0 = 12시간 반복 해소 0.

**Phase 2 (LT-W1-WIRE) 필수.** 본 PR 은 deps interface 확장만 — behavior-verify 는 Phase 2 와 묶임. 정직.

## Test plan

- [x] Vitest 528/47 pass (worktree)
- [x] tsc --noEmit GREEN
- [x] 새 test 3개: 블록 포함 / 빈입력 5입력 호환 / 3000자 cap
- [ ] Phase 2 (LT-W1-WIRE) 머지 후 prod ≥6h 관측: 동일 (task, errHash) 의 2회차 announce 가 1회차 cite 하면 PASS
- [ ] 회귀 메트릭: agent-worker-raw.jsonl 의 (taskId, errSlug) 반복 분포 (전: 24/12h, 후: ≤3/12h 기대)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 봇의 작업자 프롬프트에 최근 팀 채널 대화 컨텍스트를 자동으로 포함하여 더 나은 의사결정을 지원합니다.

* **테스트**
  * 채널 컨텍스트 기능의 포괄적인 검증 테스트를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->