### PR TITLE
fix(yawnbot): KL-083+086 webhook commit 타입 + catch any→unknown 정리

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/local-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/local-webhook.ts
@@ -88,8 +88,8 @@ export async function sendLocalEvent(
       const ok = await channel
         .send({ embeds: [embed] })
         .then(() => true)
-        .catch((e: any) => {
-          console.error('[LocalWebhook] 채널 전송 실패:', channelId, e?.message ?? e);
+        .catch((e: unknown) => {
+          console.error('[LocalWebhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e));
           return false;
         });
       if (ok) sent++;
@@ -125,8 +125,8 @@ export function mountLocalWebhook(app: Application, client: Client): void {
         );
       }
       res.sendStatus(200);
-    } catch (err: any) {
-      console.error('[LocalWebhook] Error:', err?.message ?? err);
+    } catch (err: unknown) {
+      console.error('[LocalWebhook] Error:', err instanceof Error ? err.message : String(err));
       res.sendStatus(500);
     }
   });

--- a/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
@@ -3,7 +3,7 @@ import { EmbedBuilder, Status } from 'discord.js';
 import type { Client } from 'discord.js';
 import type { GameDataService } from '../services/gamedata';
 import { getChannelsForRepo } from '../services/webhook-routes';
-import { isDigestCommit, handleDigestCommit } from '../services/digest-webhook';
+import { isDigestCommit, handleDigestCommit, type GitHubPushCommit } from '../services/digest-webhook';
 import { syncTaskStatusOnPrMerge } from '../services/task-status-sync';
 
 export function createGithubWebhookApp(client: Client, gameData: GameDataService) {
@@ -91,7 +91,7 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
 
         // TASK-YB-004 — dev-digest commit 감지: chore(digests): + digests/*.md added.
         // 해당 commit 발견 시 Yawn AI 가공 후 별도 embed 전송 + regular embed skip.
-        const digestCommit = payload.commits.find((c: any) => isDigestCommit(c));
+        const digestCommit = payload.commits.find((c: GitHubPushCommit) => isDigestCommit(c));
         if (digestCommit) {
           res.sendStatus(200);
           // async 이므로 res 먼저 보내고 AI 처리 (최대 수 초 소요)
@@ -102,14 +102,14 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
         embed.setTitle(gameData.getMessage('Webhook_Push_Title', payload.commits.length));
         const desc = payload.commits
           .slice(0, 5)
-          .map((c: any) => `- [\`${c.id.slice(0, 7)}\`](${c.url}) ${c.message}`)
+          .map((c: GitHubPushCommit) => `- [\`${c.id.slice(0, 7)}\`](${c.url}) ${c.message}`)
           .join('\n');
         embed.setDescription(desc);
 
         // TASK-WM-093 Phase F — claude-audit auto-fix push 시각 분리.
         // 모든 commit 의 subject 첫 줄이 `chore(audit-fix):` prefix 면 회색 (자동 배경 작업 톤).
         // 사람 손 push (default 초록 0x4caf50) 과 자동 fix push 디스코드 채널에서 즉시 구분.
-        const isAuditFixPush = payload.commits.every((c: any) => {
+        const isAuditFixPush = payload.commits.every((c: GitHubPushCommit) => {
           const firstLine = String(c.message ?? '').split('\n', 1)[0];
           return firstLine.startsWith('chore(audit-fix):');
         });
@@ -181,15 +181,15 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
       for (const channelId of channelIds) {
         const channel = await client.channels.fetch(channelId).catch(() => null);
         if (channel?.isSendable()) {
-          await channel.send({ embeds: [embed] }).catch((e: any) =>
-            console.error('[Webhook] 채널 전송 실패:', channelId, e?.message ?? e),
+          await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+            console.error('[Webhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
           );
         }
       }
 
       res.sendStatus(200);
-    } catch (err: any) {
-      console.error('[Webhook] Error:', err?.message ?? err);
+    } catch (err: unknown) {
+      console.error('[Webhook] Error:', err instanceof Error ? err.message : String(err));
       res.sendStatus(500);
     }
   });

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -178,8 +178,8 @@ try {
   if (generativeText) {
     console.log(`[Gemini] AI 초기화 완료 (surface=${generativeText.surface})`);
   }
-} catch (e: any) {
-  console.warn('[Gemini] 초기화 실패 (선택 기능):', e?.message ?? e);
+} catch (e: unknown) {
+  console.warn('[Gemini] 초기화 실패 (선택 기능):', e instanceof Error ? e.message : String(e));
 }
 
 function buildCtx() {
@@ -424,10 +424,10 @@ client.once('clientReady', async () => {
         console.log(
           `[ChannelProvision] ${guild.name}: 카테고리「${effectiveCategoryName(spec)}」/ 생성 ${r.created.length} · claim ${r.claimed.length} · 재사용 ${r.reused.length}`,
         );
-      } catch (e: any) {
+      } catch (e: unknown) {
         console.error(
           `[ChannelProvision] ${guild.name}(${guild.id}) reconcile 실패 — env 폴백:`,
-          e?.message ?? e,
+          e instanceof Error ? e.message : String(e),
         );
       }
     }
@@ -480,7 +480,7 @@ client.once('clientReady', async () => {
     if (channel && channel.isTextBased()) {
       const version = process.env.npm_package_version || '1.0.0';
       const greeting = gameData.getMessage('Server_Startup_Greeting', version);
-      await channel.send(greeting).catch((e: any) => console.error('[Startup] 인사 메시지 전송 실패:', e?.message ?? e));
+      await channel.send(greeting).catch((e: unknown) => console.error('[Startup] 인사 메시지 전송 실패:', e instanceof Error ? e.message : String(e)));
     }
   }
 
@@ -662,8 +662,8 @@ client.once('clientReady', async () => {
           console.error('[CoreSpeak] bus publish 실패', busErr instanceof Error ? busErr.message : busErr);
         }
         return true;
-      } catch (e: any) {
-        console.error('[CoreSpeak]', e?.message ?? e);
+      } catch (e: unknown) {
+        console.error('[CoreSpeak]', e instanceof Error ? e.message : String(e));
         return false;
       }
     });
@@ -707,8 +707,8 @@ client.once('clientReady', async () => {
         }
         const m = await ch.send(payload);
         return m.id;
-      } catch (e: any) {
-        console.error('[Dashboard]', e?.message ?? e);
+      } catch (e: unknown) {
+        console.error('[Dashboard]', e instanceof Error ? e.message : String(e));
         return null;
       }
     });
@@ -726,8 +726,8 @@ client.once('clientReady', async () => {
             if (!(ch instanceof TextChannel)) return null;
             const m = await ch.send({ content: content.slice(0, 1900) });
             return m.id;
-          } catch (e: any) {
-            console.error('[StatusBoard send]', e?.message ?? e);
+          } catch (e: unknown) {
+            console.error('[StatusBoard send]', e instanceof Error ? e.message : String(e));
             return null;
           }
         },
@@ -885,8 +885,8 @@ async function main() {
 
   try {
     await client.login(token);
-  } catch (e: any) {
-    if (e?.code === 'TokenInvalid') {
+  } catch (e: unknown) {
+    if (e !== null && typeof e === 'object' && 'code' in e && (e as { code: unknown }).code === 'TokenInvalid') {
       console.error(
         '[YawnBot] TokenInvalid — 토큰이 만료되었거나 잘못되었습니다. Discord Developer Portal에서 Bot Token을 재발급하고 .env 의 DISCORD_TOKEN을 갱신하세요.',
       );

--- a/apps/discord-bots/apps/yawnbot/src/services/channel-provision.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/channel-provision.ts
@@ -117,8 +117,8 @@ export function getChannelSpec(): ChannelSpec {
         )
       : [];
     specCache = { categoryName: String(raw.categoryName ?? '욘봇'), channels };
-  } catch (e: any) {
-    console.warn(`[ChannelProvision] ${SPEC_PATH} 로드 실패 — 프로비저닝 비활성:`, e?.message ?? e);
+  } catch (e: unknown) {
+    console.warn(`[ChannelProvision] ${SPEC_PATH} 로드 실패 — 프로비저닝 비활성:`, e instanceof Error ? e.message : String(e));
     specCache = { categoryName: '욘봇', channels: [] };
   }
   return specCache;

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.test.ts
@@ -13,6 +13,7 @@ describe('isDigestCommit', () => {
   it('chore(digests): + 일자파일 added → 그 경로 (INDEX.md 오선택 X)', () => {
     expect(
       isDigestCommit({
+        id: 'abc123', url: 'https://github.com/example',
         message: 'chore(digests): 2026-05-17 digest (routine auto)',
         added: ['digests/INDEX.md', 'digests/2026-05-17.md'],
       }),
@@ -22,6 +23,7 @@ describe('isDigestCommit', () => {
   it('같은날 재실행/수동트리거 = modified-only 도 매칭 (2차 갭 fix)', () => {
     expect(
       isDigestCommit({
+        id: 'abc123', url: 'https://github.com/example',
         message: 'chore(digests): 2026-05-17 digest (routine auto)',
         added: [],
         modified: ['digests/2026-05-17.md', 'digests/INDEX.md'],
@@ -31,10 +33,11 @@ describe('isDigestCommit', () => {
 
   it('비-digest 메시지 / INDEX·README 만 → null', () => {
     expect(
-      isDigestCommit({ message: 'feat: x', added: ['digests/2026-05-17.md'] }),
+      isDigestCommit({ id: 'abc123', url: 'https://github.com/example', message: 'feat: x', added: ['digests/2026-05-17.md'] }),
     ).toBeNull();
     expect(
       isDigestCommit({
+        id: 'abc123', url: 'https://github.com/example',
         message: 'chore(digests): note',
         added: [],
         modified: ['digests/INDEX.md', 'digests/README.md'],

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
@@ -62,6 +62,15 @@ export async function fetchRepoFile(
 /** 일자 digest 파일만 (digests/YYYY-MM-DD.md). INDEX.md/README.md 제외. */
 const DATED_DIGEST_RE = /^digests\/\d{4}-\d{2}-\d{2}\.md$/;
 
+/** GitHub push webhook payload 의 commit 원소 — 실제로 접근하는 필드만 선언. */
+export interface GitHubPushCommit {
+  id: string;
+  url: string;
+  message: string;
+  added?: string[];
+  modified?: string[];
+}
+
 /**
  * push payload 의 commit 하나가 dev-digest commit 인지 판별.
  * 조건: message 첫 줄 "chore(digests):" + **added ∪ modified** 중
@@ -72,7 +81,7 @@ const DATED_DIGEST_RE = /^digests\/\d{4}-\d{2}-\d{2}\.md$/;
  * - 일자패턴 한정: `digests/INDEX.md`·`README.md` 오선택 차단(잘못된
  *   파일 fetch → 깨진 게시 방지).
  */
-export function isDigestCommit(commit: any): string | null {
+export function isDigestCommit(commit: GitHubPushCommit): string | null {
   const firstLine = String(commit?.message ?? '').split('\n', 1)[0];
   if (!firstLine.startsWith('chore(digests):')) return null;
   const added: string[] = Array.isArray(commit?.added) ? commit.added : [];
@@ -91,7 +100,7 @@ export function isDigestCommit(commit: any): string | null {
  */
 export async function handleDigestCommit(
   client: Client,
-  commit: any,
+  commit: GitHubPushCommit,
   repoFullName: string,
   channelIds: string[],
 ): Promise<void> {
@@ -107,10 +116,10 @@ export async function handleDigestCommit(
     let rawBody = '';
     try {
       rawBody = await fetchRepoFile(repoFullName, sha, digestFile);
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error(
         `[DigestWebhook] digest 본문 fetch 실패 (${repoFullName}@${sha.slice(0, 7)}/${digestFile}):`,
-        e?.message ?? e,
+        e instanceof Error ? e.message : String(e),
       );
       return;
     }
@@ -135,8 +144,8 @@ export async function handleDigestCommit(
         tag: 'yawnbot/digest',
       });
       yawnResponse = text.trim();
-    } catch (e: any) {
-      console.error('[DigestWebhook] AI 가공 실패:', e?.message ?? e);
+    } catch (e: unknown) {
+      console.error('[DigestWebhook] AI 가공 실패:', e instanceof Error ? e.message : String(e));
       // fallback: 원본 첫 500자 그대로
       yawnResponse = body.slice(0, 500) + (body.length > 500 ? '\n…' : '');
     }
@@ -162,15 +171,15 @@ export async function handleDigestCommit(
     for (const channelId of targetChannels) {
       const channel = await client.channels.fetch(channelId).catch(() => null);
       if (channel?.isSendable()) {
-        await channel.send({ embeds: [embed] }).catch((e: any) =>
-          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e?.message ?? e),
+        await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
         );
       }
     }
 
     console.log(`[DigestWebhook] ${dateLabel} digest 전송 완료 (${targetChannels.length} 채널)`);
-  } catch (e: any) {
-    console.error('[DigestWebhook] handleDigestCommit 예외:', e?.message ?? e);
+  } catch (e: unknown) {
+    console.error('[DigestWebhook] handleDigestCommit 예외:', e instanceof Error ? e.message : String(e));
   }
 }
 

--- a/apps/discord-bots/apps/yawnbot/src/services/notifiers/unity-free.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/notifiers/unity-free.ts
@@ -265,9 +265,9 @@ async function pollOnce(client: Client, channelId: string, force: boolean): Prom
   let info: PublisherSaleAssetInfo | null;
   try {
     info = await fetchPublisherSaleAssetInfo();
-  } catch (err: any) {
-    console.error('[UnityFree] Unity 페이지 요청/파싱 실패:', err?.message ?? err);
-    return { status: 'fetch_failed', info: null, error: String(err?.message ?? err) };
+  } catch (err: unknown) {
+    console.error('[UnityFree] Unity 페이지 요청/파싱 실패:', err instanceof Error ? err.message : String(err));
+    return { status: 'fetch_failed', info: null, error: err instanceof Error ? err.message : String(err) };
   }
 
   if (!info) {

--- a/apps/discord-bots/apps/yawnbot/src/services/webhook-routes.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/webhook-routes.ts
@@ -60,8 +60,8 @@ function load(): WebhookRoutes {
         ? parsed.localDefault.filter((s) => typeof s === 'string')
         : [],
     };
-  } catch (e: any) {
-    console.warn(`[WebhookRoutes] ${ROUTES_PATH} 로드 실패 — 빈 라우팅으로 시작:`, e?.message ?? e);
+  } catch (e: unknown) {
+    console.warn(`[WebhookRoutes] ${ROUTES_PATH} 로드 실패 — 빈 라우팅으로 시작:`, e instanceof Error ? e.message : String(e));
     cached = { default: [], routes: {}, localRoutes: {}, localDefault: [] };
   }
   return cached;


### PR DESCRIPTION
## Summary

- **TASK-KL-083**: `GitHubPushCommit` 인터페이스 신설 (`id/url/message/added?/modified?`) → `isDigestCommit` · `handleDigestCommit` · `webhook.ts` commit 콜백 3곳 `any` 제거. `digest-webhook.test.ts` 필수 필드 추가.
- **TASK-KL-086**: yawnbot 7개 파일 `catch (e: any)` / `.catch((e: any) => ...)` → `unknown` 전환. `e instanceof Error ? e.message : String(e)` 패턴 적용. `TokenInvalid` 코드 체크는 object narrowing 으로 타입 안전 유지

> ⚠️ 이 PR은 #145 (KL-083) + #148 (KL-086) 를 **통합 대체**합니다. 두 PR 모두 CI failure 상태이며, 이 PR이 동일 변경에 test 픽스까지 포함합니다.

## Changed files

| 파일 | KL-083 | KL-086 |
|---|---|---|
| `src/services/digest-webhook.ts` | GitHubPushCommit 선언 + 함수 시그니처 2곳 | catch 4곳 |
| `src/services/digest-webhook.test.ts` | id/url 필수 필드 추가 | — |
| `src/bot/webhook.ts` | import + c:any 3곳 | catch 2곳 |
| `src/bot/local-webhook.ts` | — | catch 2곳 |
| `src/services/channel-provision.ts` | — | catch 1곳 |
| `src/services/webhook-routes.ts` | — | catch 1곳 |
| `src/services/notifiers/unity-free.ts` | — | catch 1곳 |
| `src/main.ts` | — | catch 7곳 |

## Test plan

- [ ] `cd apps/discord-bots && npm run build:yawnbot` 통과 (tsc 타입 오류 없음)
- [ ] `npm run verify` (master invariant) 통과
- [ ] CI post-push audit 통과

## Notes

- cloud-kl autopilot 이 생성한 Draft PR — verify 는 CI 또는 로컬에서 확인 후 merge
- machine: any 이므로 desktop 에서 verify 가능
- #145, #148 supersedes — 해당 PR close 예정