### PR TITLE
feat(yawnbot-agent-team): KAR-018-LT-DIVERSITY D-1~D-7 substrate (process-separable channel bus)

### DIFF
--- a/apps/discord-bots/apps/yawnbot/scripts/run-agent-runtime.mjs
+++ b/apps/discord-bots/apps/yawnbot/scripts/run-agent-runtime.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * agent-runtime daemon entry — capability 자율 발화 daemon 1개 인스턴스
+ * (TASK-KAR-018-LT-DIVERSITY, D-3 / D-7 migration 진입).
+ *
+ * 한 daemon = 한 코어 = 한 channelId tail. 본 entry 는 thin wrapper —
+ * 코어 정체성 + LLM 호출 + bus IO 만 묶음. orchestrator 결정 흐름 정본 =
+ * `src/bot/agent-runtime-daemon.ts` (pure, 회귀 잠금).
+ *
+ * 사용:
+ *   node scripts/run-agent-runtime.mjs --core-id <id> --channel-id <id>
+ *     [--interval-ms <N>] [--once]
+ *
+ * env:
+ *   MEMO_REPO_PATH        (필수)
+ *   YAWNBOT_AGENT_CHANNEL_ID (--channel-id 미지정 시 fallback)
+ *   AGENT_RUNTIME_DRY_RUN=1  publish/mem write skip (smoke 검증용)
+ *
+ * D-7 단계에서 nssm 서비스 `agent-<id>` 가 본 script 를 invoke. D-3 단계
+ * 현재는 *수동 smoke* 만(dry-run 권장 — LLM 호출은 본 PR 단계에서 실제
+ * channel 에 안 흘림). 라이브 활성화는 D-7 fallback dual-mode + 24h watch.
+ */
+import { existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distRoot = resolve(__dirname, '..', 'dist', 'src');
+
+function fail(msg) {
+  console.error(`[agent-runtime] ${msg}`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const out = { coreId: '', channelId: '', intervalMs: 2500, once: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--core-id') out.coreId = (argv[++i] || '').trim();
+    else if (a === '--channel-id') out.channelId = (argv[++i] || '').trim();
+    else if (a === '--interval-ms') out.intervalMs = Math.max(500, Number(argv[++i]) || 2500);
+    else if (a === '--once') out.once = true;
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.coreId) fail('--core-id 필수');
+const channelId = args.channelId || (process.env.YAWNBOT_AGENT_CHANNEL_ID || '').trim();
+if (!channelId) fail('--channel-id 또는 YAWNBOT_AGENT_CHANNEL_ID 필수');
+const memoRoot = (process.env.MEMO_REPO_PATH || '').trim();
+if (!memoRoot) fail('MEMO_REPO_PATH 필수');
+
+const dryRun = process.env.AGENT_RUNTIME_DRY_RUN === '1';
+
+const need = [
+  resolve(distRoot, 'bot', 'agent-runtime-daemon.js'),
+  resolve(distRoot, 'bot', 'agent-channel-bus.js'),
+  resolve(distRoot, 'bot', 'agent-channel-bridge.js'),
+  resolve(distRoot, 'services', 'agent-core.js'),
+];
+for (const p of need) {
+  if (!existsSync(p)) fail(`dist 산출물 없음: ${p} — 먼저 npm run build`);
+}
+const daemonMod = await import(need[0]);
+const busMod = await import(need[1]);
+const bridgeMod = await import(need[2]);
+const coreMod = await import(need[3]);
+
+const core = coreMod.loadCoreDef(memoRoot, args.coreId);
+if (!core) fail(`코어 정의 부재: memo/.claude/agents/${args.coreId}/core.md`);
+
+// LLM 호출: karmolab-ai 가 동일 패키지에 있음. dry-run 시 stub.
+let llmClient = null;
+if (!dryRun) {
+  try {
+    const aiMod = await import('karmolab-ai/node');
+    llmClient = aiMod.tryCreateGenerativeTextFromEnv();
+    if (!llmClient) console.warn('[agent-runtime] generativeText 미초기화 — stub 모드');
+  } catch (e) {
+    console.warn(`[agent-runtime] LLM import 실패: ${e?.message ?? e} — stub 모드`);
+  }
+}
+
+async function callLLM(prompt) {
+  if (!llmClient) {
+    // 미초기화 = silence default JSON (prefilter) 또는 빈 본문(speak).
+    return '{"react": false, "why": "llm-unavailable"}';
+  }
+  try {
+    const r = await llmClient.generateText({ prompt });
+    return (r?.text || '').trim();
+  } catch (e) {
+    return '';
+  }
+}
+
+const deps = {
+  readSince: (chId, sinceTs) =>
+    busMod.readRecentBusEvents({ MEMO_REPO_PATH: memoRoot }, chId, {
+      sinceTs: sinceTs || undefined,
+      daysBack: 1,
+      limit: 400,
+    }),
+  prefilterLLM: callLLM,
+  speakLLM: callLLM,
+  publishUtter: (ev) => {
+    if (dryRun) {
+      console.log(`[agent-runtime DRY] core-utter ch=${ev.channelId} core=${ev.coreId}: ${ev.text.slice(0, 200)}`);
+      return true;
+    }
+    return !!bridgeMod.publishToBus({ MEMO_REPO_PATH: memoRoot }, {
+      source: 'agent-runtime',
+      channelId: ev.channelId,
+      ts: ev.ts,
+      text: ev.text,
+      coreId: ev.coreId,
+      type: 'core-utter',
+    });
+  },
+  appendMem: (entry) => {
+    if (dryRun) return;
+    coreMod.appendCoreMemory(memoRoot, entry.coreId, {
+      session: 'agent-runtime',
+      type: entry.type,
+      topic: entry.topic,
+      summary: entry.summary,
+    });
+  },
+  readRecentMem: (coreId) => coreMod.readRecentCoreMemory(memoRoot, coreId, 6),
+  now: () => new Date(),
+};
+
+let state = { lastSeenTs: '' };
+let stopping = false;
+process.on('SIGINT', () => { stopping = true; });
+process.on('SIGTERM', () => { stopping = true; });
+
+console.log(`[agent-runtime] start coreId=${core.id} channel=${channelId} dryRun=${dryRun} interval=${args.intervalMs}ms`);
+
+async function tick() {
+  try {
+    const m = await daemonMod.agentRuntimeTickOnce(state, deps, {
+      core,
+      channelId,
+    });
+    state = { lastSeenTs: m.lastSeenTs || state.lastSeenTs };
+    if (m.scanned > 0 || m.spoken > 0 || m.skippedRateLimited > 0) {
+      console.log(daemonMod.summarizeTick(core.id, m));
+    }
+  } catch (e) {
+    console.error(`[agent-runtime] tick error: ${e?.stack || e}`);
+  }
+}
+
+if (args.once) {
+  await tick();
+  process.exit(0);
+}
+
+while (!stopping) {
+  await tick();
+  await new Promise((r) => setTimeout(r, args.intervalMs));
+}
+console.log(`[agent-runtime] stop coreId=${core.id}`);
+process.exit(0);

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-ambient.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-ambient.test.ts
@@ -1,0 +1,251 @@
+/**
+ * agent-ambient 회귀 (TASK-KAR-018-LT-DIVERSITY D-4/D-5/D-6).
+ *
+ * 결정층 *순수* — rate-limit·active context·prefilter·speak prompt 의
+ * silence default 와 멘션 우회 의 잠금. LLM 폭주 회귀의 1차 안전망.
+ */
+import { describe, it, expect } from 'vitest';
+import type { BusEvent } from './agent-channel-bus';
+import type { CoreDef } from '../services/agent-core';
+import {
+  isRateLimited,
+  isMentionedFor,
+  recentActiveContext,
+  formatActiveContext,
+  buildPrefilterPrompt,
+  parsePrefilterResponse,
+  buildSpeakPrompt,
+  DEFAULT_RATE_LIMIT,
+} from './agent-ambient';
+
+const mkUtter = (ts: string, coreId: string, text = 'x'): BusEvent => ({
+  ts,
+  source: 'agent-runtime',
+  type: 'core-utter',
+  channelId: 'C1',
+  coreId,
+  text,
+});
+const mkMsg = (ts: string, text = 'hi', refs?: BusEvent['refs']): BusEvent => ({
+  ts,
+  source: 'discord',
+  type: 'channel-msg',
+  channelId: 'C1',
+  authorName: 'fourth',
+  text,
+  refs,
+});
+
+const baseCore: CoreDef = {
+  id: 'atlas',
+  role: '시스템 진단·메타 인프라',
+  status: 'active',
+  defaultSkin: 'atlas',
+  emoji: '🛰',
+  displayName: 'Atlas',
+  body: '직무: 시스템 헬스, repo 진단. escalation: 위기 시 사용자 컨펌.',
+  skills: [],
+  frontmatter: {},
+};
+
+describe('isRateLimited — 5분 sliding 2 발화 cap', () => {
+  it('윈도우 안 0발화 = false', () => {
+    expect(isRateLimited([], 'atlas', { now: new Date('2026-05-23T03:00:00Z') })).toBe(false);
+  });
+
+  it('윈도우 안 1발화 = false (cap 미달)', () => {
+    const events = [mkUtter('2026-05-23T02:59:00.000Z', 'atlas')];
+    expect(isRateLimited(events, 'atlas', { now: new Date('2026-05-23T03:00:00Z') })).toBe(false);
+  });
+
+  it('윈도우 안 2발화 = true (cap 도달)', () => {
+    const events = [
+      mkUtter('2026-05-23T02:58:00.000Z', 'atlas'),
+      mkUtter('2026-05-23T02:59:30.000Z', 'atlas'),
+    ];
+    expect(isRateLimited(events, 'atlas', { now: new Date('2026-05-23T03:00:00Z') })).toBe(true);
+  });
+
+  it('5분 전 발화는 윈도우 밖 = false', () => {
+    const events = [
+      mkUtter('2026-05-23T02:50:00.000Z', 'atlas'),
+      mkUtter('2026-05-23T02:51:00.000Z', 'atlas'),
+    ];
+    expect(isRateLimited(events, 'atlas', { now: new Date('2026-05-23T03:00:00Z') })).toBe(false);
+  });
+
+  it('다른 코어 발화는 안 셈 (per-core cap)', () => {
+    const events = [
+      mkUtter('2026-05-23T02:58:00.000Z', 'echo'),
+      mkUtter('2026-05-23T02:59:00.000Z', 'echo'),
+    ];
+    expect(isRateLimited(events, 'atlas', { now: new Date('2026-05-23T03:00:00Z') })).toBe(false);
+  });
+
+  it('cap 옵션 override 가능', () => {
+    const events = [mkUtter('2026-05-23T02:59:00.000Z', 'atlas')];
+    expect(
+      isRateLimited(events, 'atlas', { now: new Date('2026-05-23T03:00:00Z'), cap: 1 }),
+    ).toBe(true);
+  });
+
+  it('DEFAULT_RATE_LIMIT 가 2 (사용자 컨펌 cap)', () => {
+    expect(DEFAULT_RATE_LIMIT).toBe(2);
+  });
+});
+
+describe('isMentionedFor — 멘션 우회 결정', () => {
+  it('refs.mentionedCoreIds 에 본인 id 포함 = true', () => {
+    const ev = mkMsg('2026-05-23T03:00:00Z', '@atlas 봐줘', {
+      mentionedCoreIds: ['atlas'],
+    });
+    expect(isMentionedFor(ev, 'atlas')).toBe(true);
+  });
+
+  it('다른 코어 멘션 = false', () => {
+    const ev = mkMsg('2026-05-23T03:00:00Z', '@echo', {
+      mentionedCoreIds: ['echo'],
+    });
+    expect(isMentionedFor(ev, 'atlas')).toBe(false);
+  });
+
+  it('refs 부재 = false', () => {
+    const ev = mkMsg('2026-05-23T03:00:00Z', 'plain');
+    expect(isMentionedFor(ev, 'atlas')).toBe(false);
+  });
+});
+
+describe('recentActiveContext + formatActiveContext', () => {
+  it('5분 윈도우 안 event 만 시간 오름차순', () => {
+    const events: BusEvent[] = [
+      mkMsg('2026-05-23T02:50:00Z', 'old'),
+      mkMsg('2026-05-23T02:58:00Z', 'b'),
+      mkMsg('2026-05-23T02:59:30Z', 'c'),
+      mkMsg('2026-05-23T02:57:00Z', 'a'),
+    ];
+    const ctx = recentActiveContext(events, { now: new Date('2026-05-23T03:00:00Z') });
+    expect(ctx.map((e) => e.text)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('maxLines 도달 시 가장 최근 N개만 (overflow 폭발 방지)', () => {
+    const events: BusEvent[] = [];
+    for (let i = 0; i < 50; i++) {
+      events.push(mkMsg(`2026-05-23T02:59:${String(i).padStart(2, '0')}Z`, `m${i}`));
+    }
+    const ctx = recentActiveContext(events, {
+      now: new Date('2026-05-23T03:00:00Z'),
+      maxLines: 5,
+    });
+    expect(ctx.length).toBe(5);
+    expect(ctx[0].text).toBe('m45');
+  });
+
+  it('formatActiveContext 가 channel-msg·core-utter 둘 다 표시', () => {
+    const out = formatActiveContext([
+      mkMsg('2026-05-23T03:00:00Z', '안녕'),
+      mkUtter('2026-05-23T03:00:30Z', 'atlas', '저요'),
+    ]);
+    expect(out).toContain('[fourth] 안녕');
+    expect(out).toContain('[코어:atlas] 저요');
+  });
+});
+
+describe('buildPrefilterPrompt — silence default + 멘션 우회 규칙', () => {
+  it('코어 capability(role/body) + recent context + 평가 대상 모두 포함', () => {
+    const ev = mkMsg('2026-05-23T03:00:00Z', '시스템 어떻게 돌아가?');
+    const p = buildPrefilterPrompt({
+      core: baseCore,
+      context: [ev],
+      latest: ev,
+    });
+    expect(p).toContain('Atlas');
+    expect(p).toContain('시스템 진단');
+    expect(p).toContain('시스템 어떻게 돌아가?');
+    expect(p).toContain('react');
+    expect(p).toContain('silence 가 default');
+  });
+
+  it('JSON 출력 강제 규칙 명시', () => {
+    const ev = mkMsg('2026-05-23T03:00:00Z', 'q');
+    const p = buildPrefilterPrompt({ core: baseCore, context: [ev], latest: ev });
+    expect(p).toContain('{"react": true|false, "why":');
+  });
+});
+
+describe('parsePrefilterResponse — silence default 가 안전한 폴백', () => {
+  it('정상 JSON {"react": true, "why": "..."}', () => {
+    const d = parsePrefilterResponse('{"react": true, "why": "내 capability 관련"}');
+    expect(d.react).toBe(true);
+    expect(d.why).toContain('capability');
+  });
+
+  it('react=false 정상 파싱', () => {
+    const d = parsePrefilterResponse('{"react": false, "why": "다른 코어"}');
+    expect(d.react).toBe(false);
+  });
+
+  it('비-JSON 응답 = silence(false)', () => {
+    expect(parsePrefilterResponse('아 모르겠는데요?').react).toBe(false);
+  });
+
+  it('빈 응답 = silence(false)', () => {
+    expect(parsePrefilterResponse('').react).toBe(false);
+  });
+
+  it('코드펜스 동봉 시 추출', () => {
+    const d = parsePrefilterResponse('```json\n{"react": true, "why": "ok"}\n```');
+    expect(d.react).toBe(true);
+  });
+
+  it('손상 JSON = silence(false) (안전 폴백)', () => {
+    expect(parsePrefilterResponse('{react: true why: ok}').react).toBe(false);
+  });
+
+  it('react가 문자열 "true" 라도 허용 (LLM JSON 변종 robustness)', () => {
+    expect(parsePrefilterResponse('{"react": "true", "why": "ok"}').react).toBe(true);
+  });
+});
+
+describe('buildSpeakPrompt — capability + work-memory + 발화 규칙', () => {
+  it('core body + recent mem + context 합성', () => {
+    const ev = mkMsg('2026-05-23T03:00:00Z', '나 어떻게 도와줄래?');
+    const p = buildSpeakPrompt({
+      core: baseCore,
+      prefilterWhy: '시스템 진단 도메인',
+      context: [ev],
+      latest: ev,
+      recentMem: '- [fix] worker-failed dedupe: 24h 윈도우 도입',
+    });
+    expect(p).toContain('Atlas');
+    expect(p).toContain('시스템 진단');
+    expect(p).toContain('worker-failed dedupe');
+    expect(p).toContain('시스템 진단 도메인');
+    expect(p).toContain('나 어떻게 도와줄래?');
+    expect(p).toContain('1~3문장');
+  });
+
+  it('mem 빈 문자열 = mem 블록 생략 (잡음 차단)', () => {
+    const ev = mkMsg('2026-05-23T03:00:00Z', 'q');
+    const p = buildSpeakPrompt({
+      core: baseCore,
+      prefilterWhy: '',
+      context: [ev],
+      latest: ev,
+    });
+    expect(p).not.toContain('work-memory');
+  });
+
+  it('mentioned=true 면 멘션 우회 라인 포함', () => {
+    const ev = mkMsg('2026-05-23T03:00:00Z', '@atlas 봐줘', {
+      mentionedCoreIds: ['atlas'],
+    });
+    const p = buildSpeakPrompt({
+      core: baseCore,
+      prefilterWhy: '멘션됨',
+      context: [ev],
+      latest: ev,
+      mentioned: true,
+    });
+    expect(p).toContain('멘션 우회');
+  });
+});

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-ambient.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-ambient.ts
@@ -1,0 +1,254 @@
+/**
+ * agent-ambient — capability-driven ambient listening 의 *순수* 결정층
+ * (TASK-KAR-018-LT-DIVERSITY, D-4 / D-5 / D-6).
+ *
+ * 코어 daemon 이 새 channel-msg 마다 "끼어들지 말지"를 LLM 에게 묻기 전,
+ * 결정에 필요한 *재료* 를 결정적·테스트가능하게 산출.
+ *
+ *   D-6 rate-limit / active context window — sliding 5분 안 같은 코어 발화
+ *        2회 cap (silence preference), 최근 5분 채널 흐름만 LLM 에게 노출
+ *        (전체 history X). 사용자 직접 호명/멘션 = cap 우회 (인지된 우선).
+ *   D-4 prefilter prompt — `{react: bool, why: string}` 1줄 결정. silence
+ *        default. cheap 모델용. false-positive 비용 > false-negative.
+ *   D-5 speak prompt — capability(core body) + recent work-memory + active
+ *        context 합성. 페르소나는 스킨 레이어 (기존 chat-adapter 재사용).
+ *
+ * 본 모듈 = pure (LLM 호출 X / fs X / Discord 의존 X). Daemon (D-3) 이
+ * 본 모듈 산출물을 DI'd LLM 으로 흘려보낸다.
+ */
+import type { BusEvent } from './agent-channel-bus';
+import type { CoreDef } from '../services/agent-core';
+
+// ── D-6: rate-limit + active context window ──────────────────
+
+/** 5분 (사용자 컨펌 — "직전 5분 채널 흐름만 listener 에게 전달"). */
+export const DEFAULT_ACTIVE_WINDOW_MS = 5 * 60 * 1000;
+/** 5분 안 한 코어 발화 cap (사용자 컨펌 — "5분 안 동일 코어 발화 ≤ 2"). */
+export const DEFAULT_RATE_LIMIT = 2;
+
+export interface RateLimitOpts {
+  /** 윈도우 길이 (ms). */
+  windowMs?: number;
+  /** 윈도우 안 코어 발화 cap. */
+  cap?: number;
+  /** "지금"(test inject). */
+  now?: Date;
+}
+
+/**
+ * 5분 sliding window 안 `coreId` 의 core-utter 횟수가 cap 도달했는지.
+ * true = 발화 금지(강제 read-only). 멘션 우회는 caller 의 `isMentionedFor`
+ * 가 별도 판단 — 본 함수는 *순수 rate-limit* 만 본다.
+ */
+export function isRateLimited(
+  events: BusEvent[],
+  coreId: string,
+  opts: RateLimitOpts = {},
+): boolean {
+  const cap = Math.max(1, opts.cap ?? DEFAULT_RATE_LIMIT);
+  const windowMs = Math.max(1000, opts.windowMs ?? DEFAULT_ACTIVE_WINDOW_MS);
+  const now = (opts.now ?? new Date()).getTime();
+  const cutoff = now - windowMs;
+  let count = 0;
+  for (const e of events) {
+    if (e.type !== 'core-utter' || e.coreId !== coreId) continue;
+    const t = Date.parse(e.ts);
+    if (!Number.isFinite(t)) continue;
+    if (t >= cutoff && t <= now) count++;
+  }
+  return count >= cap;
+}
+
+/** 멘션 우회 — refs.mentionedCoreIds 에 본인 id 가 있으면 prefilter 우회 강제. */
+export function isMentionedFor(event: BusEvent, coreId: string): boolean {
+  if (!event || !event.refs?.mentionedCoreIds) return false;
+  return event.refs.mentionedCoreIds.includes(coreId);
+}
+
+export interface ActiveContextOpts {
+  windowMs?: number;
+  now?: Date;
+  /** active context 안 최대 회수 (overflow 폭발 방지). */
+  maxLines?: number;
+}
+
+/**
+ * 직전 N분(default 5분) 채널 발화만 시간 오름차순으로 회수. daemon 이
+ * "지금 어떤 흐름인지" LLM 에게 보일 때만 쓴다. 전체 history X.
+ */
+export function recentActiveContext(
+  events: BusEvent[],
+  opts: ActiveContextOpts = {},
+): BusEvent[] {
+  const windowMs = Math.max(1000, opts.windowMs ?? DEFAULT_ACTIVE_WINDOW_MS);
+  const now = (opts.now ?? new Date()).getTime();
+  const cutoff = now - windowMs;
+  const maxLines = Math.max(1, opts.maxLines ?? 40);
+  const out: BusEvent[] = [];
+  for (const e of events) {
+    const t = Date.parse(e.ts);
+    if (!Number.isFinite(t)) continue;
+    if (t < cutoff || t > now) continue;
+    out.push(e);
+  }
+  out.sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts));
+  if (out.length <= maxLines) return out;
+  return out.slice(out.length - maxLines);
+}
+
+/**
+ * Active context 를 LLM 입력용 한 줄/메시지 단순 텍스트로 직렬화. 본인
+ * core-utter 도 포함(흐름 일관성 — 자기가 직전 한 말 잊고 반복 X).
+ */
+export function formatActiveContext(events: BusEvent[]): string {
+  return events
+    .map((e) => {
+      const who =
+        e.type === 'core-utter'
+          ? `[코어:${e.coreId || '?'}]`
+          : `[${e.authorName || '?'}]`;
+      const text = (e.text || '').replace(/\s+/g, ' ').slice(0, 400);
+      return `${who} ${text}`;
+    })
+    .join('\n');
+}
+
+// ── D-4: fast prefilter prompt + response parser ─────────────
+
+export interface PrefilterInput {
+  core: CoreDef;
+  /** 직전 5분 context (시간 오름차순). 최신이 가장 마지막. */
+  context: BusEvent[];
+  /** 평가 대상 — 보통 context 의 마지막 event 와 동일. caller 가 명시. */
+  latest: BusEvent;
+}
+
+export interface PrefilterDecision {
+  react: boolean;
+  why: string;
+}
+
+/**
+ * 코어가 끼어들지 결정하는 cheap 모델용 프롬프트. silence default — 모호
+ * 시 `react=false` 가 정답. role 강제 X (capability 정의로만 자기 시각
+ * 자율 판단).
+ */
+export function buildPrefilterPrompt(input: PrefilterInput): string {
+  const c = input.core;
+  const ctx = formatActiveContext(input.context).slice(0, 2000);
+  const latest =
+    input.latest.type === 'core-utter'
+      ? `[코어:${input.latest.coreId || '?'}] ${input.latest.text}`
+      : `[${input.latest.authorName || '?'}] ${input.latest.text}`;
+  return [
+    `너는 에이전트 팀의 일원 "${c.displayName}" (id: ${c.id}) 의 *판단 head* 다. 이 채널 흐름에 끼어들지 말지 1초 안에 결정.`,
+    '',
+    `# 너의 capability (할 수 있는 것·권한 경계 — role 강제 X)`,
+    `- 직무: ${c.role || '(미정)'}`,
+    c.body
+      ? c.body.slice(0, 1500) // body 는 capability/직무/escalation 디테일
+      : '',
+    '',
+    `# 직전 5분 채널 흐름`,
+    ctx || '(empty)',
+    '',
+    `# 평가 대상 (가장 최근 발화)`,
+    latest,
+    '',
+    `# 결정 규칙`,
+    `- 본인이 *명확한 시각*(capability 관련, 더 잘 아는 분야, 멘션됨, 사실 정정)이 *있으면* react=true.`,
+    `- 시각이 모호하거나 다른 코어가 더 적합 → react=false. silence 가 default.`,
+    `- 사람처럼: 의무감으로 발화 X. false-positive 비용 > false-negative.`,
+    `- 사용자/다른 코어가 직접 호명·멘션 = react=true (멘션 우회).`,
+    '',
+    `# 출력 (JSON 한 줄, 추가 텍스트 X)`,
+    `{"react": true|false, "why": "<왜 그 결정인지 한 문장>"}`,
+  ].join('\n');
+}
+
+/**
+ * prefilter 응답을 안전하게 파싱. 비-JSON·노이즈 = silence(react=false).
+ * `{react: true|false, why: "..."}` 형식. JSON 코드펜스 동봉 시 추출.
+ */
+export function parsePrefilterResponse(raw: string): PrefilterDecision {
+  const t = (raw || '').trim();
+  if (!t) return { react: false, why: 'empty-response' };
+  // 코드펜스 제거.
+  const fenceStripped = t
+    .replace(/^```(?:json)?\s*([\s\S]*?)\s*```$/i, '$1')
+    .trim();
+  // 첫 `{ … }` 블록만.
+  const m = fenceStripped.match(/\{[\s\S]*\}/);
+  if (!m) return { react: false, why: 'no-json-found' };
+  try {
+    const obj = JSON.parse(m[0]) as { react?: unknown; why?: unknown };
+    const react = obj.react === true || obj.react === 'true';
+    const why = typeof obj.why === 'string' ? obj.why.slice(0, 200) : '';
+    return { react, why };
+  } catch {
+    return { react: false, why: 'parse-error' };
+  }
+}
+
+// ── D-5: main-model speak prompt ─────────────────────────────
+
+export interface SpeakInput {
+  core: CoreDef;
+  /** prefilter 가 판단한 why — 본인 발화 방향 단서. */
+  prefilterWhy: string;
+  /** 직전 5분 context (시간 오름차순). */
+  context: BusEvent[];
+  /** 평가 대상 — context 의 마지막 event 와 동일하거나 더 최근. */
+  latest: BusEvent;
+  /** 코어 mem 압축 블록 (`readRecentCoreMemory` 산출). 없으면 빈 문자열. */
+  recentMem?: string;
+  /** 사용자/팀 호명일 때 멘션 받았음을 LLM 에 명시. */
+  mentioned?: boolean;
+}
+
+/**
+ * 본 모델(main) speak prompt. capability + recent work-memory + active
+ * context. 페르소나/말투는 *스킨 레이어*(기존 chat-adapter / agent-webhook)
+ * 가 알아서 입힘 — 본 프롬프트는 *내용* 만 결정.
+ */
+export function buildSpeakPrompt(input: SpeakInput): string {
+  const c = input.core;
+  const ctx = formatActiveContext(input.context).slice(0, 2500);
+  const latest =
+    input.latest.type === 'core-utter'
+      ? `[코어:${input.latest.coreId || '?'}] ${input.latest.text}`
+      : `[${input.latest.authorName || '?'}] ${input.latest.text}`;
+  const memBlock = (input.recentMem || '').trim();
+  return [
+    `너는 에이전트 팀의 일원 "${c.displayName}" (id: ${c.id}) 다. 사람처럼 채팅에 *자율* 참여한다 (강제 발화 X — 본 호출 시점엔 너 스스로 끼어들기로 판단함).`,
+    '',
+    `# 너의 capability (할 수 있는 것·권한 경계)`,
+    `- 직무: ${c.role || '(미정)'}`,
+    c.body ? c.body.slice(0, 1500) : '',
+    '',
+    memBlock
+      ? `# 너의 최근 작업 기억 (work-memory, *너만의*)\n${memBlock}\n`
+      : '',
+    `# 직전 5분 채널 흐름`,
+    ctx || '(empty)',
+    '',
+    `# 평가 대상 (가장 최근 발화)`,
+    latest,
+    '',
+    `# prefilter 가 판단한 너의 시각`,
+    `- ${input.prefilterWhy || '(unspecified)'}`,
+    '',
+    input.mentioned
+      ? `# 멘션 우회 — 너는 직접 호명되었다. 사용자/동료에게 답하라.\n`
+      : '',
+    `# 발화 규칙`,
+    `- 1~3문장. 사람처럼 자연스럽게. 의무감으로 길게 X.`,
+    `- capability 안에서만 — 모르는 도메인은 다른 코어에게 넘기는 한 줄.`,
+    `- 의미 없는 동조·아첨·이모티콘 잠식 X. (페르소나 말투는 스킨이 입힘 — 본 출력은 내용만.)`,
+    `- 너의 직전 발화·context 와 중복되는 말 반복 X.`,
+    '',
+    `# 출력 (본문만, JSON·메타 X)`,
+  ]
+    .filter((line) => line !== '')
+    .join('\n');
+}

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-channel-bridge.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-channel-bridge.test.ts
@@ -1,0 +1,252 @@
+/**
+ * agent-channel-bridge 회귀 (TASK-KAR-018-LT-DIVERSITY D-2).
+ *
+ * substrate 입력의 *유일한 게이트*. 분류·멘션 파싱·자기루프 차단 의 핵심
+ * 회귀를 잠근다 (잘못 분류되면 daemon 이 self-loop 또는 잡음 폭주).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  parseMentionedCoreIds,
+  parseMentionedUserIds,
+  publishIncomingDiscord,
+  publishToBus,
+} from './agent-channel-bridge';
+import { readRecentBusEvents } from './agent-channel-bus';
+
+let root: string;
+const env = () => ({ MEMO_REPO_PATH: root }) as NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'channel-bridge-'));
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('parseMentionedCoreIds', () => {
+  const cores = [
+    { id: 'atlas', displayName: 'Atlas' },
+    { id: 'echo', displayName: 'Echo' },
+    { id: 'kar-worker', displayName: 'Kar' },
+  ];
+
+  it('@id 형식 매칭', () => {
+    expect(parseMentionedCoreIds('@atlas 의견 좀', cores)).toEqual(['atlas']);
+  });
+
+  it('호명 + 쉼표 형식 매칭', () => {
+    expect(parseMentionedCoreIds('echo, 도와줘', cores)).toEqual(['echo']);
+  });
+
+  it('displayName 도 매칭 (대소문자 무관)', () => {
+    expect(parseMentionedCoreIds('@Atlas 봐줘', cores)).toEqual(['atlas']);
+  });
+
+  it('일상 단어 false-positive 차단 (호명 구두점 없으면 매치 X)', () => {
+    // 'atlas' 가 본문 한가운데 단어로 나와도 '@' 나 ',:' 동반 없으면 매치 X
+    expect(parseMentionedCoreIds('나는 atlas 책을 읽었어', cores)).toEqual([]);
+  });
+
+  it('빈 텍스트 = 빈 배열', () => {
+    expect(parseMentionedCoreIds('', cores)).toEqual([]);
+  });
+
+  it('복수 멘션 모두 회수', () => {
+    const out = parseMentionedCoreIds('@atlas, @echo 둘 다 봐줘', cores);
+    expect(out.sort()).toEqual(['atlas', 'echo']);
+  });
+});
+
+describe('parseMentionedUserIds', () => {
+  it('Discord <@id> 멘션 회수', () => {
+    expect(parseMentionedUserIds('<@123456> 안녕')).toEqual(['123456']);
+  });
+
+  it('<@!id> nickname mention 도 회수', () => {
+    expect(parseMentionedUserIds('<@!987654321> 와')).toEqual(['987654321']);
+  });
+
+  it('멘션 없음 = []', () => {
+    expect(parseMentionedUserIds('plain text')).toEqual([]);
+  });
+
+  it('중복 user id 중복 제거', () => {
+    expect(parseMentionedUserIds('<@111111> <@111111> <@222222>').sort()).toEqual([
+      '111111',
+      '222222',
+    ]);
+  });
+});
+
+describe('publishIncomingDiscord — 분류 + bus write', () => {
+  it('사람 사용자 메시지 = channel-msg', () => {
+    const ev = publishIncomingDiscord(env(), {
+      channelId: 'C1',
+      messageId: 'M1',
+      ts: '2026-05-23T03:00:00.000Z',
+      text: '안녕',
+      authorId: 'u1',
+      authorName: 'fourth',
+      isBot: false,
+      isOwnAgentWebhook: false,
+    });
+    expect(ev?.type).toBe('channel-msg');
+    expect(ev?.source).toBe('discord');
+    const events = readRecentBusEvents(env(), 'C1', {
+      now: new Date('2026-05-23T05:00:00Z'),
+    });
+    expect(events.length).toBe(1);
+    expect(events[0].text).toBe('안녕');
+  });
+
+  it('봇 자기 agent webhook + coreId = core-utter', () => {
+    const ev = publishIncomingDiscord(env(), {
+      channelId: 'C1',
+      messageId: 'M2',
+      ts: '2026-05-23T03:00:00.000Z',
+      text: '안녕 사용자',
+      authorId: 'bot',
+      authorName: 'Atlas',
+      isBot: true,
+      webhookId: 'wh1',
+      isOwnAgentWebhook: true,
+      coreIdForWebhook: 'atlas',
+    });
+    expect(ev?.type).toBe('core-utter');
+    expect(ev?.coreId).toBe('atlas');
+  });
+
+  it('자기 agent webhook 인데 coreId 못 찾으면 skip (자기루프 차단)', () => {
+    const ev = publishIncomingDiscord(env(), {
+      channelId: 'C1',
+      messageId: 'M3',
+      ts: '2026-05-23T03:00:00.000Z',
+      text: '미식별 webhook',
+      authorId: 'bot',
+      authorName: 'wh',
+      isBot: true,
+      webhookId: 'wh1',
+      isOwnAgentWebhook: true,
+      coreIdForWebhook: null,
+    });
+    expect(ev).toBeNull();
+  });
+
+  it('외부 봇/webhook 메시지 = publish 안함 (substrate 잡음 차단)', () => {
+    const ev = publishIncomingDiscord(env(), {
+      channelId: 'C1',
+      messageId: 'M4',
+      ts: '2026-05-23T03:00:00.000Z',
+      text: '외부 봇',
+      authorId: 'otherbot',
+      authorName: 'OtherBot',
+      isBot: true,
+      webhookId: null,
+      isOwnAgentWebhook: false,
+    });
+    expect(ev).toBeNull();
+  });
+
+  it('빈 텍스트 = publish 안함', () => {
+    const ev = publishIncomingDiscord(env(), {
+      channelId: 'C1',
+      messageId: 'M5',
+      ts: '2026-05-23T03:00:00.000Z',
+      text: '',
+      authorId: 'u1',
+      authorName: 'u',
+      isBot: false,
+      isOwnAgentWebhook: false,
+    });
+    expect(ev).toBeNull();
+  });
+
+  it('mentionedCoreIds 가 BusEvent.refs 에 채워짐 (멘션 우회 결정 입력)', () => {
+    const ev = publishIncomingDiscord(
+      env(),
+      {
+        channelId: 'C1',
+        messageId: 'M6',
+        ts: '2026-05-23T03:00:00.000Z',
+        text: '@echo 봐줘',
+        authorId: 'u1',
+        authorName: 'u',
+        isBot: false,
+        isOwnAgentWebhook: false,
+      },
+      [{ id: 'echo', displayName: 'Echo' }],
+    );
+    expect(ev?.refs?.mentionedCoreIds).toEqual(['echo']);
+  });
+
+  it('mentionedUserIds 도 refs 에 채워짐', () => {
+    const ev = publishIncomingDiscord(
+      env(),
+      {
+        channelId: 'C1',
+        messageId: 'M7',
+        ts: '2026-05-23T03:00:00.000Z',
+        text: '<@111111> 봐줘',
+        authorId: 'u1',
+        authorName: 'u',
+        isBot: false,
+        isOwnAgentWebhook: false,
+      },
+      [],
+    );
+    expect(ev?.refs?.mentionedUserIds).toEqual(['111111']);
+  });
+
+  it('MEMO_REPO_PATH 미설정 = null + 봇 진행 비차단', () => {
+    const ev = publishIncomingDiscord(
+      {} as NodeJS.ProcessEnv,
+      {
+        channelId: 'C1',
+        messageId: 'M8',
+        ts: '2026-05-23T03:00:00.000Z',
+        text: 'hi',
+        authorId: 'u1',
+        authorName: 'u',
+        isBot: false,
+        isOwnAgentWebhook: false,
+      },
+      [],
+    );
+    expect(ev).toBeNull();
+  });
+});
+
+describe('publishToBus — daemon/KL adapter 공통 entry', () => {
+  it('core-utter publish 가능 (daemon path)', () => {
+    const ev = publishToBus(env(), {
+      source: 'agent-runtime',
+      channelId: 'C1',
+      ts: '2026-05-23T03:00:00.000Z',
+      text: '제 의견은…',
+      coreId: 'atlas',
+      type: 'core-utter',
+    });
+    expect(ev?.type).toBe('core-utter');
+  });
+
+  it('core-utter 인데 coreId 누락 = null (스키마 보호)', () => {
+    const ev = publishToBus(env(), {
+      source: 'agent-runtime',
+      channelId: 'C1',
+      text: '익명 utter',
+      type: 'core-utter',
+    });
+    expect(ev).toBeNull();
+  });
+
+  it('알려지지 않은 type 도 null (보호)', () => {
+    const ev = publishToBus(env(), {
+      source: 'x',
+      channelId: 'C1',
+      text: 't',
+      type: 'unknown' as any,
+    });
+    expect(ev).toBeNull();
+  });
+});

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-channel-bridge.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-channel-bridge.ts
@@ -1,0 +1,224 @@
+/**
+ * agent-channel-bridge — Discord ↔ agent-channel-bus 의 *thin* adapter
+ * (TASK-KAR-018-LT-DIVERSITY, D-2).
+ *
+ * 왜 분리:
+ * 본 모듈 = Discord *MessageCreate* 를 substrate(`agent-channel-bus`) 에
+ * 비추는 단방향 publisher 만 담는다. 코어 정체성/LLM 호출/dispatch 로직 X.
+ * 다른 adapter(KL/Web/CLI) 도 *같은 substrate* 에 같은 schema 로 publish
+ * → daemon 입장에선 출처 무관(Discord 죽어도 KL 살아있으면 채널 입력 계속).
+ *
+ * 안전 바닥:
+ *   - substrate 미가용(MEMO_REPO_PATH 미설정 / 채널 unsafe) = silent no-op.
+ *     publish 실패가 봇 진행을 막지 X (best-effort, throw X).
+ *   - 봇 자기 webhook(자기 utter) 도 publish — 모든 채널 흐름의 *전체 기록*
+ *     이 substrate. 단 `coreId` 가 부여된 utter 는 `type='core-utter'` 로
+ *     일관 분류 → 다른 daemon 이 echo loop 회피 가능 (own coreId 무시).
+ *   - bot/system 메시지(코어 webhook X)는 publish X (잡음 차단).
+ *
+ * D-2 시점에는 *publish only*. subscribe 는 D-3 daemon 이 직접
+ * `readRecentBusEvents` 로 tail. 향후 D-14 KL adapter 도 같은 publish API
+ * 만 호출하면 됨 (Discord 의존 X — 본 모듈은 *publish 결정 표면* + Discord
+ * 전용 추출은 `extractDiscordPublish` 가 담당).
+ */
+import type { Message } from 'discord.js';
+import {
+  appendBusEvent,
+  type BusEvent,
+  type BusEventRefs,
+} from './agent-channel-bus';
+
+/** Discord <@123…> 형식 user 멘션 1개 이상. */
+const USER_MENTION_RX = /<@!?(\d{5,})>/g;
+
+/**
+ * 텍스트에서 코어 이름 멘션 파싱 (순수). known core id/displayName 둘 다
+ * 매칭. 첫 단어 호명 + `@<name>` 형식 + 본문 중간 `@<name>` 모두 회수.
+ * 멘션 우회(rate-limit bypass) 의 결정 입력 — daemon 이 본인 id 가
+ * mentionedCoreIds 에 있으면 강제 평가.
+ */
+export function parseMentionedCoreIds(
+  text: string,
+  knownCores: { id: string; displayName?: string }[],
+): string[] {
+  const t = (text || '').toLowerCase();
+  if (!t) return [];
+  const out = new Set<string>();
+  for (const c of knownCores) {
+    const id = (c.id || '').toLowerCase();
+    if (!id) continue;
+    const names = [id];
+    const dn = (c.displayName || '').toLowerCase();
+    if (dn && dn !== id) names.push(dn);
+    for (const n of names) {
+      // `@name`, `name,`, `name:`, 단어 경계 — 일상 단어가 코어 id 와 같은
+      // 경우 false-positive 위험 → `@` 접두 또는 호명 구두점 동반 시만.
+      const esc = n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const re = new RegExp(`(^|[\\s,])@${esc}(\\b|[\\s,:.!?])|(^|[\\s])${esc}\\s*[,:]`, 'u');
+      if (re.test(t)) {
+        out.add(c.id);
+        break;
+      }
+    }
+  }
+  return Array.from(out);
+}
+
+/** Discord <@id> user 멘션 회수 (순수). */
+export function parseMentionedUserIds(text: string): string[] {
+  const out = new Set<string>();
+  if (!text) return [];
+  let m: RegExpExecArray | null;
+  USER_MENTION_RX.lastIndex = 0;
+  while ((m = USER_MENTION_RX.exec(text)) !== null) {
+    out.add(m[1]);
+  }
+  return Array.from(out);
+}
+
+/** publish 입력 (Discord 전용 — adapter 가 추출해서 본 모듈에 넘김). */
+export interface IncomingDiscordPublishOpts {
+  /** 채널 id (bus dir key). */
+  channelId: string;
+  /** 메시지 id (replyToTs 등 향후). */
+  messageId: string;
+  /** 발화 시각 (Discord createdAt 또는 now). ISO 권장. */
+  ts: string;
+  /** 본문 (raw 그대로 — daemon 측에서 정규화). */
+  text: string;
+  /** 작성자 id. */
+  authorId: string;
+  /** 작성자 username (UX). */
+  authorName: string;
+  /** 봇/webhook 메시지 여부. */
+  isBot: boolean;
+  /** webhook 메시지면 webhookId. */
+  webhookId?: string | null;
+  /** 봇 자기 agent webhook 메시지인지 (코어 utter 분류 단서). */
+  isOwnAgentWebhook: boolean;
+  /** agent webhook 인 경우 코어 id (resolveCoreFromWebhook). */
+  coreIdForWebhook?: string | null;
+  /** answer/reply 가리키는 원본 ts (옵션). */
+  replyToTs?: string;
+}
+
+/** 알려진 코어 목록 (멘션 파싱용). */
+export interface KnownCoreSummary {
+  id: string;
+  displayName?: string;
+}
+
+/**
+ * Discord 측에서 모아온 데이터를 BusEvent 로 publish (best-effort, throw X).
+ *
+ * 분류 규칙:
+ *   - 봇 자기 agent webhook 이고 coreId 확정 = `core-utter` (코어 발화).
+ *   - 그 외 봇/webhook = publish X (잡음 차단: 다른 봇 발화는 substrate 잡음).
+ *   - 사람 사용자 = `channel-msg`.
+ *
+ * 반환 = publish 한 BusEvent (or null = skip). 호출자(main.ts)는 결과를
+ * 확인할 필요 X — 비차단·로깅용만.
+ */
+export function publishIncomingDiscord(
+  env: NodeJS.ProcessEnv,
+  opts: IncomingDiscordPublishOpts,
+  knownCores: KnownCoreSummary[] = [],
+): BusEvent | null {
+  if (!opts || !opts.channelId || !opts.text) return null;
+  // 채널-msg 또는 코어-utter 외 잡음 차단.
+  let type: 'channel-msg' | 'core-utter';
+  let coreId: string | undefined;
+  if (opts.isOwnAgentWebhook) {
+    if (!opts.coreIdForWebhook) return null; // 코어 식별 못하면 skip (자기루프 차단)
+    type = 'core-utter';
+    coreId = opts.coreIdForWebhook;
+  } else if (opts.isBot) {
+    return null; // 외부 봇/webhook = 잡음
+  } else {
+    type = 'channel-msg';
+  }
+  const refs: BusEventRefs = {};
+  const mentionedCoreIds = parseMentionedCoreIds(opts.text, knownCores);
+  if (mentionedCoreIds.length > 0) refs.mentionedCoreIds = mentionedCoreIds;
+  const mentionedUserIds = parseMentionedUserIds(opts.text);
+  if (mentionedUserIds.length > 0) refs.mentionedUserIds = mentionedUserIds;
+  if (opts.replyToTs) refs.replyToTs = opts.replyToTs;
+
+  const event: BusEvent = {
+    ts: opts.ts || new Date().toISOString(),
+    source: 'discord',
+    type,
+    channelId: opts.channelId,
+    coreId,
+    authorName: opts.authorName,
+    authorId: opts.authorId,
+    text: opts.text,
+    refs: Object.keys(refs).length > 0 ? refs : undefined,
+  };
+  return appendBusEvent(env, event) ? event : null;
+}
+
+/**
+ * 본 PR 의 daemon (D-3) 도 core-utter publish 시 같은 함수 경유 — adapter
+ * 와 substrate 사이의 *유일한 입구*. 향후 KL adapter 도 source='kl' 로
+ * 같은 패턴 (외부 사용자 발화·코어 발화 둘 다 적합).
+ */
+export interface IncomingPublishOpts {
+  source: string;
+  channelId: string;
+  ts?: string;
+  text: string;
+  authorId?: string;
+  authorName?: string;
+  coreId?: string;
+  /** 'channel-msg' (외부 사용자) | 'core-utter' (코어 발화). */
+  type: 'channel-msg' | 'core-utter';
+  refs?: BusEventRefs;
+}
+
+export function publishToBus(
+  env: NodeJS.ProcessEnv,
+  opts: IncomingPublishOpts,
+): BusEvent | null {
+  if (!opts || !opts.channelId || !opts.text || !opts.type) return null;
+  if (opts.type === 'core-utter' && !opts.coreId) return null;
+  const event: BusEvent = {
+    ts: opts.ts || new Date().toISOString(),
+    source: opts.source || 'unknown',
+    type: opts.type,
+    channelId: opts.channelId,
+    coreId: opts.coreId,
+    authorName: opts.authorName,
+    authorId: opts.authorId,
+    text: opts.text,
+    refs: opts.refs,
+  };
+  return appendBusEvent(env, event) ? event : null;
+}
+
+/**
+ * Discord Message 객체에서 publish 옵션 추출 (Discord 의존부 isolation).
+ * 호출자(main.ts) 가 멤버 데이터 접근 — 본 모듈은 Discord 타입 import 만.
+ */
+export function extractDiscordPublish(
+  message: Message,
+  helpers: {
+    isOwnAgentWebhook: (webhookId: string | null | undefined) => boolean;
+    coreIdForWebhook: (webhookId: string | null | undefined) => string | null;
+  },
+): IncomingDiscordPublishOpts {
+  const webhookId = (message as { webhookId?: string | null }).webhookId ?? null;
+  const own = helpers.isOwnAgentWebhook(webhookId);
+  return {
+    channelId: message.channel.id,
+    messageId: message.id,
+    ts: message.createdAt?.toISOString?.() || new Date().toISOString(),
+    text: (message.content || '').trim(),
+    authorId: message.author?.id || '',
+    authorName: message.author?.username || message.author?.tag || 'unknown',
+    isBot: !!message.author?.bot,
+    webhookId,
+    isOwnAgentWebhook: own,
+    coreIdForWebhook: own ? helpers.coreIdForWebhook(webhookId) : null,
+  };
+}

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-channel-bus-publisher.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-channel-bus-publisher.test.ts
@@ -1,0 +1,221 @@
+/**
+ * agent-channel-bus-publisher 회귀 (TASK-KAR-018-LT-DIVERSITY D-7 substrate
+ * 완결). 자기루프 차단·실패 재시도 X·lastSeenTs 진전·excludeSources override
+ * 의 결정 흐름 잠금.
+ */
+import { describe, it, expect } from 'vitest';
+import type { BusEvent } from './agent-channel-bus';
+import {
+  publisherTickOnce,
+  summarizePublisherTick,
+  type PublisherDeps,
+  type PublisherState,
+} from './agent-channel-bus-publisher';
+
+const NOW = new Date('2026-05-23T03:00:00.000Z');
+
+interface Spy {
+  speakCalls: { coreId: string; text: string }[];
+  speakOk: boolean;
+  throwOnce?: boolean;
+}
+
+function mkDeps(events: BusEvent[], spy: Spy): PublisherDeps {
+  return {
+    readSince: (channelId: string, sinceTs: string) => {
+      const ms = sinceTs ? Date.parse(sinceTs) : -Infinity;
+      return events.filter(
+        (e) => e.channelId === channelId && Date.parse(e.ts) > ms,
+      );
+    },
+    speak: async (coreId, text) => {
+      spy.speakCalls.push({ coreId, text });
+      if (spy.throwOnce) {
+        spy.throwOnce = false;
+        throw new Error('discord-fail');
+      }
+      return spy.speakOk;
+    },
+    now: () => NOW,
+  };
+}
+
+function ev(overrides: Partial<BusEvent>): BusEvent {
+  return {
+    ts: NOW.toISOString(),
+    source: 'agent-runtime',
+    type: 'core-utter',
+    channelId: 'team-bus',
+    coreId: 'echo',
+    text: '내 시각.',
+    ...overrides,
+  };
+}
+
+describe('publisherTickOnce', () => {
+  it('표면화: agent-runtime core-utter 만 speak 호출', async () => {
+    const events = [
+      ev({ ts: '2026-05-23T02:55:00.000Z', text: 'first' }),
+      ev({ ts: '2026-05-23T02:56:00.000Z', text: 'second' }),
+    ];
+    const spy: Spy = { speakCalls: [], speakOk: true };
+    const m = await publisherTickOnce(
+      { lastSeenTs: '' },
+      mkDeps(events, spy),
+      { channelId: 'team-bus' },
+    );
+    expect(m.scanned).toBe(2);
+    expect(m.attempted).toBe(2);
+    expect(m.posted).toBe(2);
+    expect(m.failed).toBe(0);
+    expect(m.skipped).toBe(0);
+    expect(spy.speakCalls).toEqual([
+      { coreId: 'echo', text: 'first' },
+      { coreId: 'echo', text: 'second' },
+    ]);
+    expect(m.lastSeenTs).toBe('2026-05-23T02:56:00.000Z');
+  });
+
+  it('자기루프 차단: in-process source = skip (이미 표면화된 mirror)', async () => {
+    const events = [
+      ev({ source: 'in-process', ts: '2026-05-23T02:55:00.000Z', text: 'mirror' }),
+      ev({ source: 'agent-runtime', ts: '2026-05-23T02:56:00.000Z', text: 'real' }),
+    ];
+    const spy: Spy = { speakCalls: [], speakOk: true };
+    const m = await publisherTickOnce(
+      { lastSeenTs: '' },
+      mkDeps(events, spy),
+      { channelId: 'team-bus' },
+    );
+    expect(m.skipped).toBe(1);
+    expect(m.attempted).toBe(1);
+    expect(m.posted).toBe(1);
+    expect(spy.speakCalls).toEqual([{ coreId: 'echo', text: 'real' }]);
+  });
+
+  it('channel-msg(외부 사용자) = skip (표면화 대상 X)', async () => {
+    const events = [
+      ev({ type: 'channel-msg', coreId: undefined, text: '사용자 메시지', ts: '2026-05-23T02:55:00.000Z' }),
+    ];
+    const spy: Spy = { speakCalls: [], speakOk: true };
+    const m = await publisherTickOnce(
+      { lastSeenTs: '' },
+      mkDeps(events, spy),
+      { channelId: 'team-bus' },
+    );
+    expect(m.skipped).toBe(1);
+    expect(m.attempted).toBe(0);
+    expect(spy.speakCalls).toEqual([]);
+  });
+
+  it('coreId 누락된 core-utter = skip (방어적)', async () => {
+    const events = [
+      ev({ coreId: undefined, text: '코어 미상', ts: '2026-05-23T02:55:00.000Z' }),
+    ];
+    const spy: Spy = { speakCalls: [], speakOk: true };
+    const m = await publisherTickOnce(
+      { lastSeenTs: '' },
+      mkDeps(events, spy),
+      { channelId: 'team-bus' },
+    );
+    expect(m.skipped).toBe(1);
+    expect(m.attempted).toBe(0);
+  });
+
+  it('speak 실패: failed++ · lastSeenTs 진전 · 재시도 X', async () => {
+    const events = [
+      ev({ ts: '2026-05-23T02:55:00.000Z', text: 'will-fail' }),
+      ev({ ts: '2026-05-23T02:56:00.000Z', text: 'next' }),
+    ];
+    const spy: Spy = { speakCalls: [], speakOk: false };
+    const m = await publisherTickOnce(
+      { lastSeenTs: '' },
+      mkDeps(events, spy),
+      { channelId: 'team-bus' },
+    );
+    expect(m.attempted).toBe(2);
+    expect(m.posted).toBe(0);
+    expect(m.failed).toBe(2);
+    expect(m.lastSeenTs).toBe('2026-05-23T02:56:00.000Z');
+  });
+
+  it('speak throw = failed (catch 안전망)', async () => {
+    const events = [ev({ ts: '2026-05-23T02:55:00.000Z' })];
+    const spy: Spy = { speakCalls: [], speakOk: true, throwOnce: true };
+    const m = await publisherTickOnce(
+      { lastSeenTs: '' },
+      mkDeps(events, spy),
+      { channelId: 'team-bus' },
+    );
+    expect(m.failed).toBe(1);
+    expect(m.posted).toBe(0);
+  });
+
+  it('lastSeenTs cursor: 이전 이후만 처리', async () => {
+    const events = [
+      ev({ ts: '2026-05-23T02:50:00.000Z', text: 'old' }),
+      ev({ ts: '2026-05-23T02:55:00.000Z', text: 'new' }),
+    ];
+    const spy: Spy = { speakCalls: [], speakOk: true };
+    const m = await publisherTickOnce(
+      { lastSeenTs: '2026-05-23T02:52:00.000Z' },
+      mkDeps(events, spy),
+      { channelId: 'team-bus' },
+    );
+    expect(m.scanned).toBe(1);
+    expect(spy.speakCalls.map((c) => c.text)).toEqual(['new']);
+  });
+
+  it('excludeSources override: empty 배열 = default in-process 적용', async () => {
+    const events = [ev({ source: 'in-process', text: 'mirror' })];
+    const spy: Spy = { speakCalls: [], speakOk: true };
+    const m = await publisherTickOnce(
+      { lastSeenTs: '' },
+      mkDeps(events, spy),
+      { channelId: 'team-bus', excludeSources: [] },
+    );
+    expect(m.skipped).toBe(1);
+  });
+
+  it('excludeSources override: 명시 source 차단', async () => {
+    const events = [
+      ev({ source: 'agent-runtime', text: 'runtime' }),
+      ev({ source: 'kl', text: 'kl', ts: '2026-05-23T02:56:00.000Z' }),
+    ];
+    const spy: Spy = { speakCalls: [], speakOk: true };
+    const m = await publisherTickOnce(
+      { lastSeenTs: '' },
+      mkDeps(events, spy),
+      { channelId: 'team-bus', excludeSources: ['kl'] },
+    );
+    expect(m.skipped).toBe(1);
+    expect(m.attempted).toBe(1);
+    expect(spy.speakCalls.map((c) => c.text)).toEqual(['runtime']);
+  });
+
+  it('빈 bus: noop', async () => {
+    const spy: Spy = { speakCalls: [], speakOk: true };
+    const m = await publisherTickOnce(
+      { lastSeenTs: '2026-05-22T00:00:00.000Z' },
+      mkDeps([], spy),
+      { channelId: 'team-bus' },
+    );
+    expect(m.scanned).toBe(0);
+    expect(m.attempted).toBe(0);
+    expect(m.lastSeenTs).toBe('2026-05-22T00:00:00.000Z');
+  });
+
+  it('summarizePublisherTick: 한 줄 포맷', () => {
+    const line = summarizePublisherTick({
+      scanned: 5,
+      skipped: 2,
+      attempted: 3,
+      posted: 2,
+      failed: 1,
+      lastSeenTs: '2026-05-23T02:55:00.000Z',
+    });
+    expect(line).toContain('scanned=5');
+    expect(line).toContain('posted=2');
+    expect(line).toContain('fail=1');
+  });
+});

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-channel-bus-publisher.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-channel-bus-publisher.ts
@@ -1,0 +1,149 @@
+/**
+ * agent-channel-bus-publisher — bus → Discord 표면화 (TASK-KAR-018-LT-DIVERSITY,
+ * D-7 substrate 완결).
+ *
+ * 왜 분리:
+ * daemon(`agent-runtime-daemon`)은 발화 결과를 `core-utter` 로 bus 에 publish
+ * 만 한다 — Discord(또는 다른 어댑터) 의존 0 (substrate⊥어댑터). 그 utter 가
+ * 실제로 사용자 채널에 뜨려면 *adapter 쪽에서* bus 를 tail 해 표면(=Discord
+ * webhook)으로 post 해야 한다. 본 모듈이 그 *yawnbot 측 subscriber*.
+ *
+ * 대칭:
+ *   - daemon  : publish core-utter to bus (source='agent-runtime')
+ *   - publisher: tail bus, find new core-utter, call DI'd `speak(coreId, text)`
+ *                → Discord webhook (sendAsSkin 재사용).
+ *   - 다른 어댑터(KL/Web) 도 같은 substrate 만 보면 됨 — daemon 코드 무변경.
+ *
+ * 본 모듈 = pure. fs/discord 직접 의존 X. caller(main.ts)가:
+ *   1. `readSince` 로 bus tail (현재 yawnbot 가 알고있는 채널만)
+ *   2. `speak(coreId, text)` 로 Discord 표면(현재 `setCoreSpeak` 배선)
+ *   3. lastSeenTs 외부 보관 (재기동 시 어디서 다시 시작할지 — daemon 의
+ *      `DaemonState` 와 동형).
+ *
+ * 자기루프 / 중복 차단:
+ *   - 'in-process' source 의 core-utter 는 *이미* 봇 자체 webhook 으로
+ *     Discord 에 뜬 발화의 mirror 다(가시화/감사 목적) — 다시 post X.
+ *   - 멱등 키 = `${coreId}:${ts}`(events 의 자연 키). 이미 본 키 = skip.
+ *   - publish 실패(speak returned false) = 다음 tick 재시도 X (lastSeenTs 진전).
+ *     Discord 실패는 *그 utter 의 손실* 만; 재시도 폭주 회피.
+ */
+import type { BusEvent } from './agent-channel-bus';
+
+/** publisher tick 상태. caller 가 외부 보관. */
+export interface PublisherState {
+  /** 마지막으로 처리한 BusEvent ts (ISO). 초기 = '' (오늘 처음 본 거부터). */
+  lastSeenTs: string;
+}
+
+/**
+ * DI — bus reader / Discord speak / clock.
+ * speak(coreId, text) = best-effort, true 면 표면화 성공. false = 손실.
+ */
+export interface PublisherDeps {
+  /** bus tail — sinceTs 이후 BusEvent 회수 (시간 오름차순). */
+  readSince: (channelId: string, sinceTs: string) => BusEvent[];
+  /** Discord webhook 등 표면 post — true 면 표면화 성공. */
+  speak: (coreId: string, text: string) => Promise<boolean>;
+  /** "지금"(테스트 inject). */
+  now?: () => Date;
+}
+
+export interface PublisherTickOpts {
+  /** tail 할 채널 id. */
+  channelId: string;
+  /**
+   * 표면화 *제외* 할 source 들 (default = ['in-process']).
+   * 이미 yawnbot 자체 webhook 으로 표면화된 utter 는 mirror 일 뿐 — 본 publisher
+   * 가 다시 post 하면 *같은 발화 2번* (자기루프). source='agent-runtime'(외부
+   * daemon) 만 표면화 default.
+   */
+  excludeSources?: string[];
+}
+
+export interface PublisherTickMetrics {
+  /** 회수한 BusEvent 총수 (since lastSeenTs). */
+  scanned: number;
+  /** 자기루프(excludeSources 매칭) / non-core-utter 으로 skip 수. */
+  skipped: number;
+  /** speak 호출 (실제 표면화 시도) 수. */
+  attempted: number;
+  /** speak 가 true 반환 (Discord post 성공) 수. */
+  posted: number;
+  /** speak 가 false 반환 (or throw) 한 수. */
+  failed: number;
+  /** 처리한 가장 마지막 BusEvent ts — 다음 tick 의 sinceTs. */
+  lastSeenTs: string;
+}
+
+/**
+ * 한 tick = bus 의 새 event 들을 표면화. caller 가 짧은 주기(1~3s)로 호출.
+ * Discord 실패한 utter 는 *재시도 X* (다음 tick 에 lastSeenTs 진전 — 폭주
+ * 회피, 손실 가시화는 metrics.failed 로).
+ */
+export async function publisherTickOnce(
+  state: PublisherState,
+  deps: PublisherDeps,
+  opts: PublisherTickOpts,
+): Promise<PublisherTickMetrics> {
+  const since = state.lastSeenTs || '';
+  const all = deps.readSince(opts.channelId, since);
+  const exclude = new Set(
+    opts.excludeSources && opts.excludeSources.length > 0
+      ? opts.excludeSources
+      : ['in-process'],
+  );
+  const metrics: PublisherTickMetrics = {
+    scanned: all.length,
+    skipped: 0,
+    attempted: 0,
+    posted: 0,
+    failed: 0,
+    lastSeenTs: state.lastSeenTs,
+  };
+  if (all.length === 0) return metrics;
+
+  // 시간 오름차순 보장 (안전망 — readSince contract 가 unsorted 일 가능성).
+  all.sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts));
+
+  for (const event of all) {
+    // 마지막 처리 ts 진전 — skip/fail 무관 (재시도 폭주 회피).
+    if (
+      !metrics.lastSeenTs ||
+      Date.parse(event.ts) > Date.parse(metrics.lastSeenTs)
+    ) {
+      metrics.lastSeenTs = event.ts;
+    }
+    // core-utter 가 아니거나 coreId 없으면 표면화 대상 X.
+    if (event.type !== 'core-utter' || !event.coreId) {
+      metrics.skipped++;
+      continue;
+    }
+    // excludeSources(default='in-process') = 자기루프 — 이미 표면화됨.
+    if (exclude.has(event.source)) {
+      metrics.skipped++;
+      continue;
+    }
+    metrics.attempted++;
+    let ok = false;
+    try {
+      ok = await deps.speak(event.coreId, event.text);
+    } catch {
+      ok = false;
+    }
+    if (ok) metrics.posted++;
+    else metrics.failed++;
+  }
+  return metrics;
+}
+
+/** UX 한 줄 (heartbeat/디버깅용). */
+export function summarizePublisherTick(m: PublisherTickMetrics): string {
+  return [
+    `[bus-publisher]`,
+    `scanned=${m.scanned}`,
+    `skip=${m.skipped}`,
+    `try=${m.attempted}`,
+    `posted=${m.posted}`,
+    `fail=${m.failed}`,
+  ].join(' ');
+}

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-channel-bus.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-channel-bus.test.ts
@@ -1,0 +1,265 @@
+/**
+ * agent-channel-bus 순수부 회귀 (TASK-KAR-018-LT-DIVERSITY D-1).
+ *
+ * substrate ↔ adapter race-free 의 핵심: append-only + KST 일자 회전 + 손상
+ * 라인 graceful skip. 일자 경계 + 잘못된 schema + sinceTs 슬라이싱 잠금.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  appendBusEvent,
+  readRecentBusEvents,
+  lastCoreUtterTs,
+  dayFilePath,
+  busDir,
+  channelDir,
+} from './agent-channel-bus';
+
+let root: string;
+const env = () => ({ MEMO_REPO_PATH: root }) as NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'channel-bus-'));
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('path resolvers', () => {
+  it('MEMO_REPO_PATH 미설정 = busDir 빈 문자열', () => {
+    expect(busDir({} as NodeJS.ProcessEnv)).toBe('');
+    expect(channelDir({} as NodeJS.ProcessEnv, 'c1')).toBe('');
+    expect(dayFilePath({} as NodeJS.ProcessEnv, 'c1')).toBe('');
+  });
+
+  it('부적합 channelId(path traversal 시도) = 빈 문자열', () => {
+    expect(channelDir(env(), '../escape')).toBe('');
+    expect(channelDir(env(), 'a/b')).toBe('');
+    expect(dayFilePath(env(), 'a/b')).toBe('');
+  });
+
+  it('안전 channelId = path 정상 합성', () => {
+    const d = channelDir(env(), 'team-bus_1234');
+    expect(d).toMatch(/agent-channel-bus[\\/]team-bus_1234$/);
+  });
+});
+
+describe('appendBusEvent / readRecentBusEvents 라운드트립', () => {
+  it('append → readRecent 가 같은 event 회수 (channel-msg)', () => {
+    const ok = appendBusEvent(env(), {
+      ts: '2026-05-23T03:00:00.000Z',
+      source: 'discord',
+      type: 'channel-msg',
+      channelId: 'C1',
+      authorName: 'user',
+      authorId: 'u1',
+      text: 'hi',
+    });
+    expect(ok).toBe(true);
+    const events = readRecentBusEvents(env(), 'C1', {
+      now: new Date('2026-05-23T05:00:00.000Z'),
+    });
+    expect(events.length).toBe(1);
+    expect(events[0].text).toBe('hi');
+    expect(events[0].type).toBe('channel-msg');
+  });
+
+  it('core-utter 는 coreId 누락 시 거부 (스키마 노이즈 차단)', () => {
+    const ok = appendBusEvent(env(), {
+      ts: '2026-05-23T03:00:00.000Z',
+      source: 'agent-runtime',
+      type: 'core-utter',
+      channelId: 'C1',
+      text: '발화',
+    } as any);
+    expect(ok).toBe(false);
+  });
+
+  it('잘못된 type 거부', () => {
+    const ok = appendBusEvent(env(), {
+      ts: '2026-05-23T03:00:00.000Z',
+      source: 'x',
+      type: 'unknown-type' as any,
+      channelId: 'C1',
+      text: 't',
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('부적합 channelId = false (substrate 보호)', () => {
+    const ok = appendBusEvent(env(), {
+      ts: '2026-05-23T03:00:00.000Z',
+      source: 'discord',
+      type: 'channel-msg',
+      channelId: '../traversal',
+      text: 't',
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('MEMO_REPO_PATH 미설정 = false (substrate 미가용 graceful)', () => {
+    const ok = appendBusEvent({} as NodeJS.ProcessEnv, {
+      ts: 'now',
+      source: 'discord',
+      type: 'channel-msg',
+      channelId: 'C1',
+      text: 'hi',
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('sinceTs 이후 event 만 회수 (exclusive)', () => {
+    appendBusEvent(env(), {
+      ts: '2026-05-23T03:00:00.000Z',
+      source: 'd',
+      type: 'channel-msg',
+      channelId: 'C1',
+      text: 'a',
+    });
+    appendBusEvent(env(), {
+      ts: '2026-05-23T04:00:00.000Z',
+      source: 'd',
+      type: 'channel-msg',
+      channelId: 'C1',
+      text: 'b',
+    });
+    appendBusEvent(env(), {
+      ts: '2026-05-23T05:00:00.000Z',
+      source: 'd',
+      type: 'channel-msg',
+      channelId: 'C1',
+      text: 'c',
+    });
+    const events = readRecentBusEvents(env(), 'C1', {
+      sinceTs: '2026-05-23T04:00:00.000Z',
+      now: new Date('2026-05-23T06:00:00.000Z'),
+    });
+    expect(events.map((e) => e.text)).toEqual(['c']);
+  });
+
+  it('손상된 JSON 라인은 skip — 다른 라인은 회수', () => {
+    appendBusEvent(env(), {
+      ts: '2026-05-23T03:00:00.000Z',
+      source: 'd',
+      type: 'channel-msg',
+      channelId: 'C1',
+      text: 'ok',
+    });
+    // 일자 파일에 손상 라인을 직접 추가.
+    const p = dayFilePath(env(), 'C1', new Date('2026-05-23T03:00:00.000Z'));
+    fs.appendFileSync(p, '{not-json\n');
+    appendBusEvent(env(), {
+      ts: '2026-05-23T04:00:00.000Z',
+      source: 'd',
+      type: 'channel-msg',
+      channelId: 'C1',
+      text: 'still-ok',
+    });
+    const events = readRecentBusEvents(env(), 'C1', {
+      now: new Date('2026-05-23T06:00:00.000Z'),
+    });
+    expect(events.map((e) => e.text)).toEqual(['ok', 'still-ok']);
+  });
+
+  it('daysBack=0 이면 오늘 일자만 회수 (어제 event 안 보임)', () => {
+    // 어제(KST) 일자 파일에 강제 박기 — appendBusEvent 가 ts 기반 일자 파일 결정.
+    appendBusEvent(env(), {
+      ts: '2026-05-22T03:00:00.000Z',
+      source: 'd',
+      type: 'channel-msg',
+      channelId: 'C1',
+      text: 'yesterday',
+    });
+    appendBusEvent(env(), {
+      ts: '2026-05-23T03:00:00.000Z',
+      source: 'd',
+      type: 'channel-msg',
+      channelId: 'C1',
+      text: 'today',
+    });
+    const today = readRecentBusEvents(env(), 'C1', {
+      now: new Date('2026-05-23T06:00:00.000Z'),
+      daysBack: 0,
+    });
+    expect(today.map((e) => e.text)).toEqual(['today']);
+
+    const both = readRecentBusEvents(env(), 'C1', {
+      now: new Date('2026-05-23T06:00:00.000Z'),
+      daysBack: 1,
+    });
+    expect(both.map((e) => e.text)).toEqual(['yesterday', 'today']);
+  });
+
+  it('limit = 가장 최근 N 만 (누적 cap)', () => {
+    for (let i = 0; i < 5; i++) {
+      appendBusEvent(env(), {
+        ts: `2026-05-23T03:00:0${i}.000Z`,
+        source: 'd',
+        type: 'channel-msg',
+        channelId: 'C1',
+        text: `m${i}`,
+      });
+    }
+    const events = readRecentBusEvents(env(), 'C1', {
+      now: new Date('2026-05-23T06:00:00.000Z'),
+      limit: 3,
+    });
+    expect(events.map((e) => e.text)).toEqual(['m2', 'm3', 'm4']);
+  });
+
+  it('text 6000자 초과 = slice (저장 폭발 방지)', () => {
+    const huge = 'x'.repeat(8000);
+    appendBusEvent(env(), {
+      ts: '2026-05-23T03:00:00.000Z',
+      source: 'd',
+      type: 'channel-msg',
+      channelId: 'C1',
+      text: huge,
+    });
+    const events = readRecentBusEvents(env(), 'C1', {
+      now: new Date('2026-05-23T06:00:00.000Z'),
+    });
+    expect(events[0].text.length).toBe(6000);
+  });
+});
+
+describe('lastCoreUtterTs — rate-limit 베이스', () => {
+  it('해당 코어 오늘 발화 없음 = null', () => {
+    expect(
+      lastCoreUtterTs(env(), 'C1', 'atlas', new Date('2026-05-23T03:00:00Z')),
+    ).toBeNull();
+  });
+
+  it('가장 최근 core-utter ts 반환 (다른 코어는 무시)', () => {
+    appendBusEvent(env(), {
+      ts: '2026-05-23T03:00:00.000Z',
+      source: 'agent-runtime',
+      type: 'core-utter',
+      channelId: 'C1',
+      coreId: 'atlas',
+      text: 'hi',
+    });
+    appendBusEvent(env(), {
+      ts: '2026-05-23T03:30:00.000Z',
+      source: 'agent-runtime',
+      type: 'core-utter',
+      channelId: 'C1',
+      coreId: 'echo',
+      text: 'hello',
+    });
+    appendBusEvent(env(), {
+      ts: '2026-05-23T04:00:00.000Z',
+      source: 'agent-runtime',
+      type: 'core-utter',
+      channelId: 'C1',
+      coreId: 'atlas',
+      text: 'again',
+    });
+    expect(
+      lastCoreUtterTs(env(), 'C1', 'atlas', new Date('2026-05-23T05:00:00Z')),
+    ).toBe('2026-05-23T04:00:00.000Z');
+    expect(
+      lastCoreUtterTs(env(), 'C1', 'echo', new Date('2026-05-23T05:00:00Z')),
+    ).toBe('2026-05-23T03:30:00.000Z');
+  });
+});

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-channel-bus.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-channel-bus.ts
@@ -1,0 +1,233 @@
+/**
+ * agent-channel-bus — substrate⊥어댑터 의 *어댑터 무관* 메시지 substrate
+ * (TASK-KAR-018-LT-DIVERSITY, D-1).
+ *
+ * 왜 이 substrate (사용자 비전 2026-05-23):
+ * 코어(에이전트 정체) = 독립 daemon process · adapter(Discord/Web/CLI/KL) =
+ * thin I/O bridge. 살아있음의 정의가 process-centric 이려면 daemon ↔ adapter
+ * 가 *프로세스 분리된 채로* 비동기 통신할 substrate 필요. 그 substrate =
+ * 파일 jsonl append-only(편한 race-free reader, 재기동 시 history 재구성
+ * 자동, OS atomic append per ≤PIPE_BUF). Redis/SQLite 같은 외부 의존 X
+ * (재현성·자기증식 정합).
+ *
+ * 기존 `agent-bus.ts` 는 *제안 카드*(forum 게시 / verdict reconcile) 의 어댑터
+ * 층 → 그건 그대로 두고, 본 모듈은 *채널 발화 이벤트* (ambient message + core
+ * utterance) 의 substrate 층으로 분리. 평행정의 X — 둘은 *다른 객체*(제안
+ * 카드 vs 채널 발화).
+ *
+ * Path 정본: `<MEMO_REPO_PATH>/.claude/agent-channel-bus/<channelId>/<YYYY-MM-DD>.jsonl`
+ * (KST 일자). 채널별 디렉토리 분리 = 다른 채널 이벤트가 한 파일에 섞이지 X →
+ * 한 daemon 이 본인 listening 채널만 tail 하면 됨. 일자 파일 분리 = 무한
+ * 누적 X, 회전 자동(파일 시스템 ls).
+ *
+ * Schema (BusEvent):
+ *   ts: ISO ts (event 시각)
+ *   source: 'discord' | 'web' | 'cli' | 'kl' | string (adapter id)
+ *   type: 'channel-msg' (외부 사용자/봇 발화) | 'core-utter' (코어 daemon 발화)
+ *   channelId: 외부 채널 식별자 (Discord channel id 등)
+ *   coreId?: type==='core-utter' 시 발화 코어 id
+ *   authorName?: 외부 사용자 username / 코어 displayName (UX)
+ *   authorId?: 외부 사용자 id (멘션 우회 매칭용)
+ *   text: 본문
+ *   refs?: { mentionedCoreIds?, mentionedUserIds?, replyToTs? } — 멘션·답글
+ *
+ * 안전 바닥: writer best-effort(IO 실패 = throw X, 봇 진행 막지 X). reader
+ * 손상 라인 = 폐기(다른 라인 계속 — 한 lookup 이 전체 hist 회수 막지 X).
+ */
+import fs from 'fs';
+import path from 'path';
+
+export type BusEventType = 'channel-msg' | 'core-utter';
+
+export interface BusEventRefs {
+  /** 멘션된 코어 id(들) — 운영자가 '@atlas …' 호명 / 코어가 다른 코어 언급. */
+  mentionedCoreIds?: string[];
+  /** 멘션된 외부 user id(들) — Discord <@123…> 파싱 결과. */
+  mentionedUserIds?: string[];
+  /** 답글이 가리키는 원본 ts (옵션). */
+  replyToTs?: string;
+}
+
+export interface BusEvent {
+  ts: string;
+  source: string;
+  type: BusEventType;
+  channelId: string;
+  coreId?: string;
+  authorName?: string;
+  authorId?: string;
+  text: string;
+  refs?: BusEventRefs;
+}
+
+/** channelId 가 path traversal 등 위험 문자 포함 X 인지 (substrate 보호). */
+const SAFE_CHANNEL_ID = /^[A-Za-z0-9._-]{1,64}$/;
+
+/** memo 루트가 비었으면 substrate 미가용. */
+function memoRoot(env: NodeJS.ProcessEnv): string {
+  return (env.MEMO_REPO_PATH || '').trim();
+}
+
+/** `<MEMO>/.claude/agent-channel-bus` (channel 디렉토리들의 부모). */
+export function busDir(env: NodeJS.ProcessEnv): string {
+  const root = memoRoot(env);
+  return root ? path.join(root, '.claude', 'agent-channel-bus') : '';
+}
+
+/** `<MEMO>/.claude/agent-channel-bus/<channelId>` (한 채널의 일자 파일들). */
+export function channelDir(
+  env: NodeJS.ProcessEnv,
+  channelId: string,
+): string {
+  const dir = busDir(env);
+  if (!dir) return '';
+  if (!SAFE_CHANNEL_ID.test(channelId || '')) return '';
+  return path.join(dir, channelId);
+}
+
+/** KST 일자 (`YYYY-MM-DD`). */
+function kstDate(d: Date): string {
+  return new Date(d.getTime() + 9 * 3600 * 1000).toISOString().slice(0, 10);
+}
+
+/** `<MEMO>/.claude/agent-channel-bus/<channelId>/<YYYY-MM-DD>.jsonl`. */
+export function dayFilePath(
+  env: NodeJS.ProcessEnv,
+  channelId: string,
+  date?: Date,
+): string {
+  const dir = channelDir(env, channelId);
+  if (!dir) return '';
+  return path.join(dir, `${kstDate(date ?? new Date())}.jsonl`);
+}
+
+/** event ts 보강 + 검증 (스키마 노이즈 차단). */
+function normalizeEvent(e: BusEvent): BusEvent | null {
+  if (!e || typeof e !== 'object') return null;
+  const t = (e.type || '').trim();
+  if (t !== 'channel-msg' && t !== 'core-utter') return null;
+  if (!SAFE_CHANNEL_ID.test(e.channelId || '')) return null;
+  const ts = (e.ts || '').trim() || new Date().toISOString();
+  const text = String(e.text ?? '').slice(0, 6000);
+  // text 비었어도 허용 (embed-only 등) — 단 type 별 일관성:
+  // core-utter 면 coreId 필수.
+  if (t === 'core-utter' && !(e.coreId || '').trim()) return null;
+  return {
+    ts,
+    source: (e.source || '').trim() || 'unknown',
+    type: t as BusEventType,
+    channelId: e.channelId,
+    coreId: e.coreId?.trim() || undefined,
+    authorName: e.authorName?.trim() || undefined,
+    authorId: e.authorId?.trim() || undefined,
+    text,
+    refs: e.refs,
+  };
+}
+
+/**
+ * BusEvent 1건 append (best-effort, throw X). substrate 미가용(MEMO_REPO_PATH
+ * 미설정 / 부적합 channelId / IO 실패) = false, 봇 진행은 막지 X.
+ */
+export function appendBusEvent(
+  env: NodeJS.ProcessEnv,
+  event: BusEvent,
+): boolean {
+  const norm = normalizeEvent(event);
+  if (!norm) return false;
+  const p = dayFilePath(env, norm.channelId, new Date(norm.ts));
+  if (!p) return false;
+  try {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.appendFileSync(p, JSON.stringify(norm) + '\n', 'utf-8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface ReadOpts {
+  /** 이 ts 이후(exclusive) 만 반환. ISO. 미지정 = 전체 일자 파일. */
+  sinceTs?: string;
+  /** 오늘 외 추가로 회수할 과거 일자 (0=오늘만, 1=어제까지, …). default=1. */
+  daysBack?: number;
+  /** 회수 상한 (가장 최근 N개). default=200. */
+  limit?: number;
+  /** "지금"(test inject). */
+  now?: Date;
+}
+
+/**
+ * 채널의 최근 BusEvent 회수 (ts 오름차순). 일자 파일 분할 회전 = 오늘 +
+ * daysBack 일자만 ls/read (무한 누적 read X). 손상 라인 = 폐기·계속 (한
+ * 줄 망가져도 전체 회수 막지 X). 채널 미존재 / substrate 미가용 = [].
+ */
+export function readRecentBusEvents(
+  env: NodeJS.ProcessEnv,
+  channelId: string,
+  opts: ReadOpts = {},
+): BusEvent[] {
+  const dir = channelDir(env, channelId);
+  if (!dir || !fs.existsSync(dir)) return [];
+  const now = opts.now ?? new Date();
+  const daysBack = Math.max(0, opts.daysBack ?? 1);
+  const dayFiles: string[] = [];
+  for (let i = 0; i <= daysBack; i++) {
+    const d = new Date(now.getTime() - i * 24 * 3600 * 1000);
+    const p = path.join(dir, `${kstDate(d)}.jsonl`);
+    if (fs.existsSync(p)) dayFiles.push(p);
+  }
+  // 일자 파일은 오늘이 마지막 → 시간순으로 자연 정렬되도록 reverse.
+  dayFiles.reverse();
+  const out: BusEvent[] = [];
+  const sinceMs = opts.sinceTs ? Date.parse(opts.sinceTs) : null;
+  for (const p of dayFiles) {
+    let text: string;
+    try {
+      text = fs.readFileSync(p, 'utf-8');
+    } catch {
+      continue;
+    }
+    for (const line of text.split(/\r?\n/)) {
+      const t = line.trim();
+      if (!t) continue;
+      let e: BusEvent;
+      try {
+        e = JSON.parse(t) as BusEvent;
+      } catch {
+        continue;
+      }
+      const norm = normalizeEvent(e);
+      if (!norm) continue;
+      if (sinceMs !== null) {
+        const evMs = Date.parse(norm.ts);
+        if (!Number.isFinite(evMs) || evMs <= sinceMs) continue;
+      }
+      out.push(norm);
+    }
+  }
+  // 같은 ts 면 일자 파일 + append 순서대로(stable). 충돌 정렬 X.
+  out.sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts));
+  const limit = Math.max(1, opts.limit ?? 200);
+  if (out.length <= limit) return out;
+  return out.slice(out.length - limit);
+}
+
+/**
+ * 마지막 코어-utter 시각(코어별, KST 오늘 한정). rate-limit/적합도 측정의
+ * 베이스 — 일자 파일만 보면 됨(슬라이딩 윈도우는 caller 가 ts 비교).
+ * 부재 = null.
+ */
+export function lastCoreUtterTs(
+  env: NodeJS.ProcessEnv,
+  channelId: string,
+  coreId: string,
+  now?: Date,
+): string | null {
+  const events = readRecentBusEvents(env, channelId, { daysBack: 0, now });
+  let last: string | null = null;
+  for (const e of events) {
+    if (e.type === 'core-utter' && e.coreId === coreId) last = e.ts;
+  }
+  return last;
+}

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-runtime-daemon.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-runtime-daemon.test.ts
@@ -1,0 +1,302 @@
+/**
+ * agent-runtime-daemon 회귀 (TASK-KAR-018-LT-DIVERSITY D-3).
+ *
+ * daemon orchestrator 의 *결정 흐름* 잠금. DI'd LLM/bus/mem 으로 LLM·fs
+ * 의존 0 in-test — 폭주 회귀(LLM 호출 N건/메시지) + 자기루프 + silence
+ * default + 멘션 우회 의 핵심 path 회귀.
+ */
+import { describe, it, expect } from 'vitest';
+import type { BusEvent } from './agent-channel-bus';
+import type { CoreDef } from '../services/agent-core';
+import {
+  agentRuntimeTickOnce,
+  type DaemonDeps,
+  type DaemonState,
+} from './agent-runtime-daemon';
+
+const NOW = new Date('2026-05-23T03:00:00.000Z');
+
+const atlasCore: CoreDef = {
+  id: 'atlas',
+  role: '시스템 진단',
+  status: 'active',
+  defaultSkin: 'atlas',
+  emoji: '🛰',
+  displayName: 'Atlas',
+  body: '직무 본문.',
+  skills: [],
+  frontmatter: {},
+};
+
+interface Spy {
+  prefilterCalls: number;
+  speakCalls: number;
+  publishedUtters: { coreId: string; text: string }[];
+  memEntries: { coreId: string; type: string; topic: string }[];
+}
+
+function mkDeps(
+  events: BusEvent[],
+  cfg: {
+    prefilterResponse?: string;
+    speakResponse?: string;
+    publishOk?: boolean;
+    spy?: Spy;
+    now?: Date;
+  } = {},
+): DaemonDeps {
+  const spy = cfg.spy ?? {
+    prefilterCalls: 0,
+    speakCalls: 0,
+    publishedUtters: [],
+    memEntries: [],
+  };
+  return {
+    readSince: (channelId: string, sinceTs: string) => {
+      const ms = sinceTs ? Date.parse(sinceTs) : -Infinity;
+      return events.filter(
+        (e) => e.channelId === channelId && Date.parse(e.ts) > ms,
+      );
+    },
+    prefilterLLM: async (_prompt: string) => {
+      spy.prefilterCalls++;
+      return cfg.prefilterResponse ?? '{"react": true, "why": "ok"}';
+    },
+    speakLLM: async (_prompt: string) => {
+      spy.speakCalls++;
+      return cfg.speakResponse ?? '내 생각엔 이러합니다.';
+    },
+    publishUtter: (ev) => {
+      const ok = cfg.publishOk !== false;
+      if (ok) spy.publishedUtters.push({ coreId: ev.coreId, text: ev.text });
+      return ok;
+    },
+    appendMem: (entry) => {
+      spy.memEntries.push({
+        coreId: entry.coreId,
+        type: entry.type,
+        topic: entry.topic,
+      });
+    },
+    readRecentMem: () => '',
+    now: () => cfg.now ?? NOW,
+  };
+}
+
+const mkMsg = (ts: string, text = 'hi', refs?: BusEvent['refs']): BusEvent => ({
+  ts,
+  source: 'discord',
+  type: 'channel-msg',
+  channelId: 'C1',
+  authorName: 'fourth',
+  authorId: 'u1',
+  text,
+  refs,
+});
+const mkUtter = (ts: string, coreId: string, text = 'x'): BusEvent => ({
+  ts,
+  source: 'agent-runtime',
+  type: 'core-utter',
+  channelId: 'C1',
+  coreId,
+  text,
+});
+
+describe('agentRuntimeTickOnce — 결정 흐름 잠금', () => {
+  it('빈 bus = LLM 호출 0', async () => {
+    const spy: Spy = { prefilterCalls: 0, speakCalls: 0, publishedUtters: [], memEntries: [] };
+    const deps = mkDeps([], { spy });
+    const m = await agentRuntimeTickOnce(
+      { lastSeenTs: '' },
+      deps,
+      { core: atlasCore, channelId: 'C1' },
+    );
+    expect(m.scanned).toBe(0);
+    expect(spy.prefilterCalls).toBe(0);
+    expect(spy.speakCalls).toBe(0);
+  });
+
+  it('새 channel-msg → prefilter → speak → publish + mem', async () => {
+    const ev = mkMsg('2026-05-23T02:59:30.000Z', '시스템 어떻게?');
+    const spy: Spy = { prefilterCalls: 0, speakCalls: 0, publishedUtters: [], memEntries: [] };
+    const deps = mkDeps([ev], { spy });
+    const m = await agentRuntimeTickOnce(
+      { lastSeenTs: '' },
+      deps,
+      { core: atlasCore, channelId: 'C1' },
+    );
+    expect(spy.prefilterCalls).toBe(1);
+    expect(spy.speakCalls).toBe(1);
+    expect(spy.publishedUtters).toHaveLength(1);
+    expect(spy.publishedUtters[0].coreId).toBe('atlas');
+    expect(spy.memEntries).toHaveLength(1);
+    expect(m.spoken).toBe(1);
+    expect(m.lastSeenTs).toBe(ev.ts);
+  });
+
+  it('자기 core-utter 는 평가 skip (자기루프 차단)', async () => {
+    const ev = mkUtter('2026-05-23T02:59:30.000Z', 'atlas', '내가 한 말');
+    const spy: Spy = { prefilterCalls: 0, speakCalls: 0, publishedUtters: [], memEntries: [] };
+    const deps = mkDeps([ev], { spy });
+    const m = await agentRuntimeTickOnce(
+      { lastSeenTs: '' },
+      deps,
+      { core: atlasCore, channelId: 'C1' },
+    );
+    expect(spy.prefilterCalls).toBe(0);
+    expect(spy.speakCalls).toBe(0);
+    expect(m.skippedSelf).toBe(1);
+  });
+
+  it('다른 코어의 core-utter 는 평가 대상 (ambient)', async () => {
+    const ev = mkUtter('2026-05-23T02:59:30.000Z', 'echo', '내 생각엔…');
+    const spy: Spy = { prefilterCalls: 0, speakCalls: 0, publishedUtters: [], memEntries: [] };
+    const deps = mkDeps([ev], { spy });
+    await agentRuntimeTickOnce(
+      { lastSeenTs: '' },
+      deps,
+      { core: atlasCore, channelId: 'C1' },
+    );
+    expect(spy.prefilterCalls).toBe(1);
+  });
+
+  it('rate-limit 도달(5분 안 2발화) + 미멘션 = LLM 호출 0', async () => {
+    // atlas 가 직전 5분 안 이미 2번 발화. 새 메시지 와도 silence.
+    const events: BusEvent[] = [
+      mkUtter('2026-05-23T02:58:00.000Z', 'atlas'),
+      mkUtter('2026-05-23T02:59:00.000Z', 'atlas'),
+      mkMsg('2026-05-23T02:59:30.000Z', '새 메시지'),
+    ];
+    const spy: Spy = { prefilterCalls: 0, speakCalls: 0, publishedUtters: [], memEntries: [] };
+    const deps = mkDeps(events, { spy });
+    const m = await agentRuntimeTickOnce(
+      { lastSeenTs: '2026-05-23T02:59:25.000Z' },
+      deps,
+      { core: atlasCore, channelId: 'C1' },
+    );
+    expect(spy.prefilterCalls).toBe(0);
+    expect(spy.speakCalls).toBe(0);
+    expect(m.skippedRateLimited).toBe(1);
+  });
+
+  it('rate-limit 중에도 멘션 = prefilter+speak 강제', async () => {
+    const events: BusEvent[] = [
+      mkUtter('2026-05-23T02:58:00.000Z', 'atlas'),
+      mkUtter('2026-05-23T02:59:00.000Z', 'atlas'),
+      mkMsg('2026-05-23T02:59:30.000Z', '@atlas 봐줘', {
+        mentionedCoreIds: ['atlas'],
+      }),
+    ];
+    const spy: Spy = { prefilterCalls: 0, speakCalls: 0, publishedUtters: [], memEntries: [] };
+    const deps = mkDeps(events, { spy });
+    const m = await agentRuntimeTickOnce(
+      { lastSeenTs: '2026-05-23T02:59:25.000Z' },
+      deps,
+      { core: atlasCore, channelId: 'C1' },
+    );
+    expect(spy.prefilterCalls).toBe(1);
+    expect(spy.speakCalls).toBe(1);
+    expect(m.skippedRateLimited).toBe(0);
+    expect(m.spoken).toBe(1);
+  });
+
+  it('prefilter react=false = silence (speak 호출 0)', async () => {
+    const ev = mkMsg('2026-05-23T02:59:30.000Z', '관련 없는 얘기');
+    const spy: Spy = { prefilterCalls: 0, speakCalls: 0, publishedUtters: [], memEntries: [] };
+    const deps = mkDeps([ev], {
+      spy,
+      prefilterResponse: '{"react": false, "why": "내 도메인 X"}',
+    });
+    const m = await agentRuntimeTickOnce(
+      { lastSeenTs: '' },
+      deps,
+      { core: atlasCore, channelId: 'C1' },
+    );
+    expect(spy.prefilterCalls).toBe(1);
+    expect(spy.speakCalls).toBe(0);
+    expect(m.silenced).toBe(1);
+    expect(m.spoken).toBe(0);
+  });
+
+  it('prefilter react=false 라도 멘션이면 강제 speak (멘션 우회)', async () => {
+    const ev = mkMsg('2026-05-23T02:59:30.000Z', '@atlas 봐줘', {
+      mentionedCoreIds: ['atlas'],
+    });
+    const spy: Spy = { prefilterCalls: 0, speakCalls: 0, publishedUtters: [], memEntries: [] };
+    const deps = mkDeps([ev], {
+      spy,
+      prefilterResponse: '{"react": false, "why": "X"}',
+    });
+    const m = await agentRuntimeTickOnce(
+      { lastSeenTs: '' },
+      deps,
+      { core: atlasCore, channelId: 'C1' },
+    );
+    expect(spy.speakCalls).toBe(1);
+    expect(m.spoken).toBe(1);
+  });
+
+  it('speak 결과가 비었으면 publish skip (silenced 로 분류)', async () => {
+    const ev = mkMsg('2026-05-23T02:59:30.000Z', 'q');
+    const spy: Spy = { prefilterCalls: 0, speakCalls: 0, publishedUtters: [], memEntries: [] };
+    const deps = mkDeps([ev], { spy, speakResponse: '   ' });
+    const m = await agentRuntimeTickOnce(
+      { lastSeenTs: '' },
+      deps,
+      { core: atlasCore, channelId: 'C1' },
+    );
+    expect(spy.publishedUtters).toHaveLength(0);
+    expect(m.silenced).toBe(1);
+  });
+
+  it('publish 실패 = publishFailed metric + spoken X', async () => {
+    const ev = mkMsg('2026-05-23T02:59:30.000Z', 'q');
+    const spy: Spy = { prefilterCalls: 0, speakCalls: 0, publishedUtters: [], memEntries: [] };
+    const deps = mkDeps([ev], { spy, publishOk: false });
+    const m = await agentRuntimeTickOnce(
+      { lastSeenTs: '' },
+      deps,
+      { core: atlasCore, channelId: 'C1' },
+    );
+    expect(m.publishFailed).toBe(1);
+    expect(m.spoken).toBe(0);
+    expect(spy.memEntries).toHaveLength(0); // mem 도 skip
+  });
+
+  it('lastSeenTs 갱신 — silence 한 event 도 진행 (다음 tick 에서 중복 평가 X)', async () => {
+    const events: BusEvent[] = [
+      mkMsg('2026-05-23T02:59:00.000Z', 'a'),
+      mkMsg('2026-05-23T02:59:30.000Z', 'b'),
+    ];
+    const spy: Spy = { prefilterCalls: 0, speakCalls: 0, publishedUtters: [], memEntries: [] };
+    const deps = mkDeps(events, {
+      spy,
+      prefilterResponse: '{"react": false, "why": "skip"}',
+    });
+    const m = await agentRuntimeTickOnce(
+      { lastSeenTs: '' },
+      deps,
+      { core: atlasCore, channelId: 'C1' },
+    );
+    expect(m.lastSeenTs).toBe('2026-05-23T02:59:30.000Z');
+    expect(m.silenced).toBe(2);
+  });
+
+  it('prefilter LLM throw = 안전 폴백 silence (예외 전파 X)', async () => {
+    const ev = mkMsg('2026-05-23T02:59:30.000Z', 'q');
+    const spy: Spy = { prefilterCalls: 0, speakCalls: 0, publishedUtters: [], memEntries: [] };
+    const deps: DaemonDeps = {
+      ...mkDeps([ev], { spy }),
+      prefilterLLM: async () => {
+        throw new Error('LLM unavailable');
+      },
+    };
+    const m = await agentRuntimeTickOnce(
+      { lastSeenTs: '' },
+      deps,
+      { core: atlasCore, channelId: 'C1' },
+    );
+    expect(m.silenced).toBe(1);
+    expect(m.spoken).toBe(0);
+  });
+});

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-runtime-daemon.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-runtime-daemon.ts
@@ -1,0 +1,254 @@
+/**
+ * agent-runtime-daemon — 코어 = 독립 daemon process orchestrator
+ * (TASK-KAR-018-LT-DIVERSITY, D-3).
+ *
+ * "프로세스 분리 = 코어 살아있음의 정의" (사용자 비전 2026-05-23). 본 모듈
+ * 은 *generic* — 시작 시 `--core-id <id>` 1개 주입받아 정체성 결정. 그
+ * 코어가 *살아있는* 동안 하는 일:
+ *
+ *   1. bus tail — `<MEMO>/.claude/agent-channel-bus/<channel>/<day>.jsonl` 에
+ *      append 된 새 BusEvent 회수 (마지막 처리 ts 이후).
+ *   2. 자기 core-utter 는 skip (자기루프 차단).
+ *   3. rate-limit 체크 — 5분 안 2발화 cap 도달 + 미멘션 = silence 강제.
+ *   4. prefilter (cheap 모델) — `{react: bool}` 결정. 모호 시 silence.
+ *   5. 본 모델 speak — capability + recent context + work-memory.
+ *   6. core-utter publish + core mem append.
+ *
+ * 본 모듈은 *pure*: DI 로 bus reader/writer · LLM 호출 · clock · mem 적재
+ * 를 주입받음 (테스트 가능). 실제 nssm 서비스 등록은 D-7 단계 (scripts/
+ * run-agent-runtime.mjs 가 entry).
+ *
+ * 한 daemon = 한 코어 = 한 channelId tail. 모든 코어가 같은 channel(team-bus)
+ * 을 tail 해도 됨 (append-only file, race-free reader). 다른 채널 listening
+ * = 다른 daemon 인스턴스 추가.
+ *
+ * Discord adapter 죽음·재기동 = daemon 살아있음 (bus 가 buffer). 본 모듈
+ * 은 Discord 의존 0 — substrate(bus 파일)와만 통신.
+ */
+import type { BusEvent } from './agent-channel-bus';
+import type { CoreDef } from '../services/agent-core';
+import {
+  buildPrefilterPrompt,
+  buildSpeakPrompt,
+  formatActiveContext,
+  isMentionedFor,
+  isRateLimited,
+  parsePrefilterResponse,
+  recentActiveContext,
+  type PrefilterDecision,
+} from './agent-ambient';
+
+/** daemon 한 cycle 의 누적 metric (auditor baseline 입력). */
+export interface TickMetrics {
+  /** 회수한 BusEvent 총수 (since lastSeenTs). */
+  scanned: number;
+  /** 자기루프/own utter skip 수. */
+  skippedSelf: number;
+  /** rate-limit + 미멘션 으로 skip 수. */
+  skippedRateLimited: number;
+  /** prefilter 가 react=false 로 silence 결정 수. */
+  silenced: number;
+  /** 본 모델 호출 (실제 발화) 수. */
+  spoken: number;
+  /** publish 실패 수 (substrate 미가용 등). */
+  publishFailed: number;
+  /** 처리한 가장 마지막 BusEvent ts — 다음 tick 의 sinceTs (state). */
+  lastSeenTs: string;
+}
+
+/** caller(scheduler)가 매 tick 사이에 유지·전달하는 state. */
+export interface DaemonState {
+  /** 마지막으로 처리한 BusEvent ts (ISO). 초기 = '' (전체 새로 봄). */
+  lastSeenTs: string;
+}
+
+/** DI — 본 모듈은 fs/LLM/Discord 직접 의존 X. */
+export interface DaemonDeps {
+  /** bus tail — sinceTs 이후 BusEvent 회수 (시간 오름차순). */
+  readSince: (channelId: string, sinceTs: string) => BusEvent[];
+  /** cheap 모델(prefilter) 호출 — text in / text out. */
+  prefilterLLM: (prompt: string) => Promise<string>;
+  /** 본 모델(speak) 호출. */
+  speakLLM: (prompt: string) => Promise<string>;
+  /** core-utter publish (best-effort). 성공 = true. */
+  publishUtter: (event: {
+    channelId: string;
+    coreId: string;
+    text: string;
+    ts: string;
+  }) => boolean;
+  /** core work-memory 1 entry append (best-effort). */
+  appendMem: (entry: {
+    coreId: string;
+    type: 'discovery' | 'decision' | 'fix' | 'fail' | 'insight';
+    topic: string;
+    summary: string;
+  }) => void;
+  /** 최근 work-memory 압축 (LLM 입력용, 옵션). */
+  readRecentMem?: (coreId: string) => string;
+  /** "지금"(테스트 inject). 기본 = Date.now(). */
+  now?: () => Date;
+}
+
+export interface TickOpts {
+  /** 발화할 코어 id (daemon 자체 정체성). */
+  core: CoreDef;
+  /** tail 할 채널 id. */
+  channelId: string;
+  /** 5분 윈도우 ms (override 가능, 테스트용). */
+  windowMs?: number;
+  /** rate-limit cap (override 가능). */
+  cap?: number;
+}
+
+/**
+ * 한 tick = bus 의 새 event 들을 처리. caller(스케줄러)가 본 함수를 짧은
+ * 간격(예: 1~3초)으로 호출. 각 event 별로 자기루프/rate-limit/prefilter/
+ * speak/publish 의 결정을 순차 수행.
+ *
+ * state.lastSeenTs 는 본 함수가 갱신한 metrics.lastSeenTs 로 caller 가
+ * *외부에서* 다음 호출에 넘겨준다. (본 함수는 stateless — race 회피)
+ */
+export async function agentRuntimeTickOnce(
+  state: DaemonState,
+  deps: DaemonDeps,
+  opts: TickOpts,
+): Promise<TickMetrics> {
+  const now = (deps.now ?? (() => new Date()))();
+  const since = state.lastSeenTs || '';
+  const all = deps.readSince(opts.channelId, since);
+  const metrics: TickMetrics = {
+    scanned: all.length,
+    skippedSelf: 0,
+    skippedRateLimited: 0,
+    silenced: 0,
+    spoken: 0,
+    publishFailed: 0,
+    lastSeenTs: state.lastSeenTs,
+  };
+  if (all.length === 0) return metrics;
+
+  // 시간 오름차순 보장 (caller readSince 가 unsorted 일 가능성 안전망).
+  all.sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts));
+
+  for (const event of all) {
+    // 마지막 처리 ts 갱신 — 자기루프/rate-limit 으로 skip 되어도 진행.
+    if (
+      !metrics.lastSeenTs ||
+      Date.parse(event.ts) > Date.parse(metrics.lastSeenTs)
+    ) {
+      metrics.lastSeenTs = event.ts;
+    }
+    // ① 자기루프 차단 — 본인 core-utter 는 평가 X.
+    if (event.type === 'core-utter' && event.coreId === opts.core.id) {
+      metrics.skippedSelf++;
+      continue;
+    }
+    // ② capability 평가 — channel-msg 와 *다른 코어의* core-utter 둘 다 평가
+    //    (코어끼리 대화도 ambient 임). 단 본인 utter 만 skip(①).
+    const mentioned = isMentionedFor(event, opts.core.id);
+    // ③ rate-limit (멘션 우회 제외) — 윈도우 안 history 만 본다.
+    if (!mentioned) {
+      const recentHistory = deps.readSince(opts.channelId, '');
+      const limited = isRateLimited(recentHistory, opts.core.id, {
+        windowMs: opts.windowMs,
+        cap: opts.cap,
+        now,
+      });
+      if (limited) {
+        metrics.skippedRateLimited++;
+        continue;
+      }
+    }
+    // ④ active context.
+    const fullHist = deps.readSince(opts.channelId, '');
+    const context = recentActiveContext(fullHist, { now, windowMs: opts.windowMs });
+
+    // ⑤ prefilter.
+    let decision: PrefilterDecision;
+    try {
+      const prefilterPrompt = buildPrefilterPrompt({
+        core: opts.core,
+        context,
+        latest: event,
+      });
+      const raw = await deps.prefilterLLM(prefilterPrompt);
+      decision = parsePrefilterResponse(raw);
+    } catch {
+      decision = { react: false, why: 'prefilter-error' };
+    }
+    // 멘션 우회 — prefilter 가 react=false 라도 멘션이면 강제 평가.
+    const forceSpeak = mentioned && !decision.react;
+    if (!decision.react && !forceSpeak) {
+      metrics.silenced++;
+      continue;
+    }
+
+    // ⑥ speak.
+    let text = '';
+    try {
+      const speakPrompt = buildSpeakPrompt({
+        core: opts.core,
+        prefilterWhy: decision.why || (forceSpeak ? 'mention-bypass' : ''),
+        context,
+        latest: event,
+        recentMem: deps.readRecentMem ? deps.readRecentMem(opts.core.id) : '',
+        mentioned,
+      });
+      text = (await deps.speakLLM(speakPrompt)).trim();
+    } catch {
+      text = '';
+    }
+    if (!text) {
+      metrics.silenced++;
+      continue;
+    }
+    // ⑦ publish.
+    const utterTs = now.toISOString();
+    const ok = deps.publishUtter({
+      channelId: opts.channelId,
+      coreId: opts.core.id,
+      text,
+      ts: utterTs,
+    });
+    if (!ok) {
+      metrics.publishFailed++;
+      continue;
+    }
+    metrics.spoken++;
+    // ⑧ mem write — 자기 발화·이유 적재 (학습 누적).
+    try {
+      deps.appendMem({
+        coreId: opts.core.id,
+        type: 'insight',
+        topic: `utter:${opts.channelId}`,
+        summary: `${decision.why || (mentioned ? 'mentioned' : '')}; ${text.slice(0, 200)}`,
+      });
+    } catch {
+      /* mem 적재 실패가 발화 자체를 막지 X */
+    }
+  }
+
+  return metrics;
+}
+
+/**
+ * UX 한 줄 (heartbeat / auditor 로깅용). 본 모듈 자체는 콘솔 출력 X —
+ * caller 가 본 함수로 metrics 를 사람이 읽는 줄로 변환.
+ */
+export function summarizeTick(coreId: string, m: TickMetrics): string {
+  return [
+    `[agent-runtime ${coreId}]`,
+    `scanned=${m.scanned}`,
+    `self=${m.skippedSelf}`,
+    `rate=${m.skippedRateLimited}`,
+    `silent=${m.silenced}`,
+    `spoke=${m.spoken}`,
+    `fail=${m.publishFailed}`,
+  ].join(' ');
+}
+
+/** active context dump (디버깅용 — 외부 호출 X, 평행정의 회피). */
+export function dumpActiveContext(events: BusEvent[]): string {
+  return formatActiveContext(events);
+}

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -53,6 +53,7 @@ import { setStatusBoardSender } from './bot/agent-status-board';
 import { checkMemoPushScope } from './services/memo-push';
 import { setProposalAnnouncer } from './bot/proposal-adapter';
 import { announceProposal, reconcileProposalCards } from './bot/agent-bus';
+import { extractDiscordPublish, publishIncomingDiscord } from './bot/agent-channel-bridge';
 import {
   loadCoreDef,
   listCoreIds,
@@ -267,6 +268,23 @@ client.on('messageCreate', async (message) => {
     isBot && !!message.webhookId && !!characterService &&
     isTeamRoomMessage(characterService, message as any);
   if (isBot && !teamWebhook) return;
+  // KAR-018-LT-DIVERSITY D-2: 팀 방 incoming message → agent-channel-bus publish.
+  // 추가 sink (기존 handleAssistantMessage 등은 그대로). substrate 미가용/메모
+  // 미설정 = silent no-op. 사용자 메시지만 channel-msg 로 적재 — 외부 봇은 잡음.
+  if (memoRepoPath && !isBot) {
+    try {
+      const agentCh = agentChannelId();
+      if (agentCh && message.channel.id === agentCh) {
+        const opts = extractDiscordPublish(message as any, {
+          isOwnAgentWebhook,
+          coreIdForWebhook: () => null,
+        });
+        publishIncomingDiscord({ MEMO_REPO_PATH: memoRepoPath } as NodeJS.ProcessEnv, opts);
+      }
+    } catch {
+      /* publish 실패가 봇 진행 막지 X */
+    }
+  }
   if (characterService) {
     await handleAssistantMessage(message as any, characterService, getMemory, memoRepoPath ? getMood : undefined, memoRepoPath ? getRelationship : undefined);
   }

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -53,7 +53,15 @@ import { setStatusBoardSender } from './bot/agent-status-board';
 import { checkMemoPushScope } from './services/memo-push';
 import { setProposalAnnouncer } from './bot/proposal-adapter';
 import { announceProposal, reconcileProposalCards } from './bot/agent-bus';
-import { extractDiscordPublish, publishIncomingDiscord } from './bot/agent-channel-bridge';
+import { extractDiscordPublish, publishIncomingDiscord, publishToBus } from './bot/agent-channel-bridge';
+import { readRecentBusEvents } from './bot/agent-channel-bus';
+import {
+  publisherTickOnce,
+  summarizePublisherTick,
+  type PublisherState,
+} from './bot/agent-channel-bus-publisher';
+import fs from 'node:fs';
+import path from 'node:path';
 import {
   loadCoreDef,
   listCoreIds,
@@ -293,6 +301,9 @@ client.on('messageCreate', async (message) => {
 
 // KAR-018-LT: 팀 verdict → 카드 reconciler 타이머 핸들 (shutdown 정리).
 let cardReconcileTimer: ReturnType<typeof setTimeout> | null = null;
+// KAR-018-LT-DIVERSITY D-7: 외부 daemon(agent-runtime) 의 core-utter 를
+// Discord 로 표면화하는 publisher tick 타이머 (shutdown 정리).
+let busPublisherTimer: ReturnType<typeof setTimeout> | null = null;
 
 const app = createGithubWebhookApp(client as any, gameData as any);
 mountLocalWebhook(app, client as any);
@@ -513,7 +524,16 @@ client.once('clientReady', async () => {
     // 동일 identity 패턴(평행정의0). dispatcher 내부 구동 — Discord
     // 재인입 X(self-loop 안전 불변). 미배선/실패 = cadence 가 NotifyFn
     // 폴백(무음 손실 0).
-    setCoreSpeak(async (coreId, text) => {
+    //
+    // KAR-018-LT-DIVERSITY D-7: postCoreUtterToDiscord 추출 = Discord 표면화
+    // 만 담는 *공용* 헬퍼. setCoreSpeak callback (in-process dispatcher) +
+    // bus publisher (외부 daemon 표면화) 두 caller 가 같은 경로를 쓰되,
+    // bus mirror 는 in-process 경로에서만 수행(publisher 가 부른 발화는
+    // 이미 bus 의 외부 core-utter 의 *표면화* 결과 → 다시 mirror 하면 dup).
+    const postCoreUtterToDiscord = async (
+      coreId: string,
+      text: string,
+    ): Promise<boolean> => {
       try {
         if (!memoRepoPath || !characterService) return false;
         const cd = loadCoreDef(memoRepoPath, coreId);
@@ -539,7 +559,112 @@ client.once('clientReady', async () => {
         console.error('[CoreSpeak]', e?.message ?? e);
         return false;
       }
+    };
+    setCoreSpeak(async (coreId, text) => {
+      const ok = await postCoreUtterToDiscord(coreId, text);
+      if (ok && memoRepoPath) {
+        // KAR-018-LT-DIVERSITY D-7: in-process 코어 발화도 bus 에 mirror.
+        // source='in-process' → 다른 어댑터(KL/Web/auditor) 가 같은 흐름을
+        // tail 가능. publisher 의 default excludeSources='in-process' 가
+        // self-loop(같은 utter Discord 재게시) 차단. mirror 실패 = 무해.
+        const targetCh = agentCh ?? getLocalChannels('agent-team')[0] ?? null;
+        if (targetCh) {
+          try {
+            publishToBus(
+              { MEMO_REPO_PATH: memoRepoPath } as NodeJS.ProcessEnv,
+              {
+                source: 'in-process',
+                channelId: targetCh,
+                type: 'core-utter',
+                coreId,
+                text,
+              },
+            );
+          } catch {
+            /* bus mirror 실패가 Discord 발화 자체를 막지 X */
+          }
+        }
+      }
+      return ok;
     });
+    // KAR-018-LT-DIVERSITY D-7: bus → Discord publisher ticker.
+    // 외부 agent-runtime daemon(`scripts/run-agent-runtime.mjs`) 이 코어
+    // 발화를 source='agent-runtime' 로 bus 에 publish. 본 ticker 가 bus 를
+    // tail 해 *그 외부 utter* 만 Discord 로 표면화 (in-process 발화는
+    // excludeSources=['in-process'] 가 자기루프 차단). yawnbot 단일 process
+    // ↔ 외부 daemon process 의 *물리적 분리* 의 실증 경로 (substrate⊥어댑터).
+    //
+    // state(lastSeenTs) 는 `<MEMO>/.claude/agent-channel-bus-publisher/<channelId>.json`
+    // 에 영속 — 재기동 시 이미 표면화한 utter 재게시 X (멱등). 미가용 시
+    // (memo/agentCh 부재) ticker 자체 미기동.
+    {
+      const publisherChannelId =
+        agentCh ?? getLocalChannels('agent-team')[0] ?? null;
+      if (memoRepoPath && publisherChannelId) {
+        const stateDir = path.join(
+          memoRepoPath,
+          '.claude',
+          'agent-channel-bus-publisher',
+        );
+        const statePath = path.join(stateDir, `${publisherChannelId}.json`);
+        const loadPublisherState = (): PublisherState => {
+          try {
+            const raw = fs.readFileSync(statePath, 'utf-8');
+            const parsed = JSON.parse(raw) as { lastSeenTs?: unknown };
+            return { lastSeenTs: String(parsed.lastSeenTs || '') };
+          } catch {
+            return { lastSeenTs: '' };
+          }
+        };
+        const savePublisherState = (s: PublisherState): void => {
+          try {
+            fs.mkdirSync(stateDir, { recursive: true });
+            fs.writeFileSync(statePath, JSON.stringify(s), 'utf-8');
+          } catch {
+            /* best-effort — 실패해도 다음 tick 메모리상태 진전 */
+          }
+        };
+        let publisherState = loadPublisherState();
+        const publisherIntervalMs =
+          Number(process.env.AGENT_BUS_PUBLISHER_INTERVAL_MS) || 3000;
+        const publisherTick = async (): Promise<void> => {
+          try {
+            const m = await publisherTickOnce(
+              publisherState,
+              {
+                readSince: (chId: string, sinceTs: string) =>
+                  readRecentBusEvents(
+                    { MEMO_REPO_PATH: memoRepoPath } as NodeJS.ProcessEnv,
+                    chId,
+                    {
+                      sinceTs: sinceTs || undefined,
+                      daysBack: 1,
+                      limit: 400,
+                    },
+                  ),
+                speak: postCoreUtterToDiscord,
+              },
+              { channelId: publisherChannelId },
+            );
+            if (m.lastSeenTs && m.lastSeenTs !== publisherState.lastSeenTs) {
+              publisherState = { lastSeenTs: m.lastSeenTs };
+              savePublisherState(publisherState);
+            }
+            if (m.posted > 0 || m.failed > 0) {
+              console.log(summarizePublisherTick(m));
+            }
+          } catch (e: any) {
+            console.error('[bus-publisher]', e?.message ?? e);
+          }
+          busPublisherTimer = setTimeout(publisherTick, publisherIntervalMs);
+        };
+        busPublisherTimer = setTimeout(publisherTick, publisherIntervalMs);
+      } else {
+        console.log(
+          '[bus-publisher] skip — MEMO_REPO_PATH 또는 agent-team channel 미배선',
+        );
+      }
+    }
     // TASK-KAR-077: 대시보드 sink — ensure-or-edit 한 메시지, ID 반환.
     // setCoreSpeak 동형(client 주입, agent-cadence ⊥ discord.js).
     setDashboardSink(async (channelId, messageId, panel, embed) => {
@@ -818,6 +943,10 @@ async function gracefulShutdown(reason: string): Promise<void> {
   if (cardReconcileTimer) {
     clearTimeout(cardReconcileTimer);
     cardReconcileTimer = null;
+  }
+  if (busPublisherTimer) {
+    clearTimeout(busPublisherTimer);
+    busPublisherTimer = null;
   }
   stopProactive();
   stock.stopMarket();


### PR DESCRIPTION
## TASK
**TASK-KAR-018-LT-DIVERSITY** — 코어 daemon 분리 + ambient channel listening + capability 자율 발화.

부모: TASK-KAR-018-LT-11/12/13 (§2.7 substrate⊥어댑터 의 정확한 실행). 본 PR 은 substrate + 결정층 + 발화 publisher 7 slice (D-1~D-7) 의 *machine-checkable* 1차분 — 라이브 활성화는 후속 PR.

## ⚠ 사용자 결정 필요 — master 와의 평행작업 충돌

본 branch fork 시점(`c121a09d`) **이후** master 에 **P-1~P-6 + D-9** 평행 슬롯 작업이 *직접 push* 로 착륙 — 같은 TASK 를 *다른 shape* 으로 구현:

| 축 | 본 branch (D-1~D-7) | master (P-1~P-6 + D-9) |
|---|---|---|
| substrate 파일 | 신규 `agent-channel-bus.ts` (channel 이벤트 전용 jsonl) | 기존 `agent-bus.ts` 확장 (proposal+coreSpeak 혼용) |
| daemon 격리 | 별도 `agent-runtime-daemon.ts` + `run-agent-runtime.mjs` (nssm 후보) | `agent-cadence.ts` 안 ambient self-tick (in-process) |
| dyadic 폐기 | substrate 분리 (후속 D-11 코드 제거) | `it.skip` / `describe.skip` 으로 우회 (P-2 후속) |
| 통합 진입점 | `main.ts` 에 `publisherTickOnce` + `extractDiscordPublish` 와이어 | `main.ts` 에 coreSpeak→bus publish 와이어 |
| budget cap | 본 PR 미포함 (rate-limit 만) | P-4 sliding 1h LLM budget cap |
| !kill watcher | 본 PR 미포함 | P-5 watcher daemon 자율 |
| orchestrator nssm | 본 PR 미포함 (코어 nssm 후보) | P-6 폐기 (peer-only 전환 완성) |

merge 시 `main.ts` · `agent-cadence.ts` · `agent-dialogue.ts` **충돌 큼**. 두 shape 중 *어느 것이 정본인지* 사용자 결정 필요:

- **옵션 A — master 정본**: 본 PR close. master 의 P-1~P-6 가 이미 production. 본 branch substrate 는 학습용 archive.
- **옵션 B — 본 branch 정본**: master 의 P-1~P-6 revert + 본 substrate merge. 큰 변경, 24h watch 후 회귀 시 fallback.
- **옵션 C — hybrid (권장)**: 본 substrate 의 *순수 substrate 부분* (`agent-channel-bus.ts` append-only jsonl + `agent-runtime-daemon.ts` process-separable shape) 만 master 의 `agent-bus.ts` 확장 path 위에 *layered* 로 흡수. 통합 진입점은 master 정본 유지, 본 PR 의 daemon 격리 가치만 추출.

본 워커는 *옵션 결정 권한 없음* (비가역·세계관 영향). 사용자 컨펌까지 Draft 유지.

## Why now (라이브 진단)
2026-05-23 12:13 KST #team-bus 라이브 보고 → 사용자 컨펌:
- 모든 발의에 Atlas + Echo 둘만 발화. WM/KL/YB 도메인 코어 시각 0.
- Echo "(애교)" / "ㅠ.ㅠ" 톤 잠식 = 강제 발화 부작용.
- 사용자 체감 "둘이서만 대화 / 형식적 / 봇 같음".

근본 = **role-driven turn-taking + cadence brainstorm 의제 + 단일 process 의존** 3층 동시 박힘.

## 결정 (사용자 컨펌 2026-05-23)
- **A.** ambient channel listening — Discord MessageCreate → 모든 active 코어가 자율 판단. `{react: bool}` default false (silence preference).
- **B.** process 분리 — 코어 = 독립 daemon (`agent-runtime`), adapter = thin bridge. Discord 죽음 → 코어 살아있음.
- **C.** capability ⊥ 행동 선택권 — role/kind 강제 발화 X, `core.md` body 가 "할 수 있는 것·권한 경계" 만 정의.

## What this PR ships (D-1~D-7)

| Slice | 산출물 | 회귀 잠금 |
|---|---|---|
| **D-1** agent-channel-bus | append-only jsonl substrate: `<MEMO>/.claude/agent-channel-bus/<channelId>/<day>.jsonl`. BusEvent schema (channel-msg / core-utter). 일자 회전, 손상 라인 skip, sinceTs 슬라이싱, 6000자 cap. | `agent-channel-bus.test.ts` (15 test) |
| **D-2** agent-channel-bridge | Discord MessageCreate → bus publish (additive sink). 자기 agent webhook coreId 분류, 외부 봇 잡음 차단, 멘션 파싱(코어·user). `main.ts` 팀 채널 incoming 메시지 미러링. | `agent-channel-bridge.test.ts` (21 test) |
| **D-3** agent-runtime-daemon | pure orchestrator. DI'd bus reader / LLM / publish / mem. 자기루프 차단 / rate-limit / 멘션 우회 / prefilter / speak. `scripts/run-agent-runtime.mjs` thin CLI entry (`--core-id`, dry-run). | `agent-runtime-daemon.test.ts` (12 test) |
| **D-4** prefilter | silence-default `{react: bool, why: string}` JSON 결정 cheap 모델 프롬프트 + 안전 폴백 파서 (비-JSON·throw·empty = silence). | `agent-ambient.test.ts` (parse 7 test) |
| **D-5** speak prompt | capability(`core.body`) + recent context + work-memory 본 모델 프롬프트. 페르소나 = 스킨 레이어 (기존 `chat-adapter` 재사용). | `agent-ambient.test.ts` (speak 3 test) |
| **D-6** rate-limit + active context | 5분 sliding 2 발화 cap (per-core). 멘션 우회 (`refs.mentionedCoreIds`). 5분 윈도우 active context 회수 + `maxLines` cap (폭주 방지). | `agent-ambient.test.ts` (rate/context 15 test) |
| **D-7** bus → Discord publisher | `agent-channel-bus-publisher.ts`: bus 의 core-utter 이벤트 → Discord 가시화 (코어 webhook 재사용) + in-process mirror (자기 메시지 가시화 dedup). `main.ts` 에 publisher tick 와이어. substrate⊥어댑터 *완결* (어댑터 죽어도 substrate 의 발화는 남아있음). | `agent-channel-bus-publisher.test.ts` (11 test) |

## 회귀 잠금
5 신규 test file · **84 unit test** (vitest). LLM·fs·Discord 직접 의존 0 (DI 전부).

핵심 시나리오 잠금:
- 자기 core-utter 평가 skip (자기루프 차단)
- rate-limit 도달 + 미멘션 = LLM 호출 0
- 멘션이면 rate-limit 우회 강제 평가
- prefilter `react=false` = speak 호출 0 (silence default)
- prefilter LLM throw = silence 폴백 (예외 전파 X)
- publish 실패 = mem write 도 skip (false positive metric 차단)
- 손상 JSON / 빈 응답 = silence
- publisher dedup (같은 ts core-utter 중복 게시 X)

## What this PR does NOT do (후속 PR / 또는 master P-* 흡수)
- **D-8** auditor baseline 첫 측정 (발화 coverage / 폭주율 / latency)
- **D-9** 나머지 8 코어 점진 추출 — *master 가 이미 in-process 로 활성화 (5e347f81)*. 본 branch 의 daemon 격리는 옵션 B/C 진입 시 흡수.
- **D-10** cadence brainstorm path sunset — *master P-3 가 부분 흡수*.
- **D-11** `agent-dialogue.ts` dyadic engine 폐기 — *master P-2 가 .skip 까지만 (코드 제거 후속)*.
- **D-12** `kind=worker` filter 폐기 라이브 증거
- **D-13** 멘션 우회 라이브 검증
- **D-14** (선택) KL adapter — Discord adapter 끄고도 코어 살아있음 라이브 데모

## Test plan
- [x] `npx tsc --noEmit` (yawnbot) — 0 error
- [x] `npx vitest run` (5 신규 file) — 84 신규 test 전부 GREEN (로컬 검증)
- [ ] CI verify (master invariant) — `npm run verify` 통과 (이 PR 의 GitHub Actions)
- [ ] 옵션 결정 후: live 24h watch + auditor baseline (Atlas+Echo 외 발화 코어 ≥3, 도메인 distinct ≥2)
- [ ] bus race test (9 daemon 동시 append) — 옵션 B 진입 시
- [ ] adapter restart test (Discord adapter kill → daemon 들 살아있음) — 옵션 B/C 의 핵심 가치 검증

## 환경 NOTE
로컬 Windows 환경에서 `@discordjs/opus` 네이티브 바인딩 npm 인스톨 블로커로 yawnbot 의 일부 test file 이 *pre-existing* 으로 fail (`Cannot find package 'discord.js'`). 영향 받은 test 는 본 PR 변경 무관. 본 PR 의 5 신규 test file 은 discord.js 의존 0 — 84 test 전부 로컬 통과 확인.

CI verify (`verify.yml` push trigger) 가 진짜 정본 게이트. 본 push 시점 로컬 `npm run verify` (master invariant) 통과 확인.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)