### PR TITLE
refactor(KAR-018-LT-RENAME): LT 워커 prefix autopilot → agent-team (R-3)

### DIFF
--- a/.github/workflows/agent-team-graduate.yml
+++ b/.github/workflows/agent-team-graduate.yml
@@ -19,8 +19,7 @@ name: Agent Team Graduate
 #   재-verify 안 도는 케이스)도 영구 stuck 안 됨. 이미 merged/ready 면 가드가 skip.
 #
 # 화이트리스트 = head_branch prefix (author 무관, spoof 불가):
-#   - `feature/agent-team-task-*` (R-3 prefix rename 후 정본)
-#   - `feature/autopilot-task-*`  (R-3 미완 마이그 호환, LT-RENAME 완결 후 제거)
+#   - `feature/agent-team-task-*` (LT 워커 정본 prefix)
 #   - `fix/issue-*` / `feature/issue-*` (claude.yml § claude-triage 자동 fix PR)
 #
 # PAT 사용 (GITHUB_TOKEN 아님): GITHUB_TOKEN 머지는 GitHub 재귀 방지로 master push
@@ -80,7 +79,7 @@ jobs:
           fi
           # 가드 2 — head_branch prefix 화이트리스트 (author spoof 불가)
           case "$headRef" in
-            feature/agent-team-task-*|feature/autopilot-task-*|fix/issue-*|feature/issue-*) ;;
+            feature/agent-team-task-*|fix/issue-*|feature/issue-*) ;;
             *) echo "PR #$num head '$headRef' = 화이트리스트 prefix 아님 — skip"; exit 0 ;;
           esac
           # 가드 3 — claude-pr-review 리뷰 완료 (코멘트 푸터 존재)

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-worker-repo.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-worker-repo.test.ts
@@ -53,15 +53,15 @@ describe('tsStamp / workerBranchName / workerWorktreeDir (순수·결정적)', (
     expect(tsStamp(NOW)).toBe('2605171306');
   });
 
-  it('workerBranchName = feature/autopilot + 소문자 슬러그 + ts', () => {
+  it('workerBranchName = feature/agent-team + 소문자 슬러그 + ts', () => {
     expect(workerBranchName('TASK-WM-084', NOW)).toBe(
-      'feature/autopilot-task-wm-084-2605171306',
+      'feature/agent-team-task-wm-084-2605171306',
     );
   });
 
   it('workerBranchName 특수문자 → 단일 하이픈·양끝 trim', () => {
     expect(workerBranchName('TASK-KL-055-B', NOW)).toBe(
-      'feature/autopilot-task-kl-055-b-2605171306',
+      'feature/agent-team-task-kl-055-b-2605171306',
     );
   });
 

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-worker-repo.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-worker-repo.ts
@@ -57,12 +57,14 @@ export function tsStamp(now: Date): string {
 }
 
 /**
- * autopilot 안전 룰셋 브랜치명. autopilot-graduate.yml 이 `feature/*`
+ * LT 워커 브랜치명. agent-team-graduate.yml 이 화이트리스트 prefix
  * head 를 졸업시키므로 prefix 고정. taskId 소문자 + ts = 재실행 충돌 0.
+ * 정본 = TASK-KAR-018-LT-RENAME R-1/R-3 (substrate⊥skin 정합 — autopilot
+ * skill 과 LT 워커 정체성 분리).
  */
 export function workerBranchName(taskId: string, now: Date): string {
   const slug = taskId.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-  return `feature/autopilot-${slug}-${tsStamp(now)}`;
+  return `feature/agent-team-${slug}-${tsStamp(now)}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

TASK-KAR-018-LT-RENAME § **R-3** 구현 — LT 워커 push branch prefix 를 `feature/autopilot-task-*` → `feature/agent-team-task-*` 로 rename. substrate⊥skin 정체성 정합 (autopilot skill 자체 폐기, LT 워커가 그 prefix 차용한 leftover 떼기).

- **agent-worker-repo.ts:65** — `workerBranchName()` 의 prefix 토큰 단일 변경
- **agent-worker-repo.test.ts:56,58,64** — 동행 회귀 테스트 expectation
- **agent-team-graduate.yml** — `feature/autopilot-task-*` 마이그 호환 라인 자기소멸 (코멘트 + case 분기). 워커가 옛 prefix 더 이상 push 안 하므로 즉시 dead code.

## Test plan

- [x] 단위: `vitest run agent-worker-repo` GREEN 11/11 (워크트리 격리 검증)
- [ ] CI: push 트리거 `verify.yml` GREEN (변경은 verify scope 무관 = blast radius 0)
- [ ] behavior-verify: 다음 LT 워커 cycle 이 신 prefix 로 push → claude-pr-review → graduate workflow_run 양조건 평가 → ready → auto-merge squash → progressLog delta (R-3 자체는 unit + workflow yml 검토로 충분, behavior-verify 는 TASK 시드 R-5 종주 항목)

## 정본

- 시드: `memo/tasks/TASK-KAR-018-LT-RENAME-워커-브랜치-prefix-이름-정합.md`
- 부모: TASK-KAR-018-LT (살아있는 팀)
- 관련: TASK-KAR-073, TASK-KAR-081

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 자동 작업 처리 워크플로의 브랜치 화이트리스트를 업데이트하여, 특정 prefix의 Pull Request만 자동 처리 대상으로 지정.

* **Tests**
  * 자동 작업 브랜치 생성 로직의 테스트 기대값을 업데이트.

* **Refactor**
  * 자동 작업 브랜치 생성 규칙을 변경하여 새로운 naming convention 적용.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->