### PR TITLE
feat(servermonitor): agent-orchestrator devProfile 등록 [TASK-KL-080]

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -57,8 +57,8 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            apps/karmolab-tauri/src-tauri/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('apps/karmolab-tauri/src-tauri/Cargo.lock') }}
+            apps/karmolab-tauri/target
+          key: cargo-${{ runner.os }}-${{ hashFiles('apps/karmolab-tauri/Cargo.lock') }}
           restore-keys: cargo-${{ runner.os }}-
 
       - name: Install karmolab deps

--- a/apps/discord-bots/package.json
+++ b/apps/discord-bots/package.json
@@ -16,6 +16,7 @@
     "webhook:upsert": "npm -w apps/yawnbot run webhook:upsert",
     "start": "npm -w apps/yawnbot run start",
     "start:yawnbot": "npm -w apps/yawnbot run start",
+    "start:orchestrator": "npm -w apps/agent-orchestrator run start",
     "deploy": "npm -w apps/yawnbot run deploy",
     "deploy:yawnbot": "npm -w apps/yawnbot run deploy",
     "audit:cron": "node scripts/audit-cron-traceability.mjs"

--- a/apps/karmolab-tauri/src-tauri/src/quest_index.rs
+++ b/apps/karmolab-tauri/src-tauri/src/quest_index.rs
@@ -277,7 +277,7 @@ pub async fn get_quest_tree(memo_path: Option<String>) -> Result<QuestTree, Stri
         .map_err(|e| format!("spawn_blocking join 실패: {}", e))?
 }
 
-fn get_quest_tree_blocking(memo_path: Option<String>) -> Result<QuestTree, String> {
+pub(crate) fn get_quest_tree_blocking(memo_path: Option<String>) -> Result<QuestTree, String> {
     let memo = match memo_path.filter(|s| !s.is_empty()) {
         Some(value) => PathBuf::from(value),
         None => default_memo_path().ok_or_else(|| {

--- a/apps/karmolab/data/servermonitor-config.json
+++ b/apps/karmolab/data/servermonitor-config.json
@@ -90,6 +90,14 @@
             "script": "dev",
             "healthUrl": "http://127.0.0.1:5173/",
             "npmInstall": true
+        },
+        {
+            "id": "agent-orchestrator",
+            "label": "Agent Orchestrator",
+            "app": "apps/discord-bots",
+            "script": "start:orchestrator",
+            "deployScript": "build:orchestrator",
+            "npmInstall": true
         }
     ]
 }


### PR DESCRIPTION
## TASK-KL-080: agent-orchestrator devProfile 등록

### 변경 내용

1. `apps/discord-bots/package.json` — `start:orchestrator` 스크립트 추가
2. `apps/karmolab/data/servermonitor-config.json` — `agent-orchestrator` devProfile 등록 (npm-script 형식, `npmInstall: true`)

### 수반된 버그 픽스 (CI 원인 조사 중 발견)

3. `apps/karmolab-tauri/src-tauri/src/quest_index.rs` — `get_quest_tree_blocking` → `pub(crate)` (cockpit_graph.rs 에서 호출하나 private 함수 — cargo check 실패 원인)
4. `.github/workflows/verify.yml` — Cargo 캐시 key/path 수정:
   - `apps/karmolab-tauri/src-tauri/Cargo.lock` (존재 X) → `apps/karmolab-tauri/Cargo.lock` (workspace root)
   - `apps/karmolab-tauri/src-tauri/target` (잘못된 경로) → `apps/karmolab-tauri/target`

### 완료 조건 체크

- [x] servermonitor-config-audit 통과
- [x] cargo check 통과 (로컬 verify 통과)
- [x] npm run verify 통과 (로컬)
- [ ] CI verify (master invariant) 통과 ← 대기 중