### PR TITLE
fix(yawnbot): TASK 스레드 재기동-중복 root fix + pXXX thread key (TASK-KAR-018-THR)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -23,6 +23,8 @@ IIF = "IIF"          # build.mjs: IIFE 줄임 ('Immediately Invoked Function Exp
 mmaped = "mmaped"    # candle-nn API: from_mmaped_safetensors (외부 라이브러리, 변경 불가)
 ser = "ser"          # yawnbot character-service.ts: serialize 줄임 변수 (정당 식별자)
 unparseable = "unparseable" # 유효 영어 변형 철자 (unparsable 와 동의 — 코드/주석 의도)
+THR = "THR"          # TASK-KAR-018-THR suffix (THReaded persistence — TASK 식별자)
+thr = "thr"          # 동일 (소문자 케이스)
 
 # === WM 코드 식별자가 devlog 포스트에 인용 (역사적, 변경 불가, TASK-KAR-073) ===
 # apps/blog/_posts/.../wm-devlog-*.md 가 WM C#(Data.Criterias / RuntimeCriteria)

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-thread-router.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-thread-router.test.ts
@@ -1,6 +1,14 @@
 // agent-thread-router 순수 코어 전수검증 (Discord IO 무관). KAR-018-Y.
+// + TASK-KAR-018-THR: 재기동-중복 root fix (이름검색 dedup) ·
+//   proposal-id(pXXX) thread key · findThreadByName 분기.
 import { describe, it, expect } from 'vitest';
-import { extractTaskId, chunkForDiscord } from './agent-thread-router';
+import { ChannelType } from 'discord.js';
+import {
+  extractTaskId,
+  chunkForDiscord,
+  findThreadByName,
+  makeThreadRouter,
+} from './agent-thread-router';
 
 describe('extractTaskId (순수)', () => {
   it('워커 메시지에서 TASK id 추출', () => {
@@ -18,6 +26,180 @@ describe('extractTaskId (순수)', () => {
   it('TASK 없으면 null (팀-공통=하트비트)', () => {
     expect(extractTaskId('🛰 팀 한 바퀴: 동료 echo 한마디')).toBeNull();
     expect(extractTaskId('')).toBeNull();
+  });
+
+  // ── TASK-KAR-018-THR (A): proposal-id(pXXX)도 thread key ──
+  it('proposal-id (p+8hex) 를 thread key 로 인정', () => {
+    expect(
+      extractTaskId("⑦' 발굴 → task-new (task) [p42c94051] — 승인 시 처리"),
+    ).toBe('p42c94051');
+    expect(
+      extractTaskId('{"objId":"p0a1b2c3d","status":"approved"}'),
+    ).toBe('p0a1b2c3d');
+  });
+  it('TASK id 가 proposal-id 보다 우선 (기존 틱 대상 불변·회귀0)', () => {
+    expect(
+      extractTaskId('TASK-KAR-018-THR 관련 제안 p42c94051 검토'),
+    ).toBe('TASK-KAR-018-THR');
+  });
+  it('일반어/부분일치 오매칭 0 (8 hex + 단어경계 강제)', () => {
+    // "prod" "plan" "p123" "p1234567"(7) "p123456789"(9) 전부 X
+    expect(extractTaskId('prod 배포 5회, plan 수립')).toBeNull();
+    expect(extractTaskId('포트 p1234567 (7자리) 무시')).toBeNull();
+    expect(extractTaskId('app1234567 처럼 앞에 글자면 X')).toBeNull();
+    // 8 hex 지만 g 는 hex 아님 → X
+    expect(extractTaskId('pdeadbeeg 는 hex 아님')).toBeNull();
+  });
+});
+
+// ── TASK-KAR-018-THR: findThreadByName 분기 전수 (가짜 채널) ──
+function fakeChannel(opts: {
+  active?: { id: string; name: string }[];
+  archived?: { id: string; name: string }[];
+  failActive?: boolean;
+  failArchived?: boolean;
+}) {
+  const wrap = (arr: { id: string; name: string }[]) => ({
+    threads: { values: () => arr[Symbol.iterator]() },
+  });
+  return {
+    threads: {
+      fetchActive: () =>
+        opts.failActive
+          ? Promise.reject(new Error('rate-limit'))
+          : Promise.resolve(wrap(opts.active ?? [])),
+      fetchArchived: () =>
+        opts.failArchived
+          ? Promise.reject(new Error('rate-limit'))
+          : Promise.resolve(wrap(opts.archived ?? [])),
+    },
+  };
+}
+
+describe('findThreadByName (TASK-KAR-018-THR root fix)', () => {
+  it('active 에 이름 일치 → 그 id', async () => {
+    const ch = fakeChannel({
+      active: [
+        { id: 'T1', name: 'TASK-KAR-018-THR' },
+        { id: 'T2', name: 'TASK-KL-099' },
+      ],
+    });
+    expect(await findThreadByName(ch, 'TASK-KAR-018-THR')).toBe('T1');
+  });
+  it('active miss → archived(public) 조회 hit', async () => {
+    const ch = fakeChannel({
+      active: [{ id: 'T2', name: 'TASK-KL-099' }],
+      archived: [{ id: 'A1', name: 'TASK-KAR-018-THR' }],
+    });
+    expect(await findThreadByName(ch, 'TASK-KAR-018-THR')).toBe('A1');
+  });
+  it('어디에도 없음 → null (호출부는 생성 폴백)', async () => {
+    const ch = fakeChannel({ active: [], archived: [] });
+    expect(await findThreadByName(ch, 'TASK-KAR-018-THR')).toBeNull();
+  });
+  it('fetch 실패는 swallow → null (가용성 우선, throw X)', async () => {
+    const ch = fakeChannel({ failActive: true, failArchived: true });
+    await expect(
+      findThreadByName(ch, 'TASK-KAR-018-THR'),
+    ).resolves.toBeNull();
+  });
+  it('active 실패해도 archived 로 복구', async () => {
+    const ch = fakeChannel({
+      failActive: true,
+      archived: [{ id: 'A9', name: 'TASK-KAR-018-THR' }],
+    });
+    expect(await findThreadByName(ch, 'TASK-KAR-018-THR')).toBe('A9');
+  });
+});
+
+// ── 재기동-중복 시뮬: in-memory 맵 소실 후 같은 TASK = 중복 0 ──
+describe('makeThreadRouter 재기동-중복 root fix (TASK-KAR-018-THR)', () => {
+  // prod nssm restart = 새 makeThreadRouter 인스턴스(맵 빈 상태).
+  // 같은 TASK 다음 메시지가 *이름검색* 으로 기존 스레드 재사용 →
+  // ch.threads.create 0회 + 메인채널 포인터 0회 (중복·고아 0).
+  function makeFakeClient() {
+    const created: { name: string; id: string }[] = [];
+    const liveThreads: { id: string; name: string }[] = [];
+    const sends: string[] = [];
+    const threadSends: Record<string, string[]> = {};
+    let seq = 0;
+    const channel: any = {
+      type: ChannelType.GuildText,
+      threads: {
+        create: async ({ name }: { name: string }) => {
+          const id = `thread-${++seq}`;
+          created.push({ name, id });
+          liveThreads.push({ id, name });
+          return { id };
+        },
+        fetchActive: async () => ({
+          threads: { values: () => [...liveThreads][Symbol.iterator]() },
+        }),
+        fetchArchived: async () => ({
+          threads: { values: () => [][Symbol.iterator]() },
+        }),
+      },
+      send: async (m: string) => {
+        sends.push(m);
+      },
+    };
+    const client: any = {
+      channels: {
+        fetch: async (id: string) => {
+          if (id === 'CH') return channel;
+          // threadId fetch → sendable thread
+          return {
+            isThread: () => true,
+            isSendable: () => true,
+            send: async ({ content }: { content: string }) => {
+              (threadSends[id] ??= []).push(content);
+            },
+          };
+        },
+      },
+    };
+    return { client, created, sends, threadSends };
+  }
+
+  const wait = () => new Promise((r) => setTimeout(r, 0));
+
+  it('재기동(맵 소실) 후 같은 TASK → 스레드 생성·포인터 0회 (중복 0)', async () => {
+    const f = makeFakeClient();
+    const deps = {
+      resolveChannelId: () => 'CH',
+      fallback: () => {
+        throw new Error('fallback 호출되면 안 됨 (taskId 있음)');
+      },
+    };
+
+    // ── 봇 1세대: 최초 메시지 → 스레드 신규 1회 + 포인터 1회 ──
+    const r1 = makeThreadRouter(f.client, deps);
+    r1('🤖 KAR-018-THR worker ▶ TASK-KAR-018-THR 착수');
+    await wait();
+    await wait();
+    expect(f.created.length).toBe(1);
+    expect(f.created[0].name).toBe('TASK-KAR-018-THR');
+    expect(f.sends.length).toBe(1); // 메인채널 포인터 1회
+
+    // ── 봇 2세대(재기동): 새 라우터=빈 맵. 같은 TASK 메시지 ──
+    const r2 = makeThreadRouter(f.client, deps);
+    r2('🤖 TASK-KAR-018-THR 사용자 질문에 답합니다');
+    await wait();
+    await wait();
+    // 이름검색이 기존 스레드 재사용 → 신규 생성·포인터 추가 0
+    expect(f.created.length).toBe(1);
+    expect(f.sends.length).toBe(1);
+
+    // ── 봇 3세대: 한 번 더 재기동해도 동일 (안정) ──
+    const r3 = makeThreadRouter(f.client, deps);
+    r3('🤖 TASK-KAR-018-THR 추가 보고');
+    await wait();
+    await wait();
+    expect(f.created.length).toBe(1);
+    // 전 세대 메시지가 전부 *같은* 스레드 id 로 갔는지 (연속성)
+    const tid = f.created[0].id;
+    expect(Object.keys(f.threadSends)).toEqual([tid]);
+    expect(f.threadSends[tid].length).toBe(3);
   });
 });
 

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-thread-router.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-thread-router.ts
@@ -10,11 +10,26 @@ import {
   ThreadAutoArchiveDuration,
 } from 'discord.js';
 
-/** 메시지에서 TASK id 추출 (스레드 키). 없으면 null = 팀-공통(메인채널). */
+/**
+ * 메시지에서 스레드 키 추출. 우선순위:
+ *  1) TASK-<PREFIX>-<번호>[-<서브>] (KAR/WM/KL/YB 등) — 첫 매치 = 그 틱 대상.
+ *  2) 제안 발굴 id `pXXXXXXXX` (proposalId = `p` + 8 hex, proposal.ts 정본).
+ *
+ * (2) 추가 근거 (TASK-KAR-018-THR (A) — prod 코드실증): proposal notify
+ * 라인(`⑦' 발굴 → task-new (task) [p42c94051] …`)은 TASK id 가 없어
+ * 기존 정규식에 매칭 0 → null → 메인채널 fallback = "제안 카드가 스레드
+ * 아닌 일반채팅" 페인의 root. proposal-id 도 thread key 로 인정하면 그
+ * notify 가 *그 제안 전용 안정 스레드* 로 수렴(메인채널 스팸 해소).
+ * TASK 우선이라 기존 TASK 라우팅·단위검증은 byte-identical (회귀 0).
+ * 없으면 null = 팀-공통(하트비트 등 메인채널).
+ */
 export function extractTaskId(msg: string): string | null {
-  // TASK-<PREFIX>-<번호>[-<서브>] (KAR/WM/KL/YB 등). 첫 매치 = 그 틱 대상.
-  const m = msg.match(/TASK-[A-Z]{2,6}-\d+(?:-[A-Za-z0-9]+)?/);
-  return m ? m[0] : null;
+  const t = msg.match(/TASK-[A-Z]{2,6}-\d+(?:-[A-Za-z0-9]+)?/);
+  if (t) return t[0];
+  // proposalId 형식 = `p` + 정확히 8 hex (proposal.ts proposalId). 단어
+  // 경계 강제 — "prod"/"plan" 등 일반어 오매칭 0 (8 hex 동반 필수).
+  const p = msg.match(/(?<![A-Za-z0-9])p[0-9a-f]{8}(?![0-9a-z])/);
+  return p ? p[0] : null;
 }
 
 /**
@@ -49,6 +64,50 @@ export function chunkForDiscord(text: string, max = 1900): string[] {
   return out;
 }
 
+/**
+ * 채널의 *기존* 스레드 중 이름이 정확히 `name` 인 것의 id (없으면 null).
+ * active → archived(public) 순 조회. 봇 재기동으로 in-memory 맵이
+ * 소실돼도 같은 TASK 의 스레드를 Discord 측에서 되찾는 경로
+ * (TASK-KAR-018-THR 재기동-중복 root fix). best-effort — 어떤
+ * fetch 실패도 swallow(throw X) → 호출부는 생성으로 graceful 폴백.
+ * discord.js 최소 표면(`threads.fetchActive/fetchArchived`)만 의존 →
+ * 테스트에서 가짜 채널로 분기 전수검증 가능.
+ */
+export async function findThreadByName(
+  ch: {
+    threads: {
+      fetchActive: () => Promise<{
+        threads: { values: () => Iterable<{ id: string; name: string }> };
+      }>;
+      fetchArchived: (opts?: {
+        type?: 'public' | 'private';
+      }) => Promise<{
+        threads: { values: () => Iterable<{ id: string; name: string }> };
+      }>;
+    };
+  },
+  name: string,
+): Promise<string | null> {
+  const scan = (
+    res: {
+      threads: { values: () => Iterable<{ id: string; name: string }> };
+    } | null,
+  ): string | null => {
+    if (!res) return null;
+    for (const t of res.threads.values()) {
+      if (t && t.name === name) return t.id;
+    }
+    return null;
+  };
+  const active = await ch.threads.fetchActive().catch(() => null);
+  const hitA = scan(active);
+  if (hitA) return hitA;
+  const archived = await ch.threads
+    .fetchArchived({ type: 'public' })
+    .catch(() => null);
+  return scan(archived);
+}
+
 export interface ThreadRouterDeps {
   /** agent-team 채널 id 해석 (override 우선 → webhook-routes). */
   resolveChannelId: () => string | null;
@@ -80,9 +139,24 @@ export function makeThreadRouter(
     const p = (async (): Promise<string | null> => {
       const ch = await client.channels.fetch(channelId).catch(() => null);
       if (!ch || ch.type !== ChannelType.GuildText) return null;
+      const wantName = taskId.slice(0, 100);
+      // ── TASK-KAR-018-THR root fix: 생성 전 *기존 스레드 이름검색* ──
+      // 근본 진단(코드실증): taskThreads 는 in-memory Map → prod 봇은
+      // master push 마다 nssm restart(1h~5 deploy 실측) → 맵 소실 →
+      // 같은 TASK 다음 메시지에 무조건 ch.threads.create = 중복 스레드
+      // + 옛 스레드(맥락·사용자 미응답) 고아 → OneDay 아카이브 = KAR-
+      // 018-LT D2「누적 0」를 재기동 churn 이 적극 파괴. 맵 miss 시
+      // active/archived 를 이름(=생성 시 쓰는 wantName)으로 먼저 조회 →
+      // 있으면 재사용. 스펙 명시: "기존 이름검색 단독으로도 재기동-중복
+      // 버그 해소". best-effort — 조회 실패는 생성으로 폴백(가용성 우선).
+      const existing = await findThreadByName(ch, wantName);
+      if (existing) {
+        taskThreads.set(taskId, existing);
+        return existing;
+      }
       const thread = await ch.threads
         .create({
-          name: taskId.slice(0, 100),
+          name: wantName,
           autoArchiveDuration: ThreadAutoArchiveDuration.OneDay,
           type: ChannelType.PublicThread,
           reason: `KAR-018-Y agent-team TASK thread (${taskId})`,
@@ -90,7 +164,7 @@ export function makeThreadRouter(
         .catch(() => null);
       if (!thread) return null;
       taskThreads.set(taskId, thread.id);
-      // 메인채널 포인터 = 스레드 생성 시 1회만 (스팸 0).
+      // 메인채널 포인터 = 스레드 *신규 생성* 시 1회만 (재사용 시 X = 스팸 0).
       await ch
         .send(`🧵 **${taskId}** 작업 스레드 → <#${thread.id}>`)
         .catch(() => undefined);


### PR DESCRIPTION
## Summary

TASK-KAR-018-THR: prod 봇 nssm restart 마다 같은 TASK에 중복 스레드가 생성되어 KAR-018-LT D2 「누적 0」을 적극 파괴하던 *재기동 churn* root fix.

- **`findThreadByName`** (active → archived public 순 fetch) 신설 + `getOrCreateThread` 가 `ch.threads.create` 호출 *전* 에 이름검색. 봇 재기동(in-memory `taskThreads` Map 소실) → 같은 TASK 다음 메시지 → Discord 측에서 기존 스레드 재사용. 메인채널 포인터는 *신규 생성 시 1회만* (재사용 시 스팸 0). 스펙 명시: "기존 이름검색 단독으로도 재기동-중복 버그 해소".
- **`extractTaskId` 가 `pXXXXXXXX`(proposal-id, `p` + 8 hex) 도 thread key 로 인정** — 스펙 (A) prod 관측 "제안 카드가 스레드 아닌 일반채팅으로 올라옴" root fix. proposal notify 라인(`⑦' 발굴 → … [p42c94051]`)에 TASK id 가 없어 기존 정규식 매칭 0 → null → 메인채널 fallback 이던 것을 *그 제안 전용 안정 스레드* 로 수렴. TASK id 우선 → 기존 TASK 라우팅·단위검증 byte-identical (회귀 0).
- best-effort: fetch 실패는 swallow → 생성 폴백(가용성 우선, throw X). 단어경계 + 8 hex 강제 → `prod`/`plan`/`app1234567` 등 오매칭 0.
- **typos CI red 해소** (9e138bab): `crate-ci/typos` 가 `THR` suffix 를 `THE` typo 로 23건 flag → `_typos.toml` 의 "자체 코드 의도된 줄임" 섹션에 THR/thr 추가. TASK 식별자 suffix 는 영구 false-positive (LT/ESC/THR 와 같은 패턴 확장).

회귀 0: `extractTaskId` 시그니처 보존, 새 정규식은 TASK 무매칭 시에만 진입. `main.ts:235` 인바운드 캡처(스레드명 → 결정 기록) 옛 동작은 그대로 — pXXX 스레드 답글도 결정으로 캡처되는 *추가* 효과.

## 미커버 (스펙 명시, 별 작업 — 평행정의/blast radius 회피)

- TASK frontmatter `discord_thread` write-back (durability + UX 클릭 + audit). 스펙: "기존 이름검색 단독으로도 root 해소" — 본 PR 으로 핵심 페인 해소, 파일기록은 추가 layer. memo 정본 경로 = worktree cwd 밖 → 본 PR scope 외.
- (B-1)(B-2) 승인 UX 3단 구분 (채택/머터리얼라이즈/active 명명) — `agent-bus` 표현/카피 fix, one commit one topic 정합.
- TASK-KAR-018-ESC behavior-verify (선행 게이트) — prod 사용자 관측 대기 (스펙 § 시퀀싱 게이트).

## Test plan

- [x] `vitest run src/bot/agent-thread-router.test.ts` — 17/17 GREEN (기존 8 + 신규 9: `extractTaskId` pXXX 우선순위/오매칭 가드 4건 + `findThreadByName` 분기 5건 + `makeThreadRouter` 재기동 시뮬 1건)
- [x] `tsc --noEmit` — 변경 파일 0 errors (다른 파일의 `karmolab-ai/node` import error 는 본 PR 무관 사전부담 — moduleResolution 설정 이슈)
- [x] **verify (master invariant) CI GREEN** (2026-05-21, 26230031502 — THR allowlist 후) — npm run verify + typos check 양쪽 pass.
- [ ] **prod behavior-verify** (선행 게이트 = KAR-018-ESC 후): 실 nssm restart 전후 같은 TASK 다음 메시지가 *기존* 스레드 id 로 가는지 사용자 관측. 새 스레드 0회 + 메인채널 포인터 0회 확인.
- [ ] **proposal notify behavior-verify**: 제안 발굴 라인이 `pXXX` 전용 스레드로 수렴하고 메인채널 스팸 0 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)