### PR TITLE
feat(kl-081): agent-daemon 8코어 일괄 기동 devProfile 등록

### DIFF
--- a/apps/discord-bots/apps/yawnbot/package.json
+++ b/apps/discord-bots/apps/yawnbot/package.json
@@ -21,7 +21,8 @@
     "kakao-export-watch": "node scripts/kakao-export.mjs --watch",
     "kakao-export-watch-bg": "node scripts/kakao-export-watch-background.mjs",
     "kakao-export-watch-stop": "node scripts/kakao-export-watch-stop.mjs",
-    "cadence-tick": "node scripts/run-cadence-tick.mjs"
+    "cadence-tick": "node scripts/run-cadence-tick.mjs",
+    "start:daemons-all": "node scripts/start-daemons.mjs"
   },
   "dependencies": {
     "karmolab-ai": "file:../../../../packages/karmolab-ai",

--- a/apps/discord-bots/apps/yawnbot/scripts/start-daemons.mjs
+++ b/apps/discord-bots/apps/yawnbot/scripts/start-daemons.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Agent Daemon 일괄 기동 — TASK-KL-081.
+ *
+ * 8개 active 코어(atlas/echo/kar-worker/kl-worker/wm-scout/wm-support/initiator/auditor)를
+ * 각각 독립 process 로 spawn. stdout/stderr 는 `[daemon:<coreId>]` prefix 로 relay.
+ * SIGTERM/SIGINT = 전체 자식 종료.
+ *
+ * 사용: node scripts/start-daemons.mjs
+ * env: agent-daemon.ts 와 동일 (LAPTOP_AGENT_BUS_ROOT / LAPTOP_MEMO_ROOT / etc.)
+ */
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DIST_DAEMON = resolve(__dirname, '..', 'dist', 'src', 'agent-daemon.js');
+
+const CORE_IDS = [
+  'atlas',
+  'echo',
+  'kar-worker',
+  'kl-worker',
+  'wm-scout',
+  'wm-support',
+  'initiator',
+  'auditor',
+];
+
+if (!existsSync(DIST_DAEMON)) {
+  console.error(
+    `[daemons] dist 산출물 없음: ${DIST_DAEMON}\n  먼저 npm run build 후 재실행.`,
+  );
+  process.exit(1);
+}
+
+/** @type {Array<{coreId: string, child: import('child_process').ChildProcess}>} */
+const children = [];
+
+for (const coreId of CORE_IDS) {
+  const child = spawn(process.execPath, [DIST_DAEMON, '--core-id', coreId], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, AGENT_DAEMON_CORE_ID: coreId },
+  });
+
+  const tag = `[daemon:${coreId}]`;
+
+  child.stdout.on('data', (buf) => {
+    for (const line of buf.toString().trimEnd().split('\n')) {
+      if (line) console.log(`${tag} ${line}`);
+    }
+  });
+  child.stderr.on('data', (buf) => {
+    for (const line of buf.toString().trimEnd().split('\n')) {
+      if (line) console.error(`${tag} ${line}`);
+    }
+  });
+  child.on('close', (code, signal) => {
+    console.log(`${tag} 종료 code=${code ?? '?'} signal=${signal ?? '-'}`);
+  });
+  child.on('error', (err) => {
+    console.error(`${tag} spawn 오류: ${err.message}`);
+  });
+
+  children.push({ coreId, child });
+  console.log(`[daemons] ${coreId} 기동 pid=${child.pid}`);
+}
+
+console.log(`[daemons] ${CORE_IDS.length}개 코어 기동 완료`);
+
+function killAll(sig) {
+  console.log(`[daemons] ${sig} 수신 — 전체 종료 중...`);
+  for (const { child } of children) {
+    try {
+      child.kill(sig);
+    } catch {
+      // 이미 종료된 경우 무시
+    }
+  }
+}
+
+process.on('SIGTERM', () => killAll('SIGTERM'));
+process.on('SIGINT', () => killAll('SIGINT'));

--- a/apps/discord-bots/package.json
+++ b/apps/discord-bots/package.json
@@ -18,6 +18,7 @@
     "start:yawnbot": "npm -w apps/yawnbot run start",
     "deploy": "npm -w apps/yawnbot run deploy",
     "deploy:yawnbot": "npm -w apps/yawnbot run deploy",
+    "start:daemons-all": "npm -w apps/yawnbot run start:daemons-all",
     "audit:cron": "node scripts/audit-cron-traceability.mjs"
   },
   "devDependencies": {

--- a/apps/karmolab-tauri/src-tauri/src/quest_index.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_index.rs
@@ -277,7 +277,7 @@ pub async fn get_quest_tree(memo_path: Option<String>) -> Result<QuestTree, Stri
         .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
 }
 
-fn get_quest_tree_blocking(memo_path: Option<String>) -> Result<QuestTree, String> {
+pub(crate) fn get_quest_tree_blocking(memo_path: Option<String>) -> Result<QuestTree, String> {
     let memo = match memo_path.filter(|s| !s.is_empty()) {
         Some(value) => PathBuf::from(value),
         None => default_memo_path().ok_or_else(|| {

--- a/apps/karmolab/data/servermonitor-config.json
+++ b/apps/karmolab/data/servermonitor-config.json
@@ -90,6 +90,13 @@
             "script": "dev",
             "healthUrl": "http://127.0.0.1:5173/",
             "npmInstall": true
+        },
+        {
+            "id": "agent-daemons",
+            "label": "Agent Daemons (8코어)",
+            "app": "apps/discord-bots",
+            "script": "start:daemons-all",
+            "npmInstall": true
         }
     ]
 }


### PR DESCRIPTION
## Summary

- `scripts/start-daemons.mjs` 신규: atlas/echo/kar-worker/kl-worker/wm-scout/wm-support/initiator/auditor 8개 코어를 독립 process로 spawn, `[daemon:<id>]` prefix relay, SIGTERM/SIGINT 전체 종료
- `yawnbot/package.json`: `start:daemons-all` 스크립트 추가
- `discord-bots/package.json`: workspace 위임 `start:daemons-all` 추가
- `servermonitor-config.json`: `agent-daemons` devProfile 등록 (Option A — 단일 배치)

`servermonitor-config-audit.mjs` OK (5개 프로필 정합).

## Test plan

- [ ] `node scripts/servermonitor-config-audit.mjs` — 이미 통과 (cloud 환경)
- [ ] `npm run verify` — CI 검증 (full deps 필요)
- [ ] KarmoLab Server Monitor에서 「Agent Daemons (8코어)」 카드 표시 확인
- [ ] 카드 시작 버튼 → 8개 daemon 로그 출력 확인

TASK-KL-081 / cloud-kl autopilot 2026-05-27

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdUFFQamJdb7Bindq16QWF)_