### PR TITLE
fix(KAR-MASTER-RED): verify 순서 — karmolab-ai build 먼저

### DIFF
--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -24,16 +24,22 @@ function requireDeps(sub) {
 
 console.log('[verify] master invariant 게이트 시작');
 
-// 1. apps/karmolab — build (typecheck 포함). 이전 karmolab-ts.yml + ai-quality.yml karmolab-ai-surface 흡수.
-requireDeps('apps/karmolab');
-run('apps/karmolab build', 'apps/karmolab', 'npm run build');
-
-// 2. packages/karmolab-ai — build. 이전 ai-quality.yml shared-ai-package-build 흡수.
-if (existsSync('packages/karmolab-ai/node_modules')) {
+// 1. packages/karmolab-ai — build *먼저* (apps/karmolab 의 의존성, dist 가
+//    있어야 import 해소). 이전 ai-quality.yml shared-ai-package-build 흡수.
+//    TASK-KAR-MASTER-RED (5/19~ 6+연속 RED 진단): 순서가 거꾸로면 apps/karmolab
+//    build 가 karmolab-ai/dist 부재로 "Could not resolve" RED. workspace
+//    hoist 환경에서 packages/karmolab-ai/node_modules 가 별도로 안 만들어질
+//    수 있어 guard 는 dist 부재 체크로 변경(silent skip 차단).
+if (!existsSync('packages/karmolab-ai/dist')) {
   run('packages/karmolab-ai build', 'packages/karmolab-ai', 'npm run build');
 } else {
-  console.log('[verify] ! packages/karmolab-ai/node_modules 없음 — build skip (정합: cd packages/karmolab-ai && npm ci)');
+  console.log('[verify] ! packages/karmolab-ai/dist 존재 — build skip (이미 빌드됨)');
 }
+
+// 2. apps/karmolab — build (typecheck 포함). karmolab-ai/dist 를 import.
+//    이전 karmolab-ts.yml + ai-quality.yml karmolab-ai-surface 흡수.
+requireDeps('apps/karmolab');
+run('apps/karmolab build', 'apps/karmolab', 'npm run build');
 
 // 2.9. Tauri externalBin host-triple placeholder 보장 (TASK-KAR-073 / KL-052 회귀 fix).
 //      tauri.conf.json `externalBin: ["binaries/karmolab-life-ml"]` 은 sidecar 를


### PR DESCRIPTION
## Summary

master verify 5/19부터 **6+ 연속 RED** 의 근본 fix.

- `apps/karmolab` build 가 `karmolab-ai/dist` import. dist 가 *먼저* 만들어져야 esbuild resolve.
- 옛 순서 = apps/karmolab → karmolab-ai. dist 부재로 첫 step 즉시 fail.
- 새 순서 = karmolab-ai build → apps/karmolab build.
- guard 도 `node_modules` 부재 → `dist` 부재로 변경. workspace hoist 환경에서 packages/karmolab-ai/node_modules 가 별도로 안 만들어질 수 있어 silent skip 의 잠복 위험 차단.

## 진단 source

PR #124 verify FAIL log:
```
src/gemini.ts:29:7: ERROR: Could not resolve "karmolab-ai"
  The module "./dist/index.js" was not found
  node_modules/karmolab-ai/package.json:11:17 "default": "./dist/index.js"
```

`gh run list --workflow=verify.yml --branch master --limit 5` = 5연속 같은 에러. 본 PR 의 변경 무관, origin substrate.

## 자기 검증

PR verify CI = 변경된 verify.mjs 자체로 실행 → GREEN 이면 fix 작동 증명.

## Test plan

- [ ] PR verify CI GREEN (자기 검증)
- [ ] 머지 후 master verify GREEN (회귀 완전 해소)
- [ ] autopilot Draft PR 들 (적치된 것 있으면) verify 재트리거 시 GREEN