### PR TITLE
fix(tauri): terminal_start async + spawn_blocking 전환 [TASK-KL-084]

### DIFF
--- a/apps/karmolab-tauri/src-tauri/src/terminal.rs
+++ b/apps/karmolab-tauri/src-tauri/src/terminal.rs
@@ -21,7 +21,7 @@
 use serde::Serialize;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{ChildStdin, Command, Stdio};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use tauri::{AppHandle, Emitter, State};
 
@@ -43,7 +43,7 @@ fn apply_no_window(cmd: &mut Command) {
 
 #[derive(Default)]
 pub struct TerminalState {
-    inner: Mutex<TerminalInner>,
+    inner: Arc<Mutex<TerminalInner>>,
 }
 
 #[derive(Default)]
@@ -127,12 +127,22 @@ fn initial_cwd() -> String {
 }
 
 #[tauri::command]
-pub fn terminal_start(
+pub async fn terminal_start(
     app: AppHandle,
     state: State<'_, TerminalState>,
 ) -> Result<TerminalStartResult, String> {
-    let mut inner = state.inner.lock().map_err(|e| format!("state lock 실패: {}", e))?;
-    if inner.child_id.is_some() {
+    let inner = Arc::clone(&state.inner);
+    tauri::async_runtime::spawn_blocking(move || terminal_start_blocking(app, inner))
+        .await
+        .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
+}
+
+fn terminal_start_blocking(
+    app: AppHandle,
+    inner: Arc<Mutex<TerminalInner>>,
+) -> Result<TerminalStartResult, String> {
+    let mut inner_guard = inner.lock().map_err(|e| format!("state lock 실패: {}", e))?;
+    if inner_guard.child_id.is_some() {
         return Ok(TerminalStartResult {
             running: true,
             cwd: initial_cwd(),
@@ -170,8 +180,8 @@ pub fn terminal_start(
         .take()
         .ok_or_else(|| "stderr pipe 없음".to_string())?;
 
-    inner.stdin = Some(stdin_handle);
-    inner.child_id = Some(pid);
+    inner_guard.stdin = Some(stdin_handle);
+    inner_guard.child_id = Some(pid);
 
     spawn_reader(stdout, app.clone(), "stdout");
     spawn_reader(stderr, app.clone(), "stderr");
@@ -184,7 +194,7 @@ pub fn terminal_start(
     });
 
     // 시작 직후 cwd 마커 한 번 — 위젯이 표시할 cwd 보장.
-    if let Some(stdin_handle) = inner.stdin.as_mut() {
+    if let Some(stdin_handle) = inner_guard.stdin.as_mut() {
         let _ = writeln!(
             stdin_handle,
             "Write-Host \"{}$((Get-Location).Path)\"",


### PR DESCRIPTION
## Summary

- **TASK-KL-084** quality-loop fix: `terminal_start`가 외부 프로세스(shell) spawn 하는 sync command → KL-043 패턴 위반 수정
- `TerminalState.inner`를 `Mutex<TerminalInner>` → `Arc<Mutex<TerminalInner>>`로 변경 (Arc::clone으로 spawn_blocking 클로저 이동 가능)
- `terminal_start_blocking` 헬퍼 분리 + `terminal_start` async 래퍼 적용
- 나머지 sync 커맨드(`terminal_send_stdin`/`terminal_stop`/`terminal_status`)와 `shutdown`은 Arc의 Deref→Mutex로 `.lock()` 호출 그대로 호환

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `apps/karmolab-tauri/src-tauri/src/terminal.rs` | `Arc` import, `TerminalState.inner` Arc wrapping, `terminal_start` async + `terminal_start_blocking` 분리 |

## 비고

- cloud 환경 GTK 미설치로 `cargo check` 로컬 실행 불가 (pre-existing 환경 이슈), CI가 실제 게이트
- 기존 sync 커맨드·shutdown 인터페이스 변경 없음

https://claude.ai/code/session_0145bffy2NNZ24MGSiSLkv8q

---
_Generated by [Claude Code](https://claude.ai/code/session_0145bffy2NNZ24MGSiSLkv8q)_