### PR TITLE
feat(servermonitor): agent-orchestrator + agent-daemons devProfile 등록 (TASK-KL-080/081)

### DIFF
--- a/apps/discord-bots/apps/yawnbot/package.json
+++ b/apps/discord-bots/apps/yawnbot/package.json
@@ -21,7 +21,8 @@
     "kakao-export-watch": "node scripts/kakao-export.mjs --watch",
     "kakao-export-watch-bg": "node scripts/kakao-export-watch-background.mjs",
     "kakao-export-watch-stop": "node scripts/kakao-export-watch-stop.mjs",
-    "cadence-tick": "node scripts/run-cadence-tick.mjs"
+    "cadence-tick": "node scripts/run-cadence-tick.mjs",
+    "start:daemons-all": "node scripts/start-daemons.mjs"
   },
   "dependencies": {
     "karmolab-ai": "file:../../../../packages/karmolab-ai",

--- a/apps/discord-bots/apps/yawnbot/scripts/start-daemons.mjs
+++ b/apps/discord-bots/apps/yawnbot/scripts/start-daemons.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// agent-daemon 8코어 동시 기동 — TASK-KL-081 (Option A 배치 기동).
+// 사용: npm run start:daemons-all (devProfile 버튼 또는 터미널).
+// 각 코어는 독립 child_process 로 병렬 실행. 부모 종료 시 SIGINT/SIGTERM 전파.
+
+import { spawn } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DAEMON_SCRIPT = resolve(__dirname, '..', 'dist', 'src', 'agent-daemon.js');
+
+const CORE_IDS = [
+  'atlas',
+  'echo',
+  'kar-worker',
+  'kl-worker',
+  'wm-scout',
+  'wm-support',
+  'initiator',
+  'auditor',
+];
+
+const children = [];
+
+for (const coreId of CORE_IDS) {
+  const child = spawn(
+    process.execPath,
+    [DAEMON_SCRIPT, '--core-id', coreId],
+    { stdio: ['ignore', 'inherit', 'inherit'], env: process.env }
+  );
+  child.on('exit', (code) => {
+    console.error(`[daemons] ${coreId} exited with code ${code}`);
+  });
+  children.push({ coreId, child });
+  console.log(`[daemons] started ${coreId} (pid=${child.pid})`);
+}
+
+function shutdown(signal) {
+  console.log(`[daemons] ${signal} — stopping all cores`);
+  for (const { coreId, child } of children) {
+    child.kill(signal);
+    console.log(`[daemons] sent ${signal} to ${coreId}`);
+  }
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/apps/discord-bots/package.json
+++ b/apps/discord-bots/package.json
@@ -16,6 +16,8 @@
     "webhook:upsert": "npm -w apps/yawnbot run webhook:upsert",
     "start": "npm -w apps/yawnbot run start",
     "start:yawnbot": "npm -w apps/yawnbot run start",
+    "start:orchestrator": "npm -w apps/agent-orchestrator run start",
+    "start:daemons-all": "npm -w apps/yawnbot run start:daemons-all",
     "deploy": "npm -w apps/yawnbot run deploy",
     "deploy:yawnbot": "npm -w apps/yawnbot run deploy",
     "audit:cron": "node scripts/audit-cron-traceability.mjs"

--- a/apps/karmolab/data/servermonitor-config.json
+++ b/apps/karmolab/data/servermonitor-config.json
@@ -90,6 +90,19 @@
             "script": "dev",
             "healthUrl": "http://127.0.0.1:5173/",
             "npmInstall": true
+        },
+        {
+            "id": "agent-orchestrator",
+            "label": "Agent Orchestrator",
+            "app": "apps/discord-bots",
+            "script": "start:orchestrator",
+            "deployScript": "build:orchestrator"
+        },
+        {
+            "id": "agent-daemons",
+            "label": "Agent Daemons (8코어)",
+            "app": "apps/discord-bots",
+            "script": "start:daemons-all"
         }
     ]
 }


### PR DESCRIPTION
## Summary

- `agent-orchestrator` (TASK-KAR-096) devProfile 등록 — `start:orchestrator` + `deployScript: build:orchestrator`
- `agent-daemons` (8코어: atlas/echo/kar-worker/kl-worker/wm-scout/wm-support/initiator/auditor) 배치 기동 devProfile 등록 — Option A (단일 카드)
- `start-daemons.mjs` 스크립트: 8개 코어 독립 child_process 병렬 spawn + SIGINT/SIGTERM 전파
- `servermonitor-config-audit.mjs` OK (devProfiles 6개)

## TASK

- TASK-KL-080: agent-orchestrator servermonitor devProfile 등록
- TASK-KL-081: agent-daemon 코어별 devProfile 등록 (Option A 채택)

## Note

- TASK-KL-079 (karmoddrine-map any-type): commit `41c7908` 에서 karmoddrine-map 위젯 삭제됨 → sealed 처리 예정 (memo repo)
- `npm run verify`는 cloud 환경 node_modules 미설치로 full 실행 불가 — servermonitor-config-audit (핵심 게이트) OK, CI 에서 verify 자동 검증 예정

---
_Generated by [Claude Code](https://claude.ai/code/session_011HiDPfz8QZ3qxeDuyYVZ3x)_