### PR TITLE
feat(KL-073+074): sync Tauri commands → async + spawn_blocking (KL-043 패턴)

### DIFF
--- a/apps/karmolab-tauri/src-tauri/src/activity.rs
+++ b/apps/karmolab-tauri/src-tauri/src/activity.rs
@@ -273,14 +273,19 @@ pub struct DayActivity {
     pub samples: Vec<ActivitySample>,
 }
 
+/// 파일 I/O (JSONL 전체 읽기) — async + spawn_blocking (KL-043 / KL-073).
 #[tauri::command]
-pub fn activity_query_day<R: Runtime>(
+pub async fn activity_query_day<R: Runtime>(
     app: AppHandle<R>,
     day: String,
 ) -> Result<DayActivity, String> {
-    let state = app.state::<ActivityState>();
-    let samples = load_day(state.base_dir(), &day).map_err(|e| e.to_string())?;
-    Ok(DayActivity { day, samples })
+    let base_dir = app.state::<ActivityState>().base_dir().to_path_buf();
+    tauri::async_runtime::spawn_blocking(move || {
+        let samples = load_day(&base_dir, &day).map_err(|e| e.to_string())?;
+        Ok(DayActivity { day, samples })
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
 }
 
 #[tauri::command]
@@ -295,22 +300,26 @@ pub fn activity_status<R: Runtime>(app: AppHandle<R>) -> Result<serde_json::Valu
 
 /// 저장된 일자(YYYY-MM-DD, UTC 기준 파일명) 목록 — 정렬된 채로.
 /// 위젯의 "전체" 기간 모드가 사용. 디렉토리가 없거나 비었으면 빈 배열.
+/// read_dir 디렉토리 스캔 — async + spawn_blocking (KL-043 / KL-073).
 #[tauri::command]
-pub fn activity_list_days<R: Runtime>(app: AppHandle<R>) -> Result<Vec<String>, String> {
-    let state = app.state::<ActivityState>();
-    let dir = state.base_dir();
-    if !dir.exists() {
-        return Ok(Vec::new());
-    }
-    let mut days = Vec::new();
-    let entries = std::fs::read_dir(dir).map_err(|e| e.to_string())?;
-    for entry in entries.flatten() {
-        let name_os = entry.file_name();
-        let Some(name) = name_os.to_str() else { continue };
-        if let Some(stem) = name.strip_suffix(".jsonl") {
-            days.push(stem.to_string());
+pub async fn activity_list_days<R: Runtime>(app: AppHandle<R>) -> Result<Vec<String>, String> {
+    let dir = app.state::<ActivityState>().base_dir().to_path_buf();
+    tauri::async_runtime::spawn_blocking(move || {
+        if !dir.exists() {
+            return Ok(Vec::new());
         }
-    }
-    days.sort();
-    Ok(days)
+        let mut days = Vec::new();
+        let entries = std::fs::read_dir(&dir).map_err(|e| e.to_string())?;
+        for entry in entries.flatten() {
+            let name_os = entry.file_name();
+            let Some(name) = name_os.to_str() else { continue };
+            if let Some(stem) = name.strip_suffix(".jsonl") {
+                days.push(stem.to_string());
+            }
+        }
+        days.sort();
+        Ok(days)
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
 }

--- a/apps/karmolab-tauri/src-tauri/src/alarm.rs
+++ b/apps/karmolab-tauri/src-tauri/src/alarm.rs
@@ -813,16 +813,24 @@ pub fn ensure_autostart(app: &AppHandle) {
     }
 }
 
+/// 단일 파일 읽기 — async 전환 (alarm_set_autostart 와 일관성, KL-043 / KL-074).
 #[tauri::command]
-pub fn alarm_get_autostart(app: AppHandle) -> bool {
-    read_settings(&app).autostart
+pub async fn alarm_get_autostart(app: AppHandle) -> bool {
+    tauri::async_runtime::spawn_blocking(move || read_settings(&app).autostart)
+        .await
+        .unwrap_or(false)
 }
 
+/// external process spawn (reg.exe) — async + spawn_blocking (KL-043 / KL-074).
 #[tauri::command]
-pub fn alarm_set_autostart(enabled: bool, app: AppHandle) -> Result<(), String> {
-    apply_autostart(enabled)?;
-    write_settings(&app, &AlarmSettings { autostart: enabled });
-    Ok(())
+pub async fn alarm_set_autostart(enabled: bool, app: AppHandle) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        apply_autostart(enabled)?;
+        write_settings(&app, &AlarmSettings { autostart: enabled });
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
 }
 
 #[cfg(test)]

--- a/apps/karmolab-tauri/src-tauri/src/claude_env.rs
+++ b/apps/karmolab-tauri/src-tauri/src/claude_env.rs
@@ -441,16 +441,22 @@ fn preview_sound_blocking(
     Ok(())
 }
 
+/// .ps1 파일 2회 read_to_string — async + spawn_blocking (KL-043 / KL-073).
+/// write 버전(claude_env_write_notify_config)과 동일 패턴.
 #[tauri::command]
-pub fn claude_env_read_notify_config() -> Result<NotifyConfigDto, String> {
-    let root = karmoddrine_dotfiles_root()?;
-    let stop = parse_notify_ps1(&root.join("notify-stop.ps1"))?;
-    let notification = parse_notify_ps1(&root.join("notify-notification.ps1"))?;
-    Ok(NotifyConfigDto {
-        stop,
-        notification,
-        canonical_root: root.to_string_lossy().into_owned(),
+pub async fn claude_env_read_notify_config() -> Result<NotifyConfigDto, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        let root = karmoddrine_dotfiles_root()?;
+        let stop = parse_notify_ps1(&root.join("notify-stop.ps1"))?;
+        let notification = parse_notify_ps1(&root.join("notify-notification.ps1"))?;
+        Ok(NotifyConfigDto {
+            stop,
+            notification,
+            canonical_root: root.to_string_lossy().into_owned(),
+        })
     })
+    .await
+    .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
 }
 
 /// 정본 .ps1 두 개를 받은 config 로 편집 + `sync-claude-hooks.ps1` 호출.


### PR DESCRIPTION
## 요약

TASK-KL-073 + TASK-KL-074: sync `#[tauri::command]` 가 파일 I/O / 외부 프로세스 spawn 을 수행하던 위반 5개를 `async + tauri::async_runtime::spawn_blocking` 패턴으로 전환 (KL-043 룰 정합).

## 변경 내역

### TASK-KL-073 — activity.rs + claude_env.rs

| 함수 | 위반 | 변환 |
|---|---|---|
| `activity_query_day` | `load_day()` → JSONL 파일 전체 읽기 | `base_dir` PathBuf 추출 후 `spawn_blocking` |
| `activity_list_days` | `std::fs::read_dir()` 디렉토리 스캔 | `dir` PathBuf 추출 후 `spawn_blocking` |
| `claude_env_read_notify_config` | `parse_notify_ps1()` 2회 (`read_to_string`) | `spawn_blocking` (write 버전과 동일 패턴) |

### TASK-KL-074 — alarm.rs

| 함수 | 위반 | 변환 |
|---|---|---|
| `alarm_set_autostart` | `apply_autostart()` → `Command::new("reg").output()` | `enabled`, `app` move → `spawn_blocking` |
| `alarm_get_autostart` | `read_settings()` 단일 파일 읽기 | async 전환 (setter 일관성) |

## 설계 노트

- `activity_query_day` / `activity_list_days`: `AppHandle<R: Runtime>` 는 `spawn_blocking` 클로저로 이동 불가(`'static` 제약) → 필요한 `base_dir: PathBuf` 만 추출 후 이동. AppHandle 은 클로저 밖에서 소멸.
- ACL(`acl.toml`) 변경 없음 — 함수명 동일, `async` 추가만.
- `alarm_get_autostart` 반환 `bool`: `spawn_blocking` JoinError 시 `unwrap_or(false)` (panic 가능성 없음).

## 검증

`cargo check --all-targets` = CI verify gate. 클라우드 환경(GTK3 미설치)에서 로컬 실행 불가 → CI 결과로 확인.

Refs: TASK-KL-073, TASK-KL-074, TASK-KL-043 (KL-043 패턴 정본)

🤖 cloud-kl autopilot

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkVDjDx4LD8Bhy4J2FU5d7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 활동 조회, 알람 설정, 환경 설정 읽기 등 주요 기능의 내부 처리 성능을 최적화했습니다. 이를 통해 앱의 전반적인 응답성이 개선됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->