### PR TITLE
fix(kl-084+kl-085): Tauri commands async + spawn_blocking 전환

### DIFF
--- a/apps/karmolab-tauri/src-tauri/src/quest_index.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_index.rs
@@ -277,7 +277,7 @@ pub async fn get_quest_tree(memo_path: Option<String>) -> Result<QuestTree, Stri
         .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
 }
 
-fn get_quest_tree_blocking(memo_path: Option<String>) -> Result<QuestTree, String> {
+pub(crate) fn get_quest_tree_blocking(memo_path: Option<String>) -> Result<QuestTree, String> {
     let memo = match memo_path.filter(|s| !s.is_empty()) {
         Some(value) => PathBuf::from(value),
         None => default_memo_path().ok_or_else(|| {

--- a/apps/karmolab-tauri/src-tauri/src/quest_launcher.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_launcher.rs
@@ -123,7 +123,17 @@ fn normalize_title_for_filename(title: &str) -> String {
 /// 위젯에서 "+ 새 TASK" → 다음 ID 자동 발급 + frontmatter skeleton 생성.
 /// 반환: 생성된 파일 절대 경로 (위젯이 즉시 open_task_in_editor 호출).
 #[tauri::command]
-pub fn create_task(
+pub async fn create_task(
+    domain: String,
+    title: String,
+    memo_path: Option<String>,
+) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || create_task_blocking(domain, title, memo_path))
+        .await
+        .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
+}
+
+fn create_task_blocking(
     domain: String,
     title: String,
     memo_path: Option<String>,

--- a/apps/karmolab-tauri/src-tauri/src/terminal.rs
+++ b/apps/karmolab-tauri/src-tauri/src/terminal.rs
@@ -21,7 +21,7 @@
 use serde::Serialize;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{ChildStdin, Command, Stdio};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use tauri::{AppHandle, Emitter, State};
 
@@ -41,9 +41,15 @@ fn apply_no_window(cmd: &mut Command) {
     let _ = cmd;
 }
 
-#[derive(Default)]
 pub struct TerminalState {
-    inner: Mutex<TerminalInner>,
+    /// Arc 래핑 = KL-084 spawn_blocking 클로저로 옮기기 위함 (State 는 non-'static).
+    inner: Arc<Mutex<TerminalInner>>,
+}
+
+impl Default for TerminalState {
+    fn default() -> Self {
+        Self { inner: Arc::new(Mutex::new(TerminalInner::default())) }
+    }
 }
 
 #[derive(Default)]
@@ -127,12 +133,22 @@ fn initial_cwd() -> String {
 }
 
 #[tauri::command]
-pub fn terminal_start(
+pub async fn terminal_start(
     app: AppHandle,
     state: State<'_, TerminalState>,
 ) -> Result<TerminalStartResult, String> {
-    let mut inner = state.inner.lock().map_err(|e| format!("state lock 실패: {}", e))?;
-    if inner.child_id.is_some() {
+    let inner = Arc::clone(&state.inner);
+    tauri::async_runtime::spawn_blocking(move || terminal_start_blocking(app, inner))
+        .await
+        .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
+}
+
+fn terminal_start_blocking(
+    app: AppHandle,
+    inner: Arc<Mutex<TerminalInner>>,
+) -> Result<TerminalStartResult, String> {
+    let mut guard = inner.lock().map_err(|e| format!("state lock 실패: {}", e))?;
+    if guard.child_id.is_some() {
         return Ok(TerminalStartResult {
             running: true,
             cwd: initial_cwd(),
@@ -170,8 +186,8 @@ pub fn terminal_start(
         .take()
         .ok_or_else(|| "stderr pipe 없음".to_string())?;
 
-    inner.stdin = Some(stdin_handle);
-    inner.child_id = Some(pid);
+    guard.stdin = Some(stdin_handle);
+    guard.child_id = Some(pid);
 
     spawn_reader(stdout, app.clone(), "stdout");
     spawn_reader(stderr, app.clone(), "stderr");
@@ -184,7 +200,7 @@ pub fn terminal_start(
     });
 
     // 시작 직후 cwd 마커 한 번 — 위젯이 표시할 cwd 보장.
-    if let Some(stdin_handle) = inner.stdin.as_mut() {
+    if let Some(stdin_handle) = guard.stdin.as_mut() {
         let _ = writeln!(
             stdin_handle,
             "Write-Host \"{}$((Get-Location).Path)\"",


### PR DESCRIPTION
## Summary

**TASK-KL-084**: `terminal_start` — 외부 프로세스 spawn sync → async + spawn_blocking
- `TerminalState.inner`: `Mutex<>` → `Arc<Mutex<>>` (KL-043/077 패턴 정합)
- `pub fn terminal_start` → `pub async fn terminal_start + spawn_blocking`
- `terminal_start_blocking(app, Arc<Mutex<TerminalInner>>)` 분리

**TASK-KL-085**: `create_task` — fs IO 다중 sync → async + spawn_blocking
- `pub fn create_task` → `pub async fn create_task + spawn_blocking`
- `create_task_blocking(domain, title, memo_path)` 분리

## Test plan

- [ ] `cargo check` (cloud 환경 GTK 미설치 → CI 검증)
- [ ] KarmoLab Tauri CI verify 통과

TASK-KL-084, TASK-KL-085 / cloud-kl autopilot 2026-05-27

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdUFFQamJdb7Bindq16QWF)_