### PR TITLE
feat(KAR-018-LT-FORUM P1-P3): 작업 카드 substrate = #team-work forum

### DIFF
--- a/apps/discord-bots/apps/yawnbot/data/channel-spec.json
+++ b/apps/discord-bots/apps/yawnbot/data/channel-spec.json
@@ -36,6 +36,30 @@
 			"key": "dashboard",
 			"name": "dashboard",
 			"topic": "에이전트 팀 현황 대시보드 — edit-in-place (KAR-077)"
+		},
+		{
+			"_doc": "에이전트 팀 작업 카드 substrate (TASK-KAR-018-LT-FORUM). 1포스트=1흐름객체 (discovery→proposal→in-progress→verdict→done). 태그 12개 / 3 그룹: kind(3) + status(5) + domain(4). status 만 exclusive 토글. announceProposal·worker-report·verdict 가 이 채널 사용, #team-bus 텍스트는 hb·digest 그대로.",
+			"key": "agent-work",
+			"name": "team-work",
+			"type": "GuildForum",
+			"topic": "에이전트 팀 작업 카드 — 1포스트=1흐름객체 (TASK-KAR-018-LT-FORUM)",
+			"forum": {
+				"defaultAutoArchiveDuration": 1440,
+				"availableTags": [
+					{ "name": "proposal", "emoji": "💡" },
+					{ "name": "worker-report", "emoji": "🤖" },
+					{ "name": "discovery", "emoji": "🔍" },
+					{ "name": "pending", "emoji": "🟡" },
+					{ "name": "in-progress", "emoji": "⏳" },
+					{ "name": "approved", "emoji": "✅" },
+					{ "name": "rejected", "emoji": "❌" },
+					{ "name": "done", "emoji": "🏁" },
+					{ "name": "WM", "emoji": "🧙" },
+					{ "name": "KAR", "emoji": "🛰" },
+					{ "name": "YB", "emoji": "📣" },
+					{ "name": "KL", "emoji": "🧪" }
+				]
+			}
 		}
 	]
 }

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-bus.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-bus.ts
@@ -1,19 +1,18 @@
 /**
- * agent-bus — ⑦' 발굴을 *사람이 팔로업 가능한* 디스코드 가시층 (KAR-018-V).
+ * agent-bus — ⑦' 발굴을 *사람이 팔로업 가능한* 디스코드 가시층.
  *
  * 문제(사용자 2026-05-17): 익명 "🛰 에이전트 팀" 한 줄 로그 → 누가/뭘
- * 제안했는지·왜·뭘 하면 되는지 알 수 없음. "각 에이전트가 구분되는 게
- * 아니잖아요 … 제가 원하던 게 아니에요".
+ * 제안했는지·왜·뭘 하면 되는지 알 수 없음.
  *
- * V-1: 발굴 = **명명 에이전트(atlas …)가 자기 이름·아바타로** 읽을 수
- * 있는 카드 게시 → 그 메시지를 **스레드**로 (당신 아이디어 채택) →
- * 스레드 안에 *전문* + 승인/거절/질문 안내. 메시지↔발굴id 매핑 영속
- * (V-2 리액션 승인이 소비). 평행정의0 — 코어 정체성은 기존 sub-A0/A
- * 소비(재정의 X), 인박스·승인 seam 재사용.
- *
- * 왜 embed(봇)이고 sendAsSkin(webhook) 아닌가: sendAsSkin 은 메시지 id
- * 미반환 → 스레드·리액션 매핑 불가. embed.author 로 *명명 정체성*은
- * 충족하면서 메시지 객체 확보(스레드·매핑) = V-1 실용 최선.
+ * substrate 진화:
+ *  - V-1 (2026-05-17): 텍스트 채널(#team-bus) 카드 + 스레드 + ✅/❌ react.
+ *    명명 에이전트 정체성으로 누가/뭘 박힘.
+ *  - LT-FORUM (2026-05-20): 작업 카드 substrate = 포럼 채널(#team-work).
+ *    1포스트=1흐름객체 (discovery→proposal→verdict→done). announceProposal /
+ *    reconcileProposalCards 가 forum-post.ts 단일 seam 경유 — 평행 정의 0.
+ *    #team-bus 텍스트는 hb/digest/escalate 1줄용으로 유지(변경 0).
+ *    handleProposalReaction = forum starter message 의 ✅/❌ react 그대로
+ *    소비(Discord 사양상 forum-post.starter.id == thread.id, 매핑 호환).
  */
 import fs from 'fs';
 import path from 'path';
@@ -21,7 +20,6 @@ import { EmbedBuilder } from 'discord.js';
 import type {
   Client,
   TextChannel,
-  Message,
   MessageReaction,
   PartialMessageReaction,
   User,
@@ -38,22 +36,13 @@ import {
   type TeamVerdict,
 } from './proposal-adapter';
 import { loadCoreDef, appendCoreMemory } from '../services/agent-core';
-import { sendAsSkin, WebhookPermissionError } from './agent-webhook';
-import type { CharacterCard } from '../services/character-service';
-
-/** ann.agent → sendAsSkin 용 최소 카드 (이름·아바타만 — 실 카드 불요). */
-function identityCard(ann: ProposalAnnouncement, name: string): CharacterCard {
-  return {
-    slug: ann.agent?.coreId || 'atlas',
-    name,
-    displayName: name,
-    frontmatter: ann.agent?.avatarUrl
-      ? { avatar_url: ann.agent.avatarUrl }
-      : {},
-    body: '',
-    dir: '',
-  } as unknown as CharacterCard;
-}
+import {
+  createForumPost,
+  evolveForumPost,
+  type ClientLike,
+  type ForumStatus,
+  type ForumDomain,
+} from './forum-post';
 
 export interface ProposalAnnouncement {
   /** 결정적 발굴 id (proposalId) — 승인 매칭 키. */
@@ -493,13 +482,28 @@ const VERDICT_STATE: Record<TeamVerdict, CardState> = {
   escalate: 'team-escalate',
 };
 
+/** CardState → forum 의 status 태그 매핑 (#team-work 태그 토글 정합). */
+const STATE_TO_FORUM_STATUS: Record<CardState, ForumStatus> = {
+  approved: 'approved',
+  rejected: 'rejected',
+  'team-adopt': 'in-progress', // 팀 채택 → 진행(사람 veto 여지)
+  'team-adopt-mods': 'approved', // 수정 채택 = 원본 supersede
+  'team-reject': 'rejected',
+  'team-escalate': 'pending', // 사장 결정 대기
+};
+
 /**
- * 팀 verdict 내구 원장 → 원본 카드 반영 (client 쥔 쪽 = main.ts 타이머).
+ * 팀 verdict 내구 원장 → 원본 forum-post 반영 (client 쥔 쪽 = main.ts 타이머).
  * 멱등·restart-safe(reflected 마커). adopt = 팀이 *행동* —
  * appendApproval(core:team)+inbox consumer 로 inert seed/draft 생성
  * (자동 실행 X = 진짜 게이트 seed→ready 불변). reject/escalate =
  * 카드 상태만(미잠금 — 사장님 veto/override 유효). best-effort:
- * 카드/채널 실패해도 throw X, 단 *반영 성공분만* 마커(재시도 가능).
+ * 채널/포스트 실패해도 throw X, 단 *반영 성공분만* 마커(재시도 가능).
+ *
+ * LT-FORUM 마이그: forum-post 의 evolveForumPost 단일 seam 경유 —
+ * embed edit(starter 카드) + status 태그 토글 + 스레드 결과 한 줄 누적.
+ * Legacy 텍스트 카드 entries(threadId 없는 옛 데이터) = 닫고 다음(degraded,
+ * verdict 자체는 원장 보존). 평행 정의 0.
  * @returns 이번에 카드 반영한 건수.
  */
 export async function reconcileProposalCards(
@@ -510,28 +514,13 @@ export async function reconcileProposalCards(
   let n = 0;
   for (const v of pending) {
     const entry = lookupProposalById(env, v.id);
-    if (!entry || !entry.channelId) {
-      // 카드 매핑/채널 없음(게시 실패·구버전 엔트리) — 더 기다려도
-      // 안 생김. 마커 찍어 무한 재시도 0 (verdict 는 원장/trace 영속).
+    if (!entry || !entry.channelId || !entry.threadId) {
+      // 카드 매핑/채널/스레드 없음(게시 실패·forum 마이그 전 legacy) —
+      // 더 기다려도 안 생김. 마커 찍어 무한 재시도 0.
       markCardReflected(env, v.id);
       continue;
     }
     try {
-      const channel = await client.channels
-        .fetch(entry.channelId)
-        .catch(() => null);
-      if (!channel || !channel.isTextBased() || !('messages' in channel)) {
-        // 채널 일시 fetch 실패 = 마커 미기록(다음 tick 재시도).
-        continue;
-      }
-      const msg = await (channel as TextChannel).messages
-        .fetch(entry.messageId)
-        .catch(() => null);
-      if (!msg) {
-        // 메시지 삭제됨 — 재시도 무의미. 마커 찍고 verdict 는 원장에.
-        markCardReflected(env, v.id);
-        continue;
-      }
       const state = VERDICT_STATE[v.verdict];
       let resultLine: string;
       if (v.verdict === 'adopt') {
@@ -556,27 +545,49 @@ export async function reconcileProposalCards(
       } else {
         resultLine = `🧑‍🤝‍🧑 팀이 수렴 못 함 — 사장님 ✅/❌ 결정 필요 · ${v.reason}`;
       }
-      const src = msg.embeds?.[0];
-      if (src) {
-        const eb = applyCardEmbedState(
-          src,
-          state,
-          resultLine,
-          '🧑‍🤝‍🧑 팀 토론 결과',
-        );
-        await msg.edit({ embeds: [eb] }).catch(() => {});
-      }
-      // 스레드에도 결과 한 줄 (카드 못 봐도 사람 팔로업).
-      if (entry.threadId) {
-        const th = await client.channels
-          .fetch(entry.threadId)
-          .catch(() => null);
-        if (th && th.isTextBased() && 'send' in th) {
-          await (th as TextChannel)
-            .send(resultLine.slice(0, 1900))
-            .catch(() => {});
+      // forum starter 의 source embed → applyCardEmbedState 로 진화된 embed
+      // 만들기. 채널 fetch 실패 = 일시(continue, 다음 tick 재시도).
+      const channel = (await client.channels
+        .fetch(entry.channelId)
+        .catch(() => null)) as unknown as
+        | (Awaited<ReturnType<ClientLike['channels']['fetch']>> & {
+            threads?: {
+              fetch: (id: string) => Promise<unknown>;
+            };
+          })
+        | null;
+      if (!channel) continue;
+      const thread = (await channel?.threads
+        ?.fetch(entry.threadId)
+        .catch(() => null)) as
+        | (Awaited<ReturnType<NonNullable<typeof channel.threads>['fetch']>> & {
+            fetchStarterMessage?: () => Promise<{
+              embeds?: { data?: unknown }[];
+            } | null>;
+          })
+        | null;
+      let editedEmbed: EmbedBuilder | undefined;
+      if (thread && typeof thread.fetchStarterMessage === 'function') {
+        const starter = await thread.fetchStarterMessage().catch(() => null);
+        const src = (starter?.embeds as { data?: unknown }[] | undefined)?.[0];
+        if (src) {
+          editedEmbed = applyCardEmbedState(
+            (src.data ?? src) as Parameters<typeof EmbedBuilder.from>[0],
+            state,
+            resultLine,
+            '🧑‍🤝‍🧑 팀 토론 결과',
+          );
         }
       }
+      await evolveForumPost(
+        client as unknown as ClientLike,
+        { postId: entry.threadId, channelId: entry.channelId },
+        {
+          embedEdit: editedEmbed,
+          statusTag: STATE_TO_FORUM_STATUS[state],
+          threadMessage: resultLine,
+        },
+      );
       markCardReflected(env, v.id);
       n += 1;
     } catch {
@@ -586,12 +597,24 @@ export async function reconcileProposalCards(
   return n;
 }
 
-/**
- * 발굴 1건을 #team-bus 에 *명명 에이전트 카드 + 스레드*로 게시.
- * embed.author = 에이전트(이름/아바타) → 익명 X, 누가 가 보임.
- * 스레드 안 = 전문 + 승인/거절/질문 안내. 매핑 영속(V-2 소비).
- * best-effort: 채널·권한 실패해도 throw X (발굴 파이프 비차단).
- */
+/** ProposalAnnouncement → forum domain 태그. payload.domain 우선,
+ *  coreId prefix 폴백, 기본 KAR. */
+function resolveDomain(ann: ProposalAnnouncement): ForumDomain {
+  const p = ann.envelope.payload as unknown as Record<string, unknown>;
+  const raw = (typeof p?.domain === 'string' ? p.domain : '')
+    .trim()
+    .toLowerCase();
+  if (raw === 'wm') return 'WM';
+  if (raw === 'kl' || raw === 'karmolab') return 'KL';
+  if (raw === 'yb' || raw === 'yawnbot') return 'YB';
+  if (raw === 'kar' || raw === 'karmoddrine') return 'KAR';
+  const cid = (ann.agent?.coreId || '').toLowerCase();
+  if (cid.startsWith('wm')) return 'WM';
+  if (cid.startsWith('kl')) return 'KL';
+  if (cid.startsWith('yb') || cid === 'echo') return 'YB';
+  return 'KAR';
+}
+
 /**
  * 카드 앞 동료 한 줄 — **결정적**(LLM 호출 X), KAR-018-Y 근본.
  *
@@ -631,10 +654,19 @@ function atlasVoicedIntro(
   return variants[h % variants.length];
 }
 
+/**
+ * 발굴 1건을 #team-work forum 채널에 *1포스트=1흐름객체* 로 게시
+ * (TASK-KAR-018-LT-FORUM 마이그). starter embed = 명명 에이전트 카드,
+ * appliedTags = [kind, pending, domain]. 스레드 첫 메시지 = atlas voiced
+ * intro, 두 번째 메시지 = 전문 + 승인/거절/질문 안내. starter 에 ✅/❌
+ * react (사람 결정 인터페이스, handleProposalReaction 호환).
+ *
+ * best-effort: forum 미프로비저닝(handle=null) → 콘솔 경고 후 skip.
+ * #team-bus 텍스트 폴백 X — 평행 정의 회피 (자기소멸 마이그 정합).
+ */
 export async function announceProposal(
   client: Client,
   env: NodeJS.ProcessEnv,
-  channelIds: string[],
   ann: ProposalAnnouncement,
 ): Promise<void> {
   const agentName = ann.agent?.name || '🛰 Atlas';
@@ -642,7 +674,6 @@ export async function announceProposal(
   const safeTitle = (title || '(제목 없음)').slice(0, 230);
   const kindLabel = KIND_LABEL[ann.kind] ?? ann.kind;
   const onApprove = KIND_ONAPPROVE[ann.kind] ?? '검토 단계로 넘어갑니다';
-  // R-2: atlas 가 카드 전에 자기 목소리로 운다 (주도적 동료).
   const intro = await atlasVoicedIntro(
     env,
     ann.agent?.coreId || 'atlas',
@@ -650,98 +681,73 @@ export async function announceProposal(
     cardBody,
   );
 
-  for (const channelId of channelIds) {
-    const channel = await client.channels
-      .fetch(channelId)
-      .catch(() => null);
-    if (!channel || !channel.isTextBased() || !('send' in channel)) continue;
+  const embed = new EmbedBuilder()
+    .setColor(COLOR_BY_KIND[ann.kind] ?? 0x4caf50)
+    .setAuthor({
+      name: `🛰 ${agentName} 의 제안`,
+      iconURL: ann.agent?.avatarUrl,
+    })
+    .setTitle(`💡 ${safeTitle}`)
+    .addFields(
+      {
+        name: '📋 무엇 / 왜',
+        value: (cardBody || '(내용 없음)').slice(0, 1000),
+      },
+      { name: '🏷️ 분류', value: kindLabel, inline: true },
+      { name: '🆔', value: `\`${ann.id}\``, inline: true },
+      { name: '📌 상태', value: '🟡 승인 대기', inline: true },
+      { name: '✅ 승인하면', value: onApprove },
+    )
+    .setFooter({
+      text: '✅ 승인  ·  ❌ 거절  ·  ▸ 스레드에서 자세히/질문  |  먼저 누른 결정이 확정·잠금',
+    })
+    .setTimestamp();
 
-    // 구조화 카드 — 사장이 스캔 가능. 상세·근거는 ▸ 스레드.
-    const embed = new EmbedBuilder()
-      .setColor(COLOR_BY_KIND[ann.kind] ?? 0x4caf50)
-      .setAuthor({
-        name: `🛰 ${agentName} 의 제안`,
-        iconURL: ann.agent?.avatarUrl,
-      })
-      .setTitle(`💡 ${safeTitle}`)
-      .addFields(
-        {
-          name: '📋 무엇 / 왜',
-          value: (cardBody || '(내용 없음)').slice(0, 1000),
-        },
-        { name: '🏷️ 분류', value: kindLabel, inline: true },
-        { name: '🆔', value: `\`${ann.id}\``, inline: true },
-        { name: '📌 상태', value: '🟡 승인 대기', inline: true },
-        { name: '✅ 승인하면', value: onApprove },
-      )
-      .setFooter({
-        text: '✅ 승인  ·  ❌ 거절  ·  ▸ 스레드에서 자세히/질문  |  먼저 누른 결정이 확정·잠금',
-      })
-      .setTimestamp();
+  const handle = await createForumPost(
+    client as unknown as ClientLike,
+    env,
+    {
+      kind: 'proposal',
+      domain: resolveDomain(ann),
+      title: `제안 ${ann.id}: ${safeTitle}`,
+      embed,
+      intro: intro || undefined,
+    },
+  );
+  if (!handle) {
+    console.warn(
+      '[agent-bus] #team-work forum 미프로비저닝 — 제안 카드 게시 skip:',
+      ann.id,
+    );
+    return;
+  }
 
-    try {
-      // R-2: atlas 가 *먼저 자기 목소리로* 운다 → 그 다음 정식 카드.
-      // 이름 = 봇앱("YawnDev") 아니라 *에이전트 정체*(webhook username
-      // =displayName, sub-A sendAsSkin). 권한 없으면 봇 send 폴백.
-      if (intro) {
-        const body = intro.slice(0, 1800);
-        try {
-          await sendAsSkin(
-            channel as TextChannel,
-            identityCard(ann, agentName),
-            { content: body },
-          );
-        } catch (e) {
-          if (!(e instanceof WebhookPermissionError)) {
-            console.error(
-              '[agent-bus] intro 송신 오류:',
-              e instanceof Error ? e.message : e,
-            );
-          }
-          await (channel as TextChannel)
-            .send({ content: body })
-            .catch(() => {});
+  // 진입 후속 — 스레드 상세 메시지 + starter ✅/❌ react.
+  // Discord 사양: forum-post 의 starter message id == thread id.
+  try {
+    const channel = (await client.channels
+      .fetch(handle.channelId)
+      .catch(() => null)) as unknown as
+      | {
+          threads?: {
+            fetch: (id: string) => Promise<unknown>;
+          };
         }
-      }
-      // R-5 정체통일: 카드도 *에이전트 정체* webhook 게시(봇앱 YawnDev
-      // X). hook.send 반환 id 로 fetch → react/startThread (스레드·리액션
-      // 매핑 유지). WebhookPermissionError·실패 = 봇 embed fallback
-      // (기존 동작·회귀0·graceful — 권한 없어도 카드는 뜸).
-      let msg: Message | null = null;
-      try {
-        const sentId = await sendAsSkin(
-          channel as TextChannel,
-          identityCard(ann, agentName),
-          { content: '', embeds: [embed] },
-        );
-        if (sentId) {
-          msg = await (channel as TextChannel).messages
-            .fetch(sentId)
-            .catch(() => null);
-        }
-      } catch (e) {
-        if (!(e instanceof WebhookPermissionError)) {
-          console.error(
-            '[agent-bus] 카드 정체 송신 오류:',
-            e instanceof Error ? e.message : e,
-          );
-        }
-      }
-      if (!msg) {
-        msg = await (channel as TextChannel).send({ embeds: [embed] });
-      }
-      await msg.react('✅').catch(() => {});
-      await msg.react('❌').catch(() => {});
-
-      let threadId = '';
-      try {
-        const thread = await msg.startThread({
-          name: `제안 ${ann.id}: ${safeTitle}`.slice(0, 95),
-          autoArchiveDuration: 1440,
-        });
-        threadId = thread.id;
-        await thread.send(
-          `**${agentName}** 의 제안 — 자세히\n\n` +
+      | null;
+    const thread = (await channel?.threads
+      ?.fetch(handle.postId)
+      .catch(() => null)) as
+      | (TextChannel & {
+          fetchStarterMessage?: () => Promise<{
+            react: (e: string) => Promise<unknown>;
+          } | null>;
+        })
+      | null;
+    if (thread && 'send' in thread) {
+      await thread
+        .send({
+          content:
+            `**${agentName}** 의 제안 — 자세히\n\n` +
             `**${safeTitle}**\n\n${detailBody.slice(0, 3500)}\n\n` +
             `────────\n` +
             `**어떻게 하나요?**\n` +
@@ -750,28 +756,34 @@ export async function announceProposal(
             `· 이 스레드에 **답글** = 질문/수정요청 (검토에 반영)\n` +
             `· 누르면 **여기 스레드에 처리 결과가 답글로 달립니다** (접수→완료)\n` +
             `· 규칙: 먼저 누른 결정이 확정. 확정 후 추가/취소 반응은 무시.`,
-        );
-      } catch {
-        /* 스레드 실패해도 카드는 떴음 (degraded) */
-      }
-
-      appendProposalMsg(env, {
-        messageId: msg.id,
-        threadId,
-        channelId: msg.channelId, // KAR-018-LT: verdict reconciler 메시지 fetch
-        id: ann.id,
-        kind: ann.kind,
-        target: ann.target,
-        title: safeTitle,
-        ts: new Date().toISOString(),
-        coreId: ann.agent?.coreId, // Z-2: 결과를 이 코어 mem 에 학습
-      });
-    } catch (e) {
-      console.error(
-        '[agent-bus] 발굴 카드 게시 실패:',
-        channelId,
-        e instanceof Error ? e.message : e,
-      );
+        })
+        .catch(() => {});
     }
+    if (thread && typeof thread.fetchStarterMessage === 'function') {
+      const starter = await thread.fetchStarterMessage().catch(() => null);
+      if (starter) {
+        await starter.react('✅').catch(() => {});
+        await starter.react('❌').catch(() => {});
+      }
+    }
+  } catch (e) {
+    console.error(
+      '[agent-bus] forum-post 후속 처리 실패:',
+      e instanceof Error ? e.message : e,
+    );
   }
+
+  // 매핑 영속 — forum 사양상 starter msg id == thread id, 둘 다 postId.
+  // ProposalMsgEntry 그대로 — verdict reconciler / handleProposalReaction 호환.
+  appendProposalMsg(env, {
+    messageId: handle.postId,
+    threadId: handle.postId,
+    channelId: handle.channelId,
+    id: ann.id,
+    kind: ann.kind,
+    target: ann.target,
+    title: safeTitle,
+    ts: new Date().toISOString(),
+    coreId: ann.agent?.coreId,
+  });
 }

--- a/apps/discord-bots/apps/yawnbot/src/bot/forum-post.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/forum-post.test.ts
@@ -1,0 +1,284 @@
+/**
+ * forum-post — 1포스트=1흐름객체 단일 seam 행동 테스트 (TASK-KAR-018-LT-FORUM P2).
+ *
+ * 검증 = 진화 모델 1 사이클: 생성(create) → 진화(evolve: embed+status+thread)
+ * → 종결(archive). 평행 정의 0 / deep module / silent best-effort.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  createForumPost,
+  evolveForumPost,
+  archiveForumPost,
+  type AvailableTag,
+  type ClientLike,
+  type ForumChannelLike,
+  type ThreadChannelLike,
+  type StarterMessageLike,
+} from './forum-post';
+
+const TAGS_SPEC: { name: string; id: string }[] = [
+  { name: 'proposal', id: 't-prop' },
+  { name: 'worker-report', id: 't-wr' },
+  { name: 'discovery', id: 't-disc' },
+  { name: 'pending', id: 't-pend' },
+  { name: 'in-progress', id: 't-ip' },
+  { name: 'approved', id: 't-app' },
+  { name: 'rejected', id: 't-rej' },
+  { name: 'done', id: 't-done' },
+  { name: 'WM', id: 't-wm' },
+  { name: 'KAR', id: 't-kar' },
+  { name: 'YB', id: 't-yb' },
+  { name: 'KL', id: 't-kl' },
+];
+
+interface CreateCall {
+  name: string;
+  message: { embeds?: unknown[]; content?: string };
+  appliedTags?: string[];
+  autoArchiveDuration?: number;
+}
+
+interface FakeForum {
+  client: ClientLike;
+  channel: ForumChannelLike;
+  threads: Map<string, FakeThread>;
+  createCalls: CreateCall[];
+}
+
+interface FakeThread extends ThreadChannelLike {
+  sendCalls: { content?: string; embeds?: unknown[] }[];
+  starterEdits: { embeds?: unknown[]; content?: string }[];
+  setTagsCalls: string[][];
+  archivedCalls: boolean[];
+}
+
+function buildFakeForum(opts: {
+  channelId: string;
+  availableTags?: AvailableTag[];
+}): FakeForum {
+  const tags = opts.availableTags ?? TAGS_SPEC.map((t) => ({ ...t }));
+  const threads = new Map<string, FakeThread>();
+  const createCalls: CreateCall[] = [];
+  let seq = 0;
+  const channel: ForumChannelLike = {
+    id: opts.channelId,
+    type: 15, // discord.js ChannelType.GuildForum = 15
+    availableTags: tags,
+    threads: {
+      create: async (o) => {
+        createCalls.push(o);
+        const id = `th-${++seq}`;
+        const starterEdits: { embeds?: unknown[]; content?: string }[] = [];
+        const starter: StarterMessageLike = {
+          edit: async (e) => {
+            starterEdits.push(e);
+          },
+        };
+        const sendCalls: { content?: string; embeds?: unknown[] }[] = [];
+        const setTagsCalls: string[][] = [];
+        const archivedCalls: boolean[] = [];
+        const thread: FakeThread = {
+          id,
+          appliedTags: [...(o.appliedTags ?? [])],
+          send: async (m) => {
+            sendCalls.push(m);
+          },
+          fetchStarterMessage: async () => starter,
+          setAppliedTags: async (ids) => {
+            setTagsCalls.push([...ids]);
+            thread.appliedTags = [...ids];
+          },
+          setArchived: async (b) => {
+            archivedCalls.push(b);
+          },
+          sendCalls,
+          starterEdits,
+          setTagsCalls,
+          archivedCalls,
+        };
+        threads.set(id, thread);
+        return thread;
+      },
+      fetch: async (id) => threads.get(id) ?? null,
+    },
+  };
+  const client: ClientLike = {
+    channels: {
+      fetch: async (id) => (id === opts.channelId ? channel : null),
+    },
+  };
+  return { client, channel, threads, createCalls };
+}
+
+const PROV_ENV = {
+  YAWNBOT_ALLOWED_GUILD_IDS: 'g1',
+  // channelIdFor('agent-work') = provisionedId → 없음 → env 폴백 = 없음 → null.
+  // 테스트는 env 미설정이라도 reconcile 후 rememberMap 으로 박은 ID 가 쓰임.
+} as unknown as NodeJS.ProcessEnv;
+
+describe('forum-post — 진입 (createForumPost)', () => {
+  it('channelId null = null 반환 (provision 미설정 + env 없음)', async () => {
+    const { client } = buildFakeForum({ channelId: 'ch-fw' });
+    const r = await createForumPost(client, {} as NodeJS.ProcessEnv, {
+      kind: 'proposal',
+      domain: 'WM',
+      title: '테스트',
+      embed: { title: 'x' },
+    });
+    expect(r).toBeNull();
+  });
+
+  it('포스트 생성: 카드 embed + 태그 3 (kind+pending+domain) + 1440 archive', async () => {
+    const { client, channel, createCalls } = buildFakeForum({ channelId: 'ch-fw' });
+    const env = { YAWNBOT_AGENT_WORK_CHANNEL_ID: 'ch-fw' } as unknown as NodeJS.ProcessEnv;
+    // channelIdFor('agent-work') = ENV_KEY_BY_LOGICAL 매핑 없음 → env 폴백 X.
+    // → rememberMap 으로 직접 박음 (테스트 환경).
+    const { rememberMap } = await import('../services/channel-provision');
+    rememberMap('g1', { 'agent-work': 'ch-fw' }, {
+      YAWNBOT_ALLOWED_GUILD_IDS: 'g1',
+    } as NodeJS.ProcessEnv);
+    const r = await createForumPost(
+      client,
+      { YAWNBOT_ALLOWED_GUILD_IDS: 'g1' } as NodeJS.ProcessEnv,
+      {
+        kind: 'proposal',
+        domain: 'KAR',
+        title: 'foo bar 제안',
+        embed: { description: '제안 본문' },
+        intro: 'atlas voiced intro',
+      },
+    );
+    expect(r).not.toBeNull();
+    expect(r!.channelId).toBe('ch-fw');
+    expect(createCalls.length).toBe(1);
+    const c = createCalls[0];
+    expect(c.name).toBe('foo bar 제안');
+    expect(c.message.embeds).toEqual([{ description: '제안 본문' }]);
+    expect(c.appliedTags).toEqual(['t-prop', 't-pend', 't-kar']);
+    expect(c.autoArchiveDuration).toBe(1440);
+    // intro = 첫 스레드 메시지
+    const thread = (channel.threads as unknown as { fetch: (id: string) => Promise<FakeThread | null> });
+    const th = await thread.fetch(r!.postId);
+    expect(th!.sendCalls.length).toBe(1);
+    expect(th!.sendCalls[0].content).toBe('atlas voiced intro');
+    void env;
+  });
+
+  it('title 100자 절단', async () => {
+    const { client, createCalls } = buildFakeForum({ channelId: 'ch-fw2' });
+    const { rememberMap } = await import('../services/channel-provision');
+    rememberMap('g1', { 'agent-work': 'ch-fw2' }, {
+      YAWNBOT_ALLOWED_GUILD_IDS: 'g1',
+    } as NodeJS.ProcessEnv);
+    const long = 'A'.repeat(200);
+    await createForumPost(
+      client,
+      { YAWNBOT_ALLOWED_GUILD_IDS: 'g1' } as NodeJS.ProcessEnv,
+      { kind: 'discovery', domain: 'YB', title: long, embed: {} },
+    );
+    expect(createCalls[0].name.length).toBe(100);
+  });
+});
+
+describe('forum-post — 진화 (evolveForumPost)', () => {
+  async function setupPost(channelId: string): Promise<{
+    forum: FakeForum;
+    handle: { postId: string; channelId: string };
+  }> {
+    const forum = buildFakeForum({ channelId });
+    const { rememberMap } = await import('../services/channel-provision');
+    rememberMap('g1', { 'agent-work': channelId }, {
+      YAWNBOT_ALLOWED_GUILD_IDS: 'g1',
+    } as NodeJS.ProcessEnv);
+    const handle = await createForumPost(
+      forum.client,
+      { YAWNBOT_ALLOWED_GUILD_IDS: 'g1' } as NodeJS.ProcessEnv,
+      {
+        kind: 'proposal',
+        domain: 'WM',
+        title: '시작',
+        embed: { v: 1 },
+      },
+    );
+    return { forum, handle: handle! };
+  }
+
+  it('embedEdit = starter message edit 호출', async () => {
+    const { forum, handle } = await setupPost('ch-ev1');
+    await evolveForumPost(forum.client, handle, {
+      embedEdit: { v: 2, status: 'updated' },
+    });
+    const th = forum.threads.get(handle.postId)!;
+    expect(th.starterEdits.length).toBe(1);
+    expect(th.starterEdits[0].embeds).toEqual([{ v: 2, status: 'updated' }]);
+  });
+
+  it('statusTag = 기존 status 만 교체 (kind/domain 보존)', async () => {
+    const { forum, handle } = await setupPost('ch-ev2');
+    // 진입 = [proposal, pending, WM] = [t-prop, t-pend, t-wm]
+    await evolveForumPost(forum.client, handle, { statusTag: 'in-progress' });
+    const th = forum.threads.get(handle.postId)!;
+    expect(th.setTagsCalls.length).toBe(1);
+    const next = th.setTagsCalls[0].sort();
+    expect(next).toEqual(['t-ip', 't-prop', 't-wm'].sort());
+  });
+
+  it('statusTag 연속 전이 = pending → in-progress → done (toggle exclusive)', async () => {
+    const { forum, handle } = await setupPost('ch-ev3');
+    await evolveForumPost(forum.client, handle, { statusTag: 'in-progress' });
+    await evolveForumPost(forum.client, handle, { statusTag: 'done' });
+    const th = forum.threads.get(handle.postId)!;
+    expect(th.appliedTags.sort()).toEqual(['t-done', 't-prop', 't-wm'].sort());
+  });
+
+  it('threadMessage = thread.send 추가 (intro 후 누적)', async () => {
+    const { forum, handle } = await setupPost('ch-ev4');
+    await evolveForumPost(forum.client, handle, {
+      threadMessage: 'verdict: approved (KarWorker 픽업)',
+    });
+    const th = forum.threads.get(handle.postId)!;
+    expect(th.sendCalls.some((m) => m.content?.includes('verdict'))).toBe(true);
+  });
+
+  it('embed + status + threadMessage 동시 = 3 호출 다 발생', async () => {
+    const { forum, handle } = await setupPost('ch-ev5');
+    await evolveForumPost(forum.client, handle, {
+      embedEdit: { v: 9 },
+      statusTag: 'approved',
+      threadMessage: '결정',
+    });
+    const th = forum.threads.get(handle.postId)!;
+    expect(th.starterEdits.length).toBe(1);
+    expect(th.setTagsCalls.length).toBe(1);
+    expect(th.sendCalls.some((m) => m.content === '결정')).toBe(true);
+  });
+
+  it('channel fetch 실패 = silent skip (throw X)', async () => {
+    const broken: ClientLike = { channels: { fetch: async () => null } };
+    await expect(
+      evolveForumPost(broken, { postId: 'x', channelId: 'y' }, {
+        statusTag: 'done',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('forum-post — 종결 (archiveForumPost)', () => {
+  it('setArchived(true) 호출 — lock=false (Discord native)', async () => {
+    const forum = buildFakeForum({ channelId: 'ch-arc' });
+    const { rememberMap } = await import('../services/channel-provision');
+    rememberMap('g1', { 'agent-work': 'ch-arc' }, {
+      YAWNBOT_ALLOWED_GUILD_IDS: 'g1',
+    } as NodeJS.ProcessEnv);
+    const handle = await createForumPost(
+      forum.client,
+      { YAWNBOT_ALLOWED_GUILD_IDS: 'g1' } as NodeJS.ProcessEnv,
+      { kind: 'worker-report', domain: 'KL', title: '완료', embed: {} },
+    );
+    await archiveForumPost(forum.client, handle!);
+    const th = forum.threads.get(handle!.postId)!;
+    expect(th.archivedCalls).toEqual([true]);
+  });
+});
+
+void PROV_ENV;

--- a/apps/discord-bots/apps/yawnbot/src/bot/forum-post.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/forum-post.ts
@@ -1,0 +1,206 @@
+/**
+ * 작업 카드 substrate — 1포스트 = 1 흐름 객체 (TASK-KAR-018-LT-FORUM P2).
+ *
+ * 비전: discovery → proposal → in-progress → verdict → done 이
+ * *같은 forum-post* 의 시간축 전이. 카드(starter embed) edit + 태그 토글 +
+ * 스레드 메시지 push 가 같은 객체 위에 누적. 평행 기록 X.
+ *
+ * 단일 seam — announceProposal · worker-report · verdict · archive 가
+ * 전부 이 모듈 4 함수만 호출. 이 모듈 삭제 = forum 흐름 전체 작동 X
+ * (deletion test, code-style.md § Deep Modules).
+ *
+ * 채널 = `agent-work` 논리 키 (channel-spec.json type=GuildForum,
+ *        availableTags 12 / 3 그룹: kind(3)+status(5)+domain(4)).
+ * 안전: channelId null (provision OFF + env 미설정) = null 반환 (degraded,
+ *       호출자가 본인 폴백 결정 — 기존 #team-bus 텍스트 등).
+ */
+import { channelIdFor } from '../services/channel-provision';
+
+/** 진화 가능한 포스트 = 1 흐름 객체 핸들. */
+export interface ForumPostHandle {
+  /** 포스트 = 스레드 id (forum-post 는 thread). */
+  postId: string;
+  /** team-work forum 채널 id. */
+  channelId: string;
+}
+
+export type ForumKind = 'proposal' | 'worker-report' | 'discovery';
+export type ForumStatus = 'pending' | 'in-progress' | 'approved' | 'rejected' | 'done';
+export type ForumDomain = 'WM' | 'KAR' | 'YB' | 'KL';
+
+const ALL_STATUS: ForumStatus[] = [
+  'pending',
+  'in-progress',
+  'approved',
+  'rejected',
+  'done',
+];
+
+// ── discord.js v14 ForumChannel / ThreadChannel / Message 의 구조적
+//    부분집합. 페이크 client 단위 테스트 가능, 실 코드 변경 0 (deep module). ──
+
+export interface AvailableTag {
+  id: string;
+  name: string;
+}
+
+export interface StarterMessageLike {
+  edit(opts: { embeds?: unknown[]; content?: string }): Promise<unknown>;
+}
+
+export interface ThreadChannelLike {
+  id: string;
+  /** 현재 적용된 태그 id 목록 (discord.js 동형). */
+  appliedTags: string[];
+  send(opts: { content?: string; embeds?: unknown[] }): Promise<unknown>;
+  fetchStarterMessage(): Promise<StarterMessageLike | null>;
+  setAppliedTags(tagIds: string[]): Promise<unknown>;
+  setArchived(archived: boolean): Promise<unknown>;
+}
+
+export interface ForumChannelLike {
+  id: string;
+  /** GuildForumChannel 식별 — 페이크/실 모두 명시. */
+  type: number;
+  availableTags: AvailableTag[];
+  threads: {
+    create(opts: {
+      name: string;
+      message: { embeds?: unknown[]; content?: string };
+      appliedTags?: string[];
+      autoArchiveDuration?: number;
+    }): Promise<ThreadChannelLike>;
+    /** 진화/종결 시 postId 로 thread 다시 fetch (discord.js ThreadManager.fetch 동형). */
+    fetch(id: string): Promise<ThreadChannelLike | null>;
+  };
+}
+
+export interface ClientLike {
+  channels: {
+    fetch(id: string): Promise<ForumChannelLike | null>;
+  };
+}
+
+/** 태그 이름들 → 채널 availableTags 의 id 들. 누락은 silent skip(spec 동기 lag). */
+function resolveTagIds(
+  available: AvailableTag[],
+  wantNames: string[],
+): string[] {
+  const byName = new Map(available.map((t) => [t.name, t.id]));
+  return wantNames
+    .map((n) => byName.get(n))
+    .filter((id): id is string => typeof id === 'string');
+}
+
+/**
+ * 진입 — 1 흐름 객체 생성. 호출자: announceProposal / announceWorkerReport /
+ * discovery 카드화.
+ *
+ * @returns null = forum 채널 미프로비저닝 + env 미설정 (호출자가 폴백 결정).
+ */
+export async function createForumPost(
+  client: ClientLike,
+  env: NodeJS.ProcessEnv,
+  args: {
+    kind: ForumKind;
+    domain: ForumDomain;
+    title: string;
+    embed: unknown;
+    /** 첫 스레드 메시지 (atlas voiced intro 등). 비면 스레드 메시지 X. */
+    intro?: string;
+  },
+): Promise<ForumPostHandle | null> {
+  const channelId = channelIdFor('agent-work', env);
+  if (!channelId) return null;
+  const channel = await client.channels.fetch(channelId).catch(() => null);
+  if (!channel || !Array.isArray(channel.availableTags)) return null;
+  const tagIds = resolveTagIds(channel.availableTags, [
+    args.kind,
+    'pending',
+    args.domain,
+  ]);
+  const name = (args.title || '(제목 없음)').slice(0, 100);
+  const thread = await channel.threads.create({
+    name,
+    message: { embeds: [args.embed] },
+    appliedTags: tagIds,
+    autoArchiveDuration: 1440,
+  });
+  if (args.intro) {
+    await thread.send({ content: args.intro.slice(0, 1900) }).catch(() => {});
+  }
+  return { postId: thread.id, channelId: channel.id };
+}
+
+/**
+ * 진화 — 같은 포스트의 시간축 전이. 호출자: deliberation verdict /
+ * worker 진행 노트 / TASK 매칭 / done 마킹.
+ *
+ * - embedEdit = starter message embed 갱신 (카드 본문 진화)
+ * - statusTag = 기존 status 태그 1개를 새 값으로 교체 (kind/domain 보존)
+ * - threadMessage = 스레드에 한 줄 누적 (verdict reason, 진행 노트 등)
+ *
+ * silent best-effort — 채널/메시지 fetch 실패 = degraded(throw X).
+ */
+export async function evolveForumPost(
+  client: ClientLike,
+  handle: ForumPostHandle,
+  change: {
+    embedEdit?: unknown;
+    statusTag?: ForumStatus;
+    threadMessage?: string;
+  },
+): Promise<void> {
+  const channel = await client.channels
+    .fetch(handle.channelId)
+    .catch(() => null);
+  if (!channel) return;
+  const thread = await fetchThread(channel, handle.postId);
+  if (!thread) return;
+  if (change.embedEdit !== undefined) {
+    const starter = await thread.fetchStarterMessage().catch(() => null);
+    if (starter) {
+      await starter.edit({ embeds: [change.embedEdit] }).catch(() => {});
+    }
+  }
+  if (change.statusTag) {
+    const statusIds = new Set(
+      resolveTagIds(channel.availableTags, ALL_STATUS),
+    );
+    const next = thread.appliedTags.filter((id) => !statusIds.has(id));
+    const newStatusId = resolveTagIds(channel.availableTags, [
+      change.statusTag,
+    ])[0];
+    if (newStatusId) next.push(newStatusId);
+    await thread.setAppliedTags(next).catch(() => {});
+  }
+  if (change.threadMessage) {
+    await thread
+      .send({ content: change.threadMessage.slice(0, 1900) })
+      .catch(() => {});
+  }
+}
+
+/**
+ * 종결 — done 태그 토글된 포스트를 native archive 로 접음. lock=false 유지 →
+ * 사람 retro 코멘트는 archive 해제·재open 가능 (Discord native UI).
+ */
+export async function archiveForumPost(
+  client: ClientLike,
+  handle: ForumPostHandle,
+): Promise<void> {
+  const channel = await client.channels
+    .fetch(handle.channelId)
+    .catch(() => null);
+  if (!channel) return;
+  const thread = await fetchThread(channel, handle.postId);
+  if (!thread) return;
+  await thread.setArchived(true).catch(() => {});
+}
+
+async function fetchThread(
+  channel: ForumChannelLike,
+  postId: string,
+): Promise<ThreadChannelLike | null> {
+  return channel.threads.fetch(postId).catch(() => null);
+}

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -448,9 +448,9 @@ client.once('clientReady', async () => {
     // 하드코딩 폐기, agents/ 디렉토리가 정본. 라우팅 default=atlas =
     // 기존 전량 atlas 행동 보존(회귀 0).
     setProposalAnnouncer(async (a) => {
-      const channelIds = agentCh
-        ? [agentCh]
-        : getLocalChannels('agent-team');
+      // LT-FORUM: 카드 substrate = #team-work forum 채널.
+      // channelIds 텍스트 라우팅 폐기 — channel-spec.json `agent-work` 키가
+      // forum 채널 단일 정본 (announceProposal 내부 createForumPost 경유).
       const payload = a.envelope.payload as unknown as Record<
         string,
         unknown
@@ -469,7 +469,7 @@ client.once('clientReady', async () => {
       const skinCard = coreDef
         ? characterService?.loadCard(coreDef.defaultSkin) ?? null
         : null;
-      await announceProposal(client as any, process.env, channelIds, {
+      await announceProposal(client as any, process.env, {
         ...a,
         agent: coreDef
           ? {

--- a/apps/discord-bots/apps/yawnbot/src/services/channel-provision.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/channel-provision.test.ts
@@ -30,7 +30,8 @@ function newGuildId(): string {
   return id;
 }
 
-/** discord.js GuildChannelManager 의 최소 구조적 페이크. create 는 id 증가 + cache push. */
+/** discord.js GuildChannelManager 의 최소 구조적 페이크. create 는 id 증가 + cache push.
+ *  GuildForum 채널은 availableTags 보관 + setAvailableTags 메소드 노출 (드리프트 sync 시뮬). */
 function fakeGuild(id: string, seed: ChannelLike[] = []): GuildLike {
   const channels = [...seed];
   let seq = 1000;
@@ -45,6 +46,12 @@ function fakeGuild(id: string, seed: ChannelLike[] = []): GuildLike {
           type: opts.type,
           parentId: opts.parent ?? null,
         };
+        if (opts.availableTags) ch.availableTags = [...opts.availableTags];
+        if (opts.type === ChannelType.GuildForum) {
+          ch.setAvailableTags = async (tags) => {
+            ch.availableTags = [...tags];
+          };
+        }
         channels.push(ch);
         return ch;
       },
@@ -116,7 +123,7 @@ describe('reconcileGuildChannels — 멱등 desired-state', () => {
       ...spec.channels.map((e) => ({
         id: r1.map[e.key],
         name: e.key === 'news' ? '잡담' : e.name,
-        type: ChannelType.GuildText,
+        type: e.type === 'GuildForum' ? ChannelType.GuildForum : ChannelType.GuildText,
         parentId: r1.map.__category,
       })),
     ]);
@@ -140,6 +147,12 @@ describe('reconcileGuildChannels — 멱등 desired-state', () => {
             type: o.type,
             parentId: o.parent ?? null,
           };
+          if (o.availableTags) c.availableTags = [...o.availableTags];
+          if (o.type === ChannelType.GuildForum) {
+            c.setAvailableTags = async (tags) => {
+              c.availableTags = [...tags];
+            };
+          }
           channels.push(c);
           return c;
         },
@@ -162,6 +175,79 @@ describe('reconcileGuildChannels — 멱등 desired-state', () => {
       const ch = channels.find((c) => c.id === rd.map[e.key]);
       expect(ch?.parentId).toBe(devCat);
     }
+  });
+});
+
+describe('reconcileGuildChannels — GuildForum (TASK-KAR-018-LT-FORUM)', () => {
+  it('agent-work entry = GuildForum 타입으로 생성 + availableTags 박힘', async () => {
+    const guild = fakeGuild(newGuildId());
+    const r = await reconcileGuildChannels(guild, spec, PROD);
+    expect(r.created).toContain('agent-work');
+    // cache 에서 실제 채널 객체 찾아 검증
+    const ch = guild.channels.cache.find((c) => c.id === r.map['agent-work']);
+    expect(ch).toBeDefined();
+    expect(ch!.type).toBe(ChannelType.GuildForum);
+    // spec 의 12개 태그가 그대로 박힘 (discord.js 형식 변환: emoji → { name })
+    const tagNames = (ch!.availableTags ?? []).map((t) => t.name).sort();
+    expect(tagNames).toContain('proposal');
+    expect(tagNames).toContain('worker-report');
+    expect(tagNames).toContain('discovery');
+    expect(tagNames).toContain('pending');
+    expect(tagNames).toContain('done');
+    expect(tagNames).toContain('WM');
+    expect(tagNames.length).toBe(12);
+    // emoji = { name: '<unicode>' } 형식
+    const proposalTag = (ch!.availableTags ?? []).find((t) => t.name === 'proposal');
+    expect(proposalTag?.emoji).toEqual({ name: '💡' });
+  });
+
+  it('두 번째 reconcile: forum 채널도 reused (멱등 + 태그 드리프트 sync)', async () => {
+    const guild = fakeGuild(newGuildId());
+    await reconcileGuildChannels(guild, spec, PROD);
+    // 외부에서 사용자가 태그 임의 제거 (드리프트 시뮬)
+    const forumCh = guild.channels.cache.find(
+      (c) => c.type === ChannelType.GuildForum,
+    );
+    expect(forumCh).toBeDefined();
+    forumCh!.availableTags = [{ name: 'orphan-tag' }];
+    const r2 = await reconcileGuildChannels(guild, spec, PROD);
+    expect(r2.created).toEqual([]);
+    expect(r2.reused).toContain('agent-work');
+    // setAvailableTags 가 호출돼 spec 정합으로 복원
+    expect((forumCh!.availableTags ?? []).map((t) => t.name).sort()).not.toContain(
+      'orphan-tag',
+    );
+    expect((forumCh!.availableTags ?? []).length).toBe(12);
+  });
+
+  it('같은 이름 forum 채널이 미리 있으면 claim (생성 X) + 태그 동기', async () => {
+    const gid = newGuildId();
+    const seed: ChannelLike[] = [
+      { id: 'cat-x', name: spec.categoryName, type: ChannelType.GuildCategory, parentId: null },
+      {
+        id: 'existing-forum',
+        name: 'team-work',
+        type: ChannelType.GuildForum,
+        parentId: 'cat-x',
+        availableTags: [{ name: 'legacy' }],
+        setAvailableTags: async function (this: ChannelLike, tags) {
+          this.availableTags = [...tags];
+        } as ChannelLike['setAvailableTags'],
+      },
+    ];
+    // setAvailableTags 의 this 바인딩 보정 — seed 채널 객체 자체에 박음
+    const existing = seed[1];
+    existing.setAvailableTags = async (tags) => {
+      existing.availableTags = [...tags];
+    };
+    const guild = fakeGuild(gid, seed);
+    const r = await reconcileGuildChannels(guild, spec, PROD);
+    expect(r.claimed).toContain('agent-work');
+    expect(r.created).not.toContain('agent-work');
+    expect(r.map['agent-work']).toBe('existing-forum');
+    // 태그 동기로 legacy 제거 + spec 12개 박힘
+    expect((existing.availableTags ?? []).map((t) => t.name)).not.toContain('legacy');
+    expect((existing.availableTags ?? []).length).toBe(12);
   });
 });
 

--- a/apps/discord-bots/apps/yawnbot/src/services/channel-provision.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/channel-provision.ts
@@ -38,17 +38,55 @@ function pkgRoot(): string {
 }
 const PKG_ROOT = pkgRoot();
 
+/** spec 의 forum 태그 (JSON 친화 — emoji = unicode 단일 문자). */
+export interface ForumTag {
+  name: string;
+  emoji?: string;
+  moderated?: boolean;
+}
+
+/** type=GuildForum 일 때만 적용되는 추가 설정. */
+export interface ForumConfig {
+  /** Discord native 값: 60 / 1440 / 4320 / 10080 (분). */
+  defaultAutoArchiveDuration?: number;
+  availableTags?: ForumTag[];
+}
+
 export interface ChannelSpecEntry {
   /** 논리 키 (코드·env 매핑 안정 식별자, 절대 안 바뀜). */
   key: string;
   /** 디스코드에 만들 채널 이름 (사용자가 바꿔도 저장 ID 로 추적). */
   name: string;
+  /** 채널 종류. 미지정 = GuildText (하위호환). */
+  type?: 'GuildText' | 'GuildForum';
   topic?: string;
+  /** type === 'GuildForum' 일 때만 의미. */
+  forum?: ForumConfig;
 }
 
 export interface ChannelSpec {
   categoryName: string;
   channels: ChannelSpecEntry[];
+}
+
+/** discord.js v14 GuildForumTagData 형식 (실 API 호출 시 패스). */
+export interface DiscordForumTagInput {
+  name: string;
+  emoji?: { id?: string | null; name?: string | null };
+  moderated?: boolean;
+}
+
+function specTagsToDiscord(tags: ForumTag[]): DiscordForumTagInput[] {
+  return tags.map((t) => ({
+    name: t.name,
+    ...(t.emoji ? { emoji: { name: t.emoji } } : {}),
+    ...(t.moderated !== undefined ? { moderated: t.moderated } : {}),
+  }));
+}
+
+/** entry 의 channel 종류 → discord.js ChannelType. 미지정 = GuildText (하위호환). */
+function entryChannelType(entry: ChannelSpecEntry): number {
+  return entry.type === 'GuildForum' ? ChannelType.GuildForum : ChannelType.GuildText;
 }
 
 /** 논리 키 → 기존 env 키. prod 우선·dev 폴백 매핑의 단일 정본 (평행정의 0). */
@@ -179,6 +217,10 @@ export interface ChannelLike {
   name: string;
   type: number;
   parentId?: string | null;
+  /** type === GuildForum 일 때만 의미. discord.js ForumChannel 구조적 부분집합. */
+  availableTags?: DiscordForumTagInput[];
+  /** ForumChannel 만 노출. spec 드리프트 동기용. */
+  setAvailableTags?: (tags: DiscordForumTagInput[]) => Promise<void>;
 }
 export interface GuildChannelManagerLike {
   cache: { find(fn: (c: ChannelLike) => boolean): ChannelLike | undefined };
@@ -187,6 +229,8 @@ export interface GuildChannelManagerLike {
     type: number;
     parent?: string | null;
     topic?: string;
+    availableTags?: DiscordForumTagInput[];
+    defaultAutoArchiveDuration?: number;
   }): Promise<ChannelLike>;
 }
 export interface GuildLike {
@@ -200,6 +244,21 @@ export interface ReconcileResult {
   created: string[];
   claimed: string[];
   reused: string[];
+}
+
+/**
+ * 기존 forum 채널 (reused/claimed) 의 availableTags 를 spec 정합 동기.
+ * 신규 생성은 create 옵션이 직접 박혀 호출 불요. best-effort — setAvailableTags
+ * 미지원 채널/페이크는 silent skip (드리프트만 잡으면 됨, 신규 채널엔 안전).
+ */
+async function syncForumTagsIfNeeded(
+  channel: ChannelLike,
+  entry: ChannelSpecEntry,
+): Promise<void> {
+  if (entry.type !== 'GuildForum') return;
+  if (!entry.forum?.availableTags) return;
+  if (!channel.setAvailableTags) return;
+  await channel.setAvailableTags(specTagsToDiscord(entry.forum.availableTags));
 }
 
 /**
@@ -247,28 +306,47 @@ export async function reconcileGuildChannels(
   // 2) 채널 — 이름 claim 을 *이 카테고리 하위로* 스코프 (다른 인스턴스의
   //    동일 이름 채널을 가로채지 않음 = prod↔dev 교차오염 차단).
   for (const entry of spec.channels) {
+    const wantType = entryChannelType(entry);
     const stored = byId(map[entry.key]);
-    if (stored && stored.type === ChannelType.GuildText) {
+    if (stored && stored.type === wantType) {
+      await syncForumTagsIfNeeded(stored, entry);
       reused.push(entry.key);
       continue;
     }
     const existing = guild.channels.cache.find(
       (c) =>
-        c.type === ChannelType.GuildText &&
+        c.type === wantType &&
         c.name === entry.name &&
         c.parentId === categoryId,
     );
     if (existing) {
       map[entry.key] = existing.id;
+      await syncForumTagsIfNeeded(existing, entry);
       claimed.push(entry.key);
       continue;
     }
-    const ch = await guild.channels.create({
+    const createOpts: {
+      name: string;
+      type: number;
+      parent?: string | null;
+      topic?: string;
+      availableTags?: DiscordForumTagInput[];
+      defaultAutoArchiveDuration?: number;
+    } = {
       name: entry.name,
-      type: ChannelType.GuildText,
+      type: wantType,
       parent: categoryId,
       topic: entry.topic,
-    });
+    };
+    if (wantType === ChannelType.GuildForum && entry.forum) {
+      if (entry.forum.availableTags) {
+        createOpts.availableTags = specTagsToDiscord(entry.forum.availableTags);
+      }
+      if (entry.forum.defaultAutoArchiveDuration) {
+        createOpts.defaultAutoArchiveDuration = entry.forum.defaultAutoArchiveDuration;
+      }
+    }
+    const ch = await guild.channels.create(createOpts);
     map[entry.key] = ch.id;
     created.push(entry.key);
   }


### PR DESCRIPTION
## Summary

작업 카드 substrate 를 디스코드 *포럼 채널* 로 격상 — 1포스트 = 1 흐름 객체 (discovery → proposal → in-progress → verdict → done).

정본: `memo/tasks/TASK-KAR-018-LT-FORUM-작업-포럼-substrate.md`

사용자 발화 (2026-05-20, 의역 X):
> "지금 에이전트 팀이 메시지로 대화 하려고 했는데, 작업은 포럼 쓰는게 더 좋아보이네."
> "어차피 발견 소스나 제안 카드나 Task나 하나의 흐름으로 변화하는 것 아닌지?"

### 변경 요약 (3 commits)

- **P1** `89001978` — `channel-spec.json` GuildForum 스키마 + `team-work` 엔트리 (태그 12 / kind·status·domain 3 그룹) + `channel-provision.ts` reconcile 분기
- **P2** `d06c3c2e` — `bot/forum-post.ts` 단일 seam: createForumPost / evolveForumPost / archiveForumPost (deep module · 좁은 seam)
- **P3** `7fcca65c` — `agent-bus.ts` announceProposal / reconcileProposalCards = forum-post 일원화 + `main.ts` caller 정리 (sendAsSkin webhook intro / 텍스트 카드 게시 / startThread 흐름 = 전부 자기소멸 마이그)

### 근본성

- 평행 정의 0 — 옛 텍스트 카드 게시 코드 *전부 삭제*, forum-post.ts 단일 경로
- deletion test ✓ — forum-post.ts 삭제 시 announceProposal/reconcile null short-circuit
- substrate-split 회피 — verdict 가 카드(=포스트) 위에 직접 박힘, 평행 기록 X
- #team-bus 텍스트 채널 = 변경 0 (hb / digest / escalate / dialogue 그대로)

### 후속 (별 PR)

P4 — worker-report 라우팅 + done 태그 시 native archive + discovery backlink + LT-12 다이제스트 측정 forcing-function

## Test plan

- [x] yawnbot vitest 50 files / 601 tests GREEN (P1 +3 / P2 +10 / P3 회귀 0)
- [x] tsc --noEmit GREEN
- [ ] master 머지 후 prod 자동 배포 (deploy-discord-bots.yml, 노트북 nssm restart)
- [ ] 디스코드 욘봇 카테고리에 `#team-work` 포럼 채널 자동 생성·태그 12 동기 (channel-provision reconcile)
- [ ] 다음 제안 발화 시 카드가 `#team-work` 포스트로 박히는지 관측
- [ ] 팀 verdict 발생 시 같은 포스트의 starter embed 진화 + status 태그 토글 + 스레드 결과 한 줄 누적 관측

🤖 Generated with [Claude Code](https://claude.com/claude-code)