### PR TITLE
fix(yawnbot): GitHubCommit 타입으로 webhook commit any 제거 [TASK-KL-083]

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
@@ -4,6 +4,7 @@ import type { Client } from 'discord.js';
 import type { GameDataService } from '../services/gamedata';
 import { getChannelsForRepo } from '../services/webhook-routes';
 import { isDigestCommit, handleDigestCommit } from '../services/digest-webhook';
+import type { GitHubCommit } from '../services/digest-webhook';
 import { syncTaskStatusOnPrMerge } from '../services/task-status-sync';
 
 export function createGithubWebhookApp(client: Client, gameData: GameDataService) {
@@ -91,7 +92,7 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
 
         // TASK-YB-004 — dev-digest commit 감지: chore(digests): + digests/*.md added.
         // 해당 commit 발견 시 Yawn AI 가공 후 별도 embed 전송 + regular embed skip.
-        const digestCommit = payload.commits.find((c: any) => isDigestCommit(c));
+        const digestCommit = (payload.commits as GitHubCommit[]).find((c) => isDigestCommit(c));
         if (digestCommit) {
           res.sendStatus(200);
           // async 이므로 res 먼저 보내고 AI 처리 (최대 수 초 소요)
@@ -100,16 +101,16 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
         }
 
         embed.setTitle(gameData.getMessage('Webhook_Push_Title', payload.commits.length));
-        const desc = payload.commits
+        const desc = (payload.commits as GitHubCommit[])
           .slice(0, 5)
-          .map((c: any) => `- [\`${c.id.slice(0, 7)}\`](${c.url}) ${c.message}`)
+          .map((c) => `- [\`${c.id.slice(0, 7)}\`](${c.url}) ${c.message}`)
           .join('\n');
         embed.setDescription(desc);
 
         // TASK-WM-093 Phase F — claude-audit auto-fix push 시각 분리.
         // 모든 commit 의 subject 첫 줄이 `chore(audit-fix):` prefix 면 회색 (자동 배경 작업 톤).
         // 사람 손 push (default 초록 0x4caf50) 과 자동 fix push 디스코드 채널에서 즉시 구분.
-        const isAuditFixPush = payload.commits.every((c: any) => {
+        const isAuditFixPush = (payload.commits as GitHubCommit[]).every((c) => {
           const firstLine = String(c.message ?? '').split('\n', 1)[0];
           return firstLine.startsWith('chore(audit-fix):');
         });

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.test.ts
@@ -13,6 +13,7 @@ describe('isDigestCommit', () => {
   it('chore(digests): + 일자파일 added → 그 경로 (INDEX.md 오선택 X)', () => {
     expect(
       isDigestCommit({
+        id: 'abc123', url: 'https://github.com',
         message: 'chore(digests): 2026-05-17 digest (routine auto)',
         added: ['digests/INDEX.md', 'digests/2026-05-17.md'],
       }),
@@ -22,6 +23,7 @@ describe('isDigestCommit', () => {
   it('같은날 재실행/수동트리거 = modified-only 도 매칭 (2차 갭 fix)', () => {
     expect(
       isDigestCommit({
+        id: 'abc123', url: 'https://github.com',
         message: 'chore(digests): 2026-05-17 digest (routine auto)',
         added: [],
         modified: ['digests/2026-05-17.md', 'digests/INDEX.md'],
@@ -31,10 +33,11 @@ describe('isDigestCommit', () => {
 
   it('비-digest 메시지 / INDEX·README 만 → null', () => {
     expect(
-      isDigestCommit({ message: 'feat: x', added: ['digests/2026-05-17.md'] }),
+      isDigestCommit({ id: 'abc123', url: 'https://github.com', message: 'feat: x', added: ['digests/2026-05-17.md'] }),
     ).toBeNull();
     expect(
       isDigestCommit({
+        id: 'abc123', url: 'https://github.com',
         message: 'chore(digests): note',
         added: [],
         modified: ['digests/INDEX.md', 'digests/README.md'],

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
@@ -14,6 +14,15 @@ import { channelIdFor } from './channel-provision';
 const MAX_PLAIN_CHARS = 1800;
 const MAX_FETCH_CHARS = 8000;
 
+/** GitHub push webhook payload 의 commit 원소 타입 (실제 접근 필드만). */
+export interface GitHubCommit {
+  id: string;
+  url: string;
+  message: string;
+  added?: string[];
+  modified?: string[];
+}
+
 /** .md 본문에서 앞 YAML frontmatter (--- ... ---) 를 제거하고 본문만 반환 */
 function stripFrontmatter(raw: string): string {
   const m = raw.match(/^---[\s\S]*?---\r?\n([\s\S]*)$/);
@@ -72,7 +81,7 @@ const DATED_DIGEST_RE = /^digests\/\d{4}-\d{2}-\d{2}\.md$/;
  * - 일자패턴 한정: `digests/INDEX.md`·`README.md` 오선택 차단(잘못된
  *   파일 fetch → 깨진 게시 방지).
  */
-export function isDigestCommit(commit: any): string | null {
+export function isDigestCommit(commit: GitHubCommit): string | null {
   const firstLine = String(commit?.message ?? '').split('\n', 1)[0];
   if (!firstLine.startsWith('chore(digests):')) return null;
   const added: string[] = Array.isArray(commit?.added) ? commit.added : [];
@@ -91,7 +100,7 @@ export function isDigestCommit(commit: any): string | null {
  */
 export async function handleDigestCommit(
   client: Client,
-  commit: any,
+  commit: GitHubCommit,
   repoFullName: string,
   channelIds: string[],
 ): Promise<void> {


### PR DESCRIPTION
## Summary

- **TASK-KL-083** quality-loop fix: GitHub push webhook payload의 commit 콜백 `any` 타입 제거
- `digest-webhook.ts`에 `GitHubCommit` 인터페이스 정의 및 export (`id`, `url`, `message`, `added?`, `modified?`)
- `isDigestCommit` / `handleDigestCommit` 파라미터 `any → GitHubCommit`
- `webhook.ts` 3곳 콜백 `(c: any)` → `(c: GitHubCommit)` (find/map/every)

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `src/services/digest-webhook.ts` | `GitHubCommit` 인터페이스 추가, `isDigestCommit`/`handleDigestCommit` 파라미터 타입 교체 |
| `src/bot/webhook.ts` | `GitHubCommit` import, push 이벤트 3곳 `any` 제거 |

## 비고

- `@octokit/webhooks-types` 외부 패키지 도입 없이 로컬 인터페이스로 해결 (의존성 최소화)
- cloud 환경 node_modules 미설치로 `npm run verify` 전체 실행 불가 — 변경 파일 한정 타입 오류 없음 확인

https://claude.ai/code/session_0145bffy2NNZ24MGSiSLkv8q

---
_Generated by [Claude Code](https://claude.ai/code/session_0145bffy2NNZ24MGSiSLkv8q)_