### PR TITLE
fix(yawnbot): catch any → unknown + instanceof Error 가드 [TASK-KL-086]

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/local-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/local-webhook.ts
@@ -88,8 +88,8 @@ export async function sendLocalEvent(
       const ok = await channel
         .send({ embeds: [embed] })
         .then(() => true)
-        .catch((e: any) => {
-          console.error('[LocalWebhook] 채널 전송 실패:', channelId, e?.message ?? e);
+        .catch((e: unknown) => {
+          console.error('[LocalWebhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e));
           return false;
         });
       if (ok) sent++;
@@ -125,8 +125,8 @@ export function mountLocalWebhook(app: Application, client: Client): void {
         );
       }
       res.sendStatus(200);
-    } catch (err: any) {
-      console.error('[LocalWebhook] Error:', err?.message ?? err);
+    } catch (err: unknown) {
+      console.error('[LocalWebhook] Error:', err instanceof Error ? err.message : String(err));
       res.sendStatus(500);
     }
   });

--- a/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
@@ -181,15 +181,15 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
       for (const channelId of channelIds) {
         const channel = await client.channels.fetch(channelId).catch(() => null);
         if (channel?.isSendable()) {
-          await channel.send({ embeds: [embed] }).catch((e: any) =>
-            console.error('[Webhook] 채널 전송 실패:', channelId, e?.message ?? e),
+          await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+            console.error('[Webhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
           );
         }
       }
 
       res.sendStatus(200);
-    } catch (err: any) {
-      console.error('[Webhook] Error:', err?.message ?? err);
+    } catch (err: unknown) {
+      console.error('[Webhook] Error:', err instanceof Error ? err.message : String(err));
       res.sendStatus(500);
     }
   });

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -178,8 +178,8 @@ try {
   if (generativeText) {
     console.log(`[Gemini] AI 초기화 완료 (surface=${generativeText.surface})`);
   }
-} catch (e: any) {
-  console.warn('[Gemini] 초기화 실패 (선택 기능):', e?.message ?? e);
+} catch (e: unknown) {
+  console.warn('[Gemini] 초기화 실패 (선택 기능):', e instanceof Error ? e.message : String(e));
 }
 
 function buildCtx() {
@@ -424,10 +424,10 @@ client.once('clientReady', async () => {
         console.log(
           `[ChannelProvision] ${guild.name}: 카테고리「${effectiveCategoryName(spec)}」/ 생성 ${r.created.length} · claim ${r.claimed.length} · 재사용 ${r.reused.length}`,
         );
-      } catch (e: any) {
+      } catch (e: unknown) {
         console.error(
           `[ChannelProvision] ${guild.name}(${guild.id}) reconcile 실패 — env 폴백:`,
-          e?.message ?? e,
+          e instanceof Error ? e.message : String(e),
         );
       }
     }
@@ -480,7 +480,7 @@ client.once('clientReady', async () => {
     if (channel && channel.isTextBased()) {
       const version = process.env.npm_package_version || '1.0.0';
       const greeting = gameData.getMessage('Server_Startup_Greeting', version);
-      await channel.send(greeting).catch((e: any) => console.error('[Startup] 인사 메시지 전송 실패:', e?.message ?? e));
+      await channel.send(greeting).catch((e: unknown) => console.error('[Startup] 인사 메시지 전송 실패:', e instanceof Error ? e.message : String(e)));
     }
   }
 
@@ -662,8 +662,8 @@ client.once('clientReady', async () => {
           console.error('[CoreSpeak] bus publish 실패', busErr instanceof Error ? busErr.message : busErr);
         }
         return true;
-      } catch (e: any) {
-        console.error('[CoreSpeak]', e?.message ?? e);
+      } catch (e: unknown) {
+        console.error('[CoreSpeak]', e instanceof Error ? e.message : String(e));
         return false;
       }
     });
@@ -707,8 +707,8 @@ client.once('clientReady', async () => {
         }
         const m = await ch.send(payload);
         return m.id;
-      } catch (e: any) {
-        console.error('[Dashboard]', e?.message ?? e);
+      } catch (e: unknown) {
+        console.error('[Dashboard]', e instanceof Error ? e.message : String(e));
         return null;
       }
     });
@@ -726,8 +726,8 @@ client.once('clientReady', async () => {
             if (!(ch instanceof TextChannel)) return null;
             const m = await ch.send({ content: content.slice(0, 1900) });
             return m.id;
-          } catch (e: any) {
-            console.error('[StatusBoard send]', e?.message ?? e);
+          } catch (e: unknown) {
+            console.error('[StatusBoard send]', e instanceof Error ? e.message : String(e));
             return null;
           }
         },
@@ -885,8 +885,8 @@ async function main() {
 
   try {
     await client.login(token);
-  } catch (e: any) {
-    if (e?.code === 'TokenInvalid') {
+  } catch (e: unknown) {
+    if (e instanceof Error && (e as Error & { code?: string }).code === 'TokenInvalid') {
       console.error(
         '[YawnBot] TokenInvalid — 토큰이 만료되었거나 잘못되었습니다. Discord Developer Portal에서 Bot Token을 재발급하고 .env 의 DISCORD_TOKEN을 갱신하세요.',
       );

--- a/apps/discord-bots/apps/yawnbot/src/services/channel-provision.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/channel-provision.ts
@@ -117,8 +117,8 @@ export function getChannelSpec(): ChannelSpec {
         )
       : [];
     specCache = { categoryName: String(raw.categoryName ?? '욘봇'), channels };
-  } catch (e: any) {
-    console.warn(`[ChannelProvision] ${SPEC_PATH} 로드 실패 — 프로비저닝 비활성:`, e?.message ?? e);
+  } catch (e: unknown) {
+    console.warn(`[ChannelProvision] ${SPEC_PATH} 로드 실패 — 프로비저닝 비활성:`, e instanceof Error ? e.message : String(e));
     specCache = { categoryName: '욘봇', channels: [] };
   }
   return specCache;

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
@@ -107,10 +107,10 @@ export async function handleDigestCommit(
     let rawBody = '';
     try {
       rawBody = await fetchRepoFile(repoFullName, sha, digestFile);
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error(
         `[DigestWebhook] digest 본문 fetch 실패 (${repoFullName}@${sha.slice(0, 7)}/${digestFile}):`,
-        e?.message ?? e,
+        e instanceof Error ? e.message : String(e),
       );
       return;
     }
@@ -135,8 +135,8 @@ export async function handleDigestCommit(
         tag: 'yawnbot/digest',
       });
       yawnResponse = text.trim();
-    } catch (e: any) {
-      console.error('[DigestWebhook] AI 가공 실패:', e?.message ?? e);
+    } catch (e: unknown) {
+      console.error('[DigestWebhook] AI 가공 실패:', e instanceof Error ? e.message : String(e));
       // fallback: 원본 첫 500자 그대로
       yawnResponse = body.slice(0, 500) + (body.length > 500 ? '\n…' : '');
     }
@@ -162,15 +162,15 @@ export async function handleDigestCommit(
     for (const channelId of targetChannels) {
       const channel = await client.channels.fetch(channelId).catch(() => null);
       if (channel?.isSendable()) {
-        await channel.send({ embeds: [embed] }).catch((e: any) =>
-          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e?.message ?? e),
+        await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
         );
       }
     }
 
     console.log(`[DigestWebhook] ${dateLabel} digest 전송 완료 (${targetChannels.length} 채널)`);
-  } catch (e: any) {
-    console.error('[DigestWebhook] handleDigestCommit 예외:', e?.message ?? e);
+  } catch (e: unknown) {
+    console.error('[DigestWebhook] handleDigestCommit 예외:', e instanceof Error ? e.message : String(e));
   }
 }
 

--- a/apps/discord-bots/apps/yawnbot/src/services/notifiers/unity-free.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/notifiers/unity-free.ts
@@ -265,9 +265,10 @@ async function pollOnce(client: Client, channelId: string, force: boolean): Prom
   let info: PublisherSaleAssetInfo | null;
   try {
     info = await fetchPublisherSaleAssetInfo();
-  } catch (err: any) {
-    console.error('[UnityFree] Unity 페이지 요청/파싱 실패:', err?.message ?? err);
-    return { status: 'fetch_failed', info: null, error: String(err?.message ?? err) };
+  } catch (err: unknown) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    console.error('[UnityFree] Unity 페이지 요청/파싱 실패:', errMsg);
+    return { status: 'fetch_failed', info: null, error: errMsg };
   }
 
   if (!info) {

--- a/apps/discord-bots/apps/yawnbot/src/services/webhook-routes.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/webhook-routes.ts
@@ -60,8 +60,8 @@ function load(): WebhookRoutes {
         ? parsed.localDefault.filter((s) => typeof s === 'string')
         : [],
     };
-  } catch (e: any) {
-    console.warn(`[WebhookRoutes] ${ROUTES_PATH} 로드 실패 — 빈 라우팅으로 시작:`, e?.message ?? e);
+  } catch (e: unknown) {
+    console.warn(`[WebhookRoutes] ${ROUTES_PATH} 로드 실패 — 빈 라우팅으로 시작:`, e instanceof Error ? e.message : String(e));
     cached = { default: [], routes: {}, localRoutes: {}, localDefault: [] };
   }
   return cached;


### PR DESCRIPTION
## Summary

- **TASK-KL-086** quality-loop fix: 7개 파일 18곳의 `catch (e: any)` / `.catch((e: any) => ...)` → `catch (e: unknown)`으로 교체
- `e?.message ?? e` 패턴 → `e instanceof Error ? e.message : String(e)` 로 안전하게 접근
- `main.ts` TokenInvalid 코드 검사: `e instanceof Error && (e as Error & { code?: string }).code` 교차 타입 캐스트

## 변경 파일

| 파일 | 위반 수정 수 |
|---|---|
| `bot/local-webhook.ts` | 2 |
| `bot/webhook.ts` | 2 |
| `services/channel-provision.ts` | 1 |
| `services/webhook-routes.ts` | 1 |
| `services/notifiers/unity-free.ts` | 1 (중복 접근 → errMsg 변수로 단일화) |
| `services/digest-webhook.ts` | 4 |
| `main.ts` | 7 |

https://claude.ai/code/session_0145bffy2NNZ24MGSiSLkv8q

---
_Generated by [Claude Code](https://claude.ai/code/session_0145bffy2NNZ24MGSiSLkv8q)_