### PR TITLE
test(KAR-018-X): 워커 cadence 8 테스트 회귀 fix — 🤖 착수 알림 정합

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-cadence-escalate.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-cadence-escalate.test.ts
@@ -129,13 +129,15 @@ describe('runWorkerConsumerOnce — decision-needed escalate (KAR-018-ESC)', () 
     });
     expect(r).toBe('wm-worker:escalated:TASK-WM-010-A');
     expect(released).toEqual(['TASK-WM-010-A']); // 점유 해제(다른 task 회전)
-    expect(spoken).toHaveLength(1);
+    // KAR-018(2026-05-21): spoken[0] = 🤖 착수, spoken[-1] = escalate outcome.
+    expect(spoken).toHaveLength(2);
+    const outcome = spoken.at(-1) ?? '';
     // agent-thread-router.extractTaskId 가 라우팅하려면 TASK id 문자열 필수
-    expect(spoken[0]).toContain('TASK-WM-010-A');
-    expect(spoken[0]).toContain('🛠 WmWorker'); // 스킨 정체 발화
-    expect(spoken[0]).toContain('사용자 결정 필요');
+    expect(outcome).toContain('TASK-WM-010-A');
+    expect(outcome).toContain('🛠 WmWorker'); // 스킨 정체 발화
+    expect(outcome).toContain('사용자 결정 필요');
     // agentic 옵션 리포트 동봉(사용자가 그 스레드서 보고 결정)
-    expect(spoken[0]).toContain('선택지: A안 / B안');
+    expect(outcome).toContain('선택지: A안 / B안');
   });
 
   it('(a2) 리포트 escalate 마커만 있어도(type=fix) escalate — 견고 OR', async () => {
@@ -183,8 +185,10 @@ describe('runWorkerConsumerOnce — decision-needed escalate (KAR-018-ESC)', () 
     // 종전 코드와 동일: done-no-artifact + 미푸시 메시지 + release.
     expect(r).toBe('wm-worker:done-no-artifact:TASK-WM-300');
     expect(released).toEqual(['TASK-WM-300']);
-    expect(spoken[0]).toContain('미푸시');
-    expect(spoken[0]).not.toContain('사용자 결정 필요');
+    // KAR-018(2026-05-21): spoken[0] = 🤖 착수, spoken[-1] = outcome 메시지.
+    const outcome = spoken.at(-1) ?? '';
+    expect(outcome).toContain('미푸시');
+    expect(outcome).not.toContain('사용자 결정 필요');
   });
 
   it('(b2) spawn 에러(status=error) → 종전 release+에러보고 *불변* (escalate 경로 미진입)', async () => {
@@ -208,8 +212,10 @@ describe('runWorkerConsumerOnce — decision-needed escalate (KAR-018-ESC)', () 
     });
     expect(r).toBe('wm-worker:error');
     expect(released).toEqual(['TASK-WM-400']);
-    expect(spoken[0]).toContain('점유 해제');
-    expect(spoken[0]).not.toContain('사용자 결정 필요');
+    // KAR-018(2026-05-21): spoken[0] = 🤖 착수, spoken[-1] = 점유 해제 outcome.
+    const outcome = spoken.at(-1) ?? '';
+    expect(outcome).toContain('점유 해제');
+    expect(outcome).not.toContain('사용자 결정 필요');
   });
 
   it('(c) escalate dedupe — 같은 task 다음 틱 재escalate 도배 X (escalate-cooldown 윈도우 skip)', async () => {
@@ -237,15 +243,15 @@ describe('runWorkerConsumerOnce — decision-needed escalate (KAR-018-ESC)', () 
       },
       voice: async () => '',
     };
-    // 1틱: escalate
+    // 1틱: escalate. KAR-018(2026-05-21): 🤖 착수 + escalate outcome = 2 발화.
     const r1 = await runWorkerConsumerOnce(env(), deps);
     expect(r1).toBe('wm-worker:escalated:TASK-WM-010-A');
-    expect(spoken).toHaveLength(1);
+    expect(spoken).toHaveLength(2);
     // 2틱: 동일 task 만 후보 → escalate-cooldown 으로 skip → cooldown-all
-    //      (#team-bus 재escalate 도배 X — speak 추가 호출 0)
+    //      (#team-bus 재escalate 도배 X — 착수/outcome 추가 발화 0)
     const r2 = await runWorkerConsumerOnce(env(), deps);
     expect(r2).toBe('wm-worker:cooldown-all');
-    expect(spoken).toHaveLength(1); // 도배 0 (dedupe 작동)
+    expect(spoken).toHaveLength(2); // 도배 0 (dedupe 작동 — 추가 발화 없음)
   });
 
   it('(c2) escalate 후 *다른* task 는 정상 회전(escalate-cooldown 은 그 task 한정)', async () => {

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-cadence-worker.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-cadence-worker.test.ts
@@ -409,6 +409,7 @@ describe('runWorkerConsumerOnce (주입 IO)', () => {
     expect(notified).toHaveLength(0); // 스팸 0
     expect(r1).toContain('idle'); // ground-truth = 반환/trace 에 보존(무손실)
     // 실 활동(작업 착수)은 여전히 발화 — heartbeat 아닌 의미활동.
+    // KAR-018(2026-05-21): claim 직후 "🤖 착수" + 완료 후 outcome = 2 발화.
     const deps2 = {
       listWorkers: () => [W],
       scan: () => [{ id: 'TASK-WM-9', file: 'f' }],
@@ -419,8 +420,8 @@ describe('runWorkerConsumerOnce (주입 IO)', () => {
       },
     };
     await runWorkerConsumerOnce(env(), deps2);
-    expect(notified).toHaveLength(1);
-    expect(notified[0]).toContain('TASK-WM-9');
+    expect(notified).toHaveLength(2); // 착수 + outcome
+    expect(notified.every((n) => n.includes('TASK-WM-9'))).toBe(true);
   });
 
   it('후보→claim ok→spawn done → 보고 + done', async () => {
@@ -438,8 +439,10 @@ describe('runWorkerConsumerOnce (주입 IO)', () => {
     });
     expect(r).toBe('wm-worker:done:TASK-WM-119');
     expect(claimed).toEqual(['TASK-WM-119']);
-    expect(notified[0]).toContain('TASK-WM-119');
-    expect(notified[0]).toContain('🛠 WmWorker');
+    // KAR-018(2026-05-21): notified[0] = 🤖 착수, notified[-1] = outcome(label+TASK id).
+    const outcome = notified.at(-1) ?? '';
+    expect(outcome).toContain('TASK-WM-119');
+    expect(outcome).toContain('🛠 WmWorker');
   });
 
   it('claim 레이스 — 첫 후보 실패 시 다음 후보', async () => {
@@ -475,7 +478,8 @@ describe('runWorkerConsumerOnce (주입 IO)', () => {
     });
     expect(r).toBe('wm-worker:done-no-artifact:TASK-WM-9');
     expect(released).toEqual(['TASK-WM-9']);
-    expect(notified[0]).toContain('미푸시');
+    // KAR-018(2026-05-21): 미푸시 outcome 은 착수 알림 다음(마지막).
+    expect(notified.at(-1) ?? '').toContain('미푸시');
   });
 
   it('trace 는 spawn status 가 아니라 최종 산출물 판정(done-no-artifact)을 남긴다', async () => {
@@ -598,7 +602,8 @@ describe('runWorkerConsumerOnce (주입 IO)', () => {
     });
     expect(r).toBe('wm-worker:error');
     expect(released).toEqual(['TASK-WM-9']);
-    expect(notified[0]).toContain('점유 해제');
+    // KAR-018(2026-05-21): 점유 해제 outcome 은 착수 알림(또는 worktree-실패 경로) 다음.
+    expect(notified.at(-1) ?? '').toContain('점유 해제');
   });
 
   it('MEMO_REPO_PATH 부재 → no-memo-root', async () => {


### PR DESCRIPTION
## Summary

- 마스터 `1efe2f18` (워커 claim 직후 #team-bus 🤖 착수 알림) 이후 워커 cadence 테스트 8건이 `notified[0]`/`spoken[0]` = outcome 메시지를 가정한 채 stale → `at(-1)` 로 outcome 검사 + `toHaveLength(1)→(2)` 정합. dedupe 테스트(c)는 2틱 후에도 발화 누적 0 가정 유지.
- 영향 파일: `apps/discord-bots/apps/yawnbot/src/bot/agent-cadence-{worker,escalate}.test.ts`. 코드 동작 불변 (test-only). 🤖 착수 알림 제품 의도(claim 직후 가시성, KAR-018) 보존.

## TASK-KAR-018-X 정합

소비자 워커 cadence 의 가시성 알림(🤖 착수) 도입이 master에는 들어갔으나 vitest 가 stale. TASK 의 "단위 검증" 게이트 회복. 본 PR 자체는 새 기능 X — 회귀 fix 한 commit (`ee6c8a40`). 워커 코어/큐/claim 등 SPEC 의 다른 완료조건은 이미 master 에 머지됨; 잔여는 사람 게이트(`status:draft→active` 승격 + prod `AGENT_CADENCE_ENABLED=1`) + 거동 관측.

## Test plan

- [x] `cd apps/discord-bots/apps/yawnbot && npx vitest run` — **624/624 GREEN** (이 worktree 로컬 검증, 2026-05-21 22:29 KST)
- [x] 두 영향 파일 단독 = 55/55 GREEN
- [ ] master CI (verify.yml) 트리거 — graduate 화이트리스트 `feature/agent-team-task-*` 정합
- [ ] prod 봇 재기동 후 #team-bus 에서 🤖 착수 알림 + outcome 분리 라이브 관측 = TASK-KAR-018-X "백로그 드레인 실증" rung

## Notes

- 푸시는 별도 — branch 는 이미 origin 에 동기화 (HEAD `ee6c8a40`). pre-push `npm run verify` 가 이 worktree 의 `apps/karmolab/node_modules` 미설치로 fail (코드 회귀 X, env 설치 부재). PR 본체 코드는 vitest 로컬 검증 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Tests**
  * 워커 에스컬레이션 및 작업 할당 흐름의 회귀 테스트를 업데이트했습니다.
  * 다중 알림 및 메시지 발송 시나리오에 대한 검증 로직을 강화하여 시스템 안정성을 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->