### PR TITLE
fix(tauri): create_task async + spawn_blocking 전환 [TASK-KL-085]

### DIFF
--- a/apps/karmolab-tauri/src-tauri/src/quest_launcher.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_launcher.rs
@@ -123,7 +123,17 @@ fn normalize_title_for_filename(title: &str) -> String {
 /// 위젯에서 "+ 새 TASK" → 다음 ID 자동 발급 + frontmatter skeleton 생성.
 /// 반환: 생성된 파일 절대 경로 (위젯이 즉시 open_task_in_editor 호출).
 #[tauri::command]
-pub fn create_task(
+pub async fn create_task(
+    domain: String,
+    title: String,
+    memo_path: Option<String>,
+) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || create_task_blocking(domain, title, memo_path))
+        .await
+        .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
+}
+
+fn create_task_blocking(
     domain: String,
     title: String,
     memo_path: Option<String>,


### PR DESCRIPTION
## Summary

- **TASK-KL-085** quality-loop fix: `create_task`가 `fs::create_dir_all` + `read_dir` 다중 스캔 + `fs::write`를 sync command에서 수행하는 KL-043 패턴 위반 수정
- `create_task_blocking` 헬퍼 분리 + `create_task` async 래퍼 적용
- 파라미터가 모두 `String`/`Option<String>`(`'static`)이므로 State 구조 변경 불필요 (KL-084와 달리 단순)

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `apps/karmolab-tauri/src-tauri/src/quest_launcher.rs` | `create_task` async + `create_task_blocking` 분리 (+11줄) |

https://claude.ai/code/session_0145bffy2NNZ24MGSiSLkv8q

---
_Generated by [Claude Code](https://claude.ai/code/session_0145bffy2NNZ24MGSiSLkv8q)_