### PR TITLE
perf(kl-075,kl-076): adventure_save_image + desktop_trigger_release_workflow async spawn_blocking

### DIFF
--- a/apps/karmolab-tauri/src-tauri/src/adventure.rs
+++ b/apps/karmolab-tauri/src-tauri/src/adventure.rs
@@ -204,7 +204,15 @@ fn safe_session_slug(slug: &str) -> Result<&str, String> {
 }
 
 #[tauri::command]
-pub fn adventure_save_image(
+pub async fn adventure_save_image(
+    payload: AdventureSaveImagePayload,
+) -> Result<AdventureSaveImageResult, String> {
+    tauri::async_runtime::spawn_blocking(move || adventure_save_image_blocking(payload))
+        .await
+        .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
+}
+
+fn adventure_save_image_blocking(
     payload: AdventureSaveImagePayload,
 ) -> Result<AdventureSaveImageResult, String> {
     let slug = safe_session_slug(&payload.session_slug)?;

--- a/apps/karmolab-tauri/src-tauri/src/lib.rs
+++ b/apps/karmolab-tauri/src-tauri/src/lib.rs
@@ -687,7 +687,18 @@ fn desktop_notify(
 }
 
 #[tauri::command]
-fn desktop_trigger_release_workflow(
+async fn desktop_trigger_release_workflow(
+    ref_name: Option<String>,
+    bump_type: Option<String>,
+) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        desktop_trigger_release_workflow_blocking(ref_name, bump_type)
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
+}
+
+fn desktop_trigger_release_workflow_blocking(
     ref_name: Option<String>,
     bump_type: Option<String>,
 ) -> Result<String, String> {


### PR DESCRIPTION
## Summary

- **TASK-KL-075**: `adventure_save_image` — sync `#[tauri::command]` 가 base64 디코드 + `fs::create_dir_all` + `fs::write` (이미지 I/O) 수행 → `pub async fn` + `tauri::async_runtime::spawn_blocking` 전환
- **TASK-KL-076**: `desktop_trigger_release_workflow` — sync `#[tauri::command]` 가 `Command::new("gh")` 3회 spawn → `async fn` + `spawn_blocking` 전환

둘 다 KL-043 표준 패턴 적용. 인접 `adventure_save_raw` / `desktop_install_pending_update` 가 참고 모델.
ACL 변경 없음 (함수명·시그니처 유지, `async` 추가만).

## Changed Files

| 파일 | 변경 |
|---|---|
| `apps/karmolab-tauri/src-tauri/src/adventure.rs` | `adventure_save_image` → async + `adventure_save_image_blocking` 분리 |
| `apps/karmolab-tauri/src-tauri/src/lib.rs` | `desktop_trigger_release_workflow` → async + `desktop_trigger_release_workflow_blocking` 분리 |

## Verify

`cargo check --all-targets` — cloud 환경 GTK3 미설치로 로컬 검증 불가. CI (verify.yml `cargo check`) 통과 확인 필요.

## Autopilot

machine=cloud-kl, seed→active 전환. TASK-KL-075 + TASK-KL-076.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTdwvqLUcXdnAoVddDL9Qc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **성능 개선**
  * 내부 명령 처리를 최적화하여 애플리케이션 응답성을 향상했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mascari4615/mascari4615.github.io/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->