### PR TITLE
test(KAR-018-LT-W2-A): dispatcher.test 에 ClaudeCliError 전파 unit test 2개 추가

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/dispatcher.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/dispatcher.test.ts
@@ -139,6 +139,37 @@ describe('spawnTier3 — 오케스트레이션 (B-1/2/4)', () => {
     expect(d.registry.isBusy('atlas')).toBe(false); // finally release
   });
 
+  // TASK-KAR-018-LT-W2-A: cli-claude 가 stderrFull/stdoutFull/exitCode 를
+  // Error 객체에 부착 → spawnTier3 catch 분기에서 duck-type 추출해
+  // Tier3Result 의 해당 필드로 전파. 다음 세션 grep 진단 게이트의 데이터 줄.
+  it('ClaudeCliError shape 전파 — stderrFull/stdoutFull/exitCode 가 result 에 동봉', async () => {
+    const err = new Error('Claude CLI 종료 코드 1 (cwd=/repo): stderr=cap | stdout=cap') as
+      Error & { stderrFull?: string; stdoutFull?: string; exitCode?: number | null };
+    err.stderrFull = 'Not logged in · Please run /login\n[full backtrace ...]';
+    err.stdoutFull = 'partial stdout before failure';
+    err.exitCode = 1;
+    const d = deps({ run: vi.fn().mockRejectedValue(err) });
+    const res = await spawnTier3(req, d);
+    expect(res.status).toBe('error');
+    expect(res.error).toContain('Claude CLI 종료 코드 1');
+    expect(res.stderrFull).toContain('Not logged in');
+    expect(res.stdoutFull).toBe('partial stdout before failure');
+    expect(res.exitCode).toBe(1);
+    expect(d.registry.isBusy('atlas')).toBe(false);
+  });
+
+  // 일반 Error (cli-claude 외 — 타임아웃·spawn 실패 등) = 진단 필드 없이도
+  // status='error' + message 만으로 동작 (현행 동작 회귀 방지).
+  it('일반 Error (stderrFull 없음) = 진단 필드 undefined, 그래도 status=error', async () => {
+    const d = deps({ run: vi.fn().mockRejectedValue(new Error('타임아웃')) });
+    const res = await spawnTier3(req, d);
+    expect(res.status).toBe('error');
+    expect(res.error).toBe('타임아웃');
+    expect(res.stderrFull).toBeUndefined();
+    expect(res.stdoutFull).toBeUndefined();
+    expect(res.exitCode).toBeUndefined();
+  });
+
   it('done 후에도 release (재acquire 가능)', async () => {
     const d = deps();
     await spawnTier3(req, d);


### PR DESCRIPTION
## Summary

TASK-KAR-018-LT-W2 의 잔여 — dispatcher 의 `Error → Tier3Result` 변환 분기를 직접 검증하는 unit test 2개 추가. 본 PR 은 핵심 구현 (e5e0754d, master 已 머지) 의 *테스트 게이지* 만 보강.

- **신규 1**: `ClaudeCliError shape 전파` — duck-typed `stderrFull`/`stdoutFull`/`exitCode` 가 `Tier3Result` 의 동명 필드로 1:1 전파되는지 검증. 이게 다음 세션 grep 진단 게이트의 데이터 줄.
- **신규 2**: `일반 Error (stderrFull 없음)` 회귀 0 — 진단 필드 없는 일반 `Error` 도 `status=error` + `message` 로 계속 동작 (스펙 § "부재 시 — undefined, caller duck-type 검사" 정합).

### 배경

직전 branch `feature/agent-team-task-kar-018-lt-w2-2605201458` (commit `63aa423d`) 이 같은 패치를 만들었으나 환경문제로 push 봉쇄됨 → 본 branch 가 잔여 closeout. 동일 내용 1:1 포팅 (스펙 변경 X).

`cadence-worker.test` 의 integration 은 spawn mock 이 직접 `res` 객체를 반환 → dispatcher 의 *Error → Result* 변환 분기 자체는 cover 안 됨. 이 2 테스트가 그 구멍을 채움.

## Test plan

- [x] `dispatcher.test.ts` 20/20 PASS (vitest, 로컬)
- [x] 전체 yawnbot 테스트: 610/618 PASS — 8 fail 은 본 PR 무관 (master 동일 fail. 1efe2f18 "워커 claim 직후 #team-bus 착수 알림" 추가 후 `agent-cadence-worker.test.ts` 의 assertion stale. 별도 시드 필요)
- [ ] CI `verify.yml` 통과 확인 (post-push audit)

## 환경 메모 — pre-push 우회

본 worktree 환경에 Rust toolchain 미설치 → `npm run verify` 의 `cargo check` 게이트 부분이 `rustc -vV 실패` 로 stop → `.husky/pre-push` 실패. 본 패치는 *test 파일 단일 수정*, Rust 코드 미접근 → `git push --no-verify` (CLAUDE.md `§ Quality 게이트` 명시 응급 우회) 사용. CI `verify.yml` 가 server-side 에서 정식 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 오류 처리 시나리오에 대한 검증 테스트 추가: 진단 정보 전파 확인 및 일반 오류 메시지 보존 검증으로 시스템 안정성을 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->