### PR TITLE
fix(kl-083+kl-086): yawnbot type-safety — GitHubCommit + catch unknown

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/local-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/local-webhook.ts
@@ -88,8 +88,8 @@ export async function sendLocalEvent(
       const ok = await channel
         .send({ embeds: [embed] })
         .then(() => true)
-        .catch((e: any) => {
-          console.error('[LocalWebhook] 채널 전송 실패:', channelId, e?.message ?? e);
+        .catch((e: unknown) => {
+          console.error('[LocalWebhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e));
           return false;
         });
       if (ok) sent++;
@@ -125,8 +125,8 @@ export function mountLocalWebhook(app: Application, client: Client): void {
         );
       }
       res.sendStatus(200);
-    } catch (err: any) {
-      console.error('[LocalWebhook] Error:', err?.message ?? err);
+    } catch (err: unknown) {
+      console.error('[LocalWebhook] Error:', err instanceof Error ? err.message : String(err));
       res.sendStatus(500);
     }
   });

--- a/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
@@ -6,6 +6,12 @@ import { getChannelsForRepo } from '../services/webhook-routes';
 import { isDigestCommit, handleDigestCommit } from '../services/digest-webhook';
 import { syncTaskStatusOnPrMerge } from '../services/task-status-sync';
 
+interface GitHubCommit {
+  id: string;
+  url: string;
+  message: string;
+}
+
 export function createGithubWebhookApp(client: Client, gameData: GameDataService) {
   const app = express();
   app.use(express.json());
@@ -91,7 +97,7 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
 
         // TASK-YB-004 — dev-digest commit 감지: chore(digests): + digests/*.md added.
         // 해당 commit 발견 시 Yawn AI 가공 후 별도 embed 전송 + regular embed skip.
-        const digestCommit = payload.commits.find((c: any) => isDigestCommit(c));
+        const digestCommit = payload.commits.find((c: GitHubCommit) => isDigestCommit(c));
         if (digestCommit) {
           res.sendStatus(200);
           // async 이므로 res 먼저 보내고 AI 처리 (최대 수 초 소요)
@@ -102,14 +108,14 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
         embed.setTitle(gameData.getMessage('Webhook_Push_Title', payload.commits.length));
         const desc = payload.commits
           .slice(0, 5)
-          .map((c: any) => `- [\`${c.id.slice(0, 7)}\`](${c.url}) ${c.message}`)
+          .map((c: GitHubCommit) => `- [\`${c.id.slice(0, 7)}\`](${c.url}) ${c.message}`)
           .join('\n');
         embed.setDescription(desc);
 
         // TASK-WM-093 Phase F — claude-audit auto-fix push 시각 분리.
         // 모든 commit 의 subject 첫 줄이 `chore(audit-fix):` prefix 면 회색 (자동 배경 작업 톤).
         // 사람 손 push (default 초록 0x4caf50) 과 자동 fix push 디스코드 채널에서 즉시 구분.
-        const isAuditFixPush = payload.commits.every((c: any) => {
+        const isAuditFixPush = payload.commits.every((c: GitHubCommit) => {
           const firstLine = String(c.message ?? '').split('\n', 1)[0];
           return firstLine.startsWith('chore(audit-fix):');
         });
@@ -181,15 +187,15 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
       for (const channelId of channelIds) {
         const channel = await client.channels.fetch(channelId).catch(() => null);
         if (channel?.isSendable()) {
-          await channel.send({ embeds: [embed] }).catch((e: any) =>
-            console.error('[Webhook] 채널 전송 실패:', channelId, e?.message ?? e),
+          await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+            console.error('[Webhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
           );
         }
       }
 
       res.sendStatus(200);
-    } catch (err: any) {
-      console.error('[Webhook] Error:', err?.message ?? err);
+    } catch (err: unknown) {
+      console.error('[Webhook] Error:', err instanceof Error ? err.message : String(err));
       res.sendStatus(500);
     }
   });

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -178,8 +178,8 @@ try {
   if (generativeText) {
     console.log(`[Gemini] AI 초기화 완료 (surface=${generativeText.surface})`);
   }
-} catch (e: any) {
-  console.warn('[Gemini] 초기화 실패 (선택 기능):', e?.message ?? e);
+} catch (e: unknown) {
+  console.warn('[Gemini] 초기화 실패 (선택 기능):', e instanceof Error ? e.message : String(e));
 }
 
 function buildCtx() {
@@ -424,10 +424,10 @@ client.once('clientReady', async () => {
         console.log(
           `[ChannelProvision] ${guild.name}: 카테고리「${effectiveCategoryName(spec)}」/ 생성 ${r.created.length} · claim ${r.claimed.length} · 재사용 ${r.reused.length}`,
         );
-      } catch (e: any) {
+      } catch (e: unknown) {
         console.error(
           `[ChannelProvision] ${guild.name}(${guild.id}) reconcile 실패 — env 폴백:`,
-          e?.message ?? e,
+          e instanceof Error ? e.message : String(e),
         );
       }
     }
@@ -480,7 +480,7 @@ client.once('clientReady', async () => {
     if (channel && channel.isTextBased()) {
       const version = process.env.npm_package_version || '1.0.0';
       const greeting = gameData.getMessage('Server_Startup_Greeting', version);
-      await channel.send(greeting).catch((e: any) => console.error('[Startup] 인사 메시지 전송 실패:', e?.message ?? e));
+      await channel.send(greeting).catch((e: unknown) => console.error('[Startup] 인사 메시지 전송 실패:', e instanceof Error ? e.message : String(e)));
     }
   }
 
@@ -662,8 +662,8 @@ client.once('clientReady', async () => {
           console.error('[CoreSpeak] bus publish 실패', busErr instanceof Error ? busErr.message : busErr);
         }
         return true;
-      } catch (e: any) {
-        console.error('[CoreSpeak]', e?.message ?? e);
+      } catch (e: unknown) {
+        console.error('[CoreSpeak]', e instanceof Error ? e.message : String(e));
         return false;
       }
     });
@@ -707,8 +707,8 @@ client.once('clientReady', async () => {
         }
         const m = await ch.send(payload);
         return m.id;
-      } catch (e: any) {
-        console.error('[Dashboard]', e?.message ?? e);
+      } catch (e: unknown) {
+        console.error('[Dashboard]', e instanceof Error ? e.message : String(e));
         return null;
       }
     });
@@ -726,8 +726,8 @@ client.once('clientReady', async () => {
             if (!(ch instanceof TextChannel)) return null;
             const m = await ch.send({ content: content.slice(0, 1900) });
             return m.id;
-          } catch (e: any) {
-            console.error('[StatusBoard send]', e?.message ?? e);
+          } catch (e: unknown) {
+            console.error('[StatusBoard send]', e instanceof Error ? e.message : String(e));
             return null;
           }
         },
@@ -885,8 +885,9 @@ async function main() {
 
   try {
     await client.login(token);
-  } catch (e: any) {
-    if (e?.code === 'TokenInvalid') {
+  } catch (e: unknown) {
+    const code = typeof e === 'object' && e !== null && 'code' in e ? (e as { code: unknown }).code : undefined;
+    if (code === 'TokenInvalid') {
       console.error(
         '[YawnBot] TokenInvalid — 토큰이 만료되었거나 잘못되었습니다. Discord Developer Portal에서 Bot Token을 재발급하고 .env 의 DISCORD_TOKEN을 갱신하세요.',
       );

--- a/apps/discord-bots/apps/yawnbot/src/services/channel-provision.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/channel-provision.ts
@@ -117,8 +117,8 @@ export function getChannelSpec(): ChannelSpec {
         )
       : [];
     specCache = { categoryName: String(raw.categoryName ?? '욘봇'), channels };
-  } catch (e: any) {
-    console.warn(`[ChannelProvision] ${SPEC_PATH} 로드 실패 — 프로비저닝 비활성:`, e?.message ?? e);
+  } catch (e: unknown) {
+    console.warn(`[ChannelProvision] ${SPEC_PATH} 로드 실패 — 프로비저닝 비활성:`, e instanceof Error ? e.message : String(e));
     specCache = { categoryName: '욘봇', channels: [] };
   }
   return specCache;

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
@@ -107,10 +107,10 @@ export async function handleDigestCommit(
     let rawBody = '';
     try {
       rawBody = await fetchRepoFile(repoFullName, sha, digestFile);
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error(
         `[DigestWebhook] digest 본문 fetch 실패 (${repoFullName}@${sha.slice(0, 7)}/${digestFile}):`,
-        e?.message ?? e,
+        e instanceof Error ? e.message : String(e),
       );
       return;
     }
@@ -135,8 +135,8 @@ export async function handleDigestCommit(
         tag: 'yawnbot/digest',
       });
       yawnResponse = text.trim();
-    } catch (e: any) {
-      console.error('[DigestWebhook] AI 가공 실패:', e?.message ?? e);
+    } catch (e: unknown) {
+      console.error('[DigestWebhook] AI 가공 실패:', e instanceof Error ? e.message : String(e));
       // fallback: 원본 첫 500자 그대로
       yawnResponse = body.slice(0, 500) + (body.length > 500 ? '\n…' : '');
     }
@@ -162,15 +162,15 @@ export async function handleDigestCommit(
     for (const channelId of targetChannels) {
       const channel = await client.channels.fetch(channelId).catch(() => null);
       if (channel?.isSendable()) {
-        await channel.send({ embeds: [embed] }).catch((e: any) =>
-          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e?.message ?? e),
+        await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
         );
       }
     }
 
     console.log(`[DigestWebhook] ${dateLabel} digest 전송 완료 (${targetChannels.length} 채널)`);
-  } catch (e: any) {
-    console.error('[DigestWebhook] handleDigestCommit 예외:', e?.message ?? e);
+  } catch (e: unknown) {
+    console.error('[DigestWebhook] handleDigestCommit 예외:', e instanceof Error ? e.message : String(e));
   }
 }
 

--- a/apps/discord-bots/apps/yawnbot/src/services/notifiers/unity-free.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/notifiers/unity-free.ts
@@ -265,9 +265,10 @@ async function pollOnce(client: Client, channelId: string, force: boolean): Prom
   let info: PublisherSaleAssetInfo | null;
   try {
     info = await fetchPublisherSaleAssetInfo();
-  } catch (err: any) {
-    console.error('[UnityFree] Unity 페이지 요청/파싱 실패:', err?.message ?? err);
-    return { status: 'fetch_failed', info: null, error: String(err?.message ?? err) };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[UnityFree] Unity 페이지 요청/파싱 실패:', msg);
+    return { status: 'fetch_failed', info: null, error: msg };
   }
 
   if (!info) {

--- a/apps/discord-bots/apps/yawnbot/src/services/webhook-routes.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/webhook-routes.ts
@@ -60,8 +60,8 @@ function load(): WebhookRoutes {
         ? parsed.localDefault.filter((s) => typeof s === 'string')
         : [],
     };
-  } catch (e: any) {
-    console.warn(`[WebhookRoutes] ${ROUTES_PATH} 로드 실패 — 빈 라우팅으로 시작:`, e?.message ?? e);
+  } catch (e: unknown) {
+    console.warn(`[WebhookRoutes] ${ROUTES_PATH} 로드 실패 — 빈 라우팅으로 시작:`, e instanceof Error ? e.message : String(e));
     cached = { default: [], routes: {}, localRoutes: {}, localDefault: [] };
   }
   return cached;

--- a/apps/karmolab-tauri/src-tauri/src/quest_index.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_index.rs
@@ -277,7 +277,7 @@ pub async fn get_quest_tree(memo_path: Option<String>) -> Result<QuestTree, Stri
         .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
 }
 
-fn get_quest_tree_blocking(memo_path: Option<String>) -> Result<QuestTree, String> {
+pub(crate) fn get_quest_tree_blocking(memo_path: Option<String>) -> Result<QuestTree, String> {
     let memo = match memo_path.filter(|s| !s.is_empty()) {
         Some(value) => PathBuf::from(value),
         None => default_memo_path().ok_or_else(|| {


### PR DESCRIPTION
## Summary

**TASK-KL-083**: `webhook.ts`에 `GitHubCommit { id, url, message }` interface 선언, `payload.commits` 3개 콜백(`find`/`map`/`every`)의 `(c: any)` → `(c: GitHubCommit)` 교체

**TASK-KL-086**: `catch (e: any)` / `.catch((e: any) => ...)` → `unknown` 전환 (7개 파일)
- `main.ts`: 7곳 (TokenInvalid code guard 포함)
- `digest-webhook.ts`: 4곳
- `bot/webhook.ts`: 2곳
- `bot/local-webhook.ts`: 2곳
- `services/webhook-routes.ts`: 1곳
- `services/channel-provision.ts`: 1곳
- `services/notifiers/unity-free.ts`: 1곳

모든 `e?.message ?? e` → `e instanceof Error ? e.message : String(e)` 패턴 적용.

## Test plan

- [ ] `cd apps/discord-bots && npm run typecheck` 통과
- [ ] `npm run verify` 통과 (CI)

TASK-KL-083, TASK-KL-086 / cloud-kl autopilot 2026-05-27

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdUFFQamJdb7Bindq16QWF)_