### PR TITLE
fix(yawnbot): KL-088+089 catch/as-any 3차 + cursor-local proper typing

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/cursor-local.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/cursor-local.ts
@@ -1,5 +1,5 @@
 import { spawn, execFile } from 'child_process';
-import type { ChatInputCommandInteraction, StringSelectMenuInteraction } from 'discord.js';
+import type { ChatInputCommandInteraction, Message, StringSelectMenuInteraction } from 'discord.js';
 import { ActionRowBuilder, EmbedBuilder, MessageFlags, StringSelectMenuBuilder } from 'discord.js';
 import { cursorRunnerScript, resolveCursorRepoDir } from '../paths';
 import { truncateDiscordDescription } from '@discord-bots/common';
@@ -21,33 +21,34 @@ export async function discordAnswerCursorQuestion(
     if (typeof o === 'string') {
       return { label: o.slice(0, 100), value: String(i) };
     }
-    const label = String((o as any).label ?? (o as any).title ?? (o as any).text ?? `선택 ${i + 1}`).slice(0, 100);
-    const out: any = { label, value: String(i) };
-    if ((o as any).description != null) out.description = String((o as any).description).slice(0, 100);
+    const r = o as Record<string, unknown>;
+    const label = String(r.label ?? r.title ?? r.text ?? `선택 ${i + 1}`).slice(0, 100);
+    const out: { label: string; value: string; description?: string } = { label, value: String(i) };
+    if (r.description != null) out.description = String(r.description).slice(0, 100);
     return out;
   });
   if (selectOptions.length === 0) {
     return { cancelled: true };
   }
-  const heading = (params as any).title || (params as any).question || '에이전트 질문';
+  const heading = params.title || params.question || '에이전트 질문';
   const embed = new EmbedBuilder().setTitle('에이전트 질문').setDescription(truncateDiscordDescription(String(heading))).setColor(0x5865f2);
   const customId = `cursor_q_${String(payload.rpcId)}`;
-  const menu = new StringSelectMenuBuilder().setCustomId(customId).setPlaceholder('답을 선택하세요').addOptions(selectOptions as any);
-  const row = new ActionRowBuilder().addComponents(menu as any);
-  const reply: any = await (interaction as any).followUp({
+  const menu = new StringSelectMenuBuilder().setCustomId(customId).setPlaceholder('답을 선택하세요').addOptions(selectOptions);
+  const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+  const reply = await interaction.followUp({
     embeds: [embed],
     components: [row],
     flags: MessageFlags.Ephemeral,
     fetchReply: true,
-  });
+  }) as Message<boolean>;
   const uid = interaction.user.id;
   try {
     const comp = (await reply.awaitMessageComponent({
-      filter: (i: any): i is StringSelectMenuInteraction => i.user.id === uid && i.customId === customId,
+      filter: (i: StringSelectMenuInteraction): i is StringSelectMenuInteraction => i.user.id === uid && i.customId === customId,
       time: 600_000,
     })) as StringSelectMenuInteraction;
-    const idx = parseInt((comp as any).values[0], 10);
-    await (comp as any).update({ components: [] });
+    const idx = parseInt(comp.values[0], 10);
+    await comp.update({ components: [] });
     return { selectedIndex: idx };
   } catch {
     try {

--- a/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
@@ -187,15 +187,15 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
       for (const channelId of channelIds) {
         const channel = await client.channels.fetch(channelId).catch(() => null);
         if (channel?.isSendable()) {
-          await channel.send({ embeds: [embed] }).catch((e: any) =>
-            console.error('[Webhook] 채널 전송 실패:', channelId, e?.message ?? e),
+          await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+            console.error('[Webhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
           );
         }
       }
 
       res.sendStatus(200);
-    } catch (err: any) {
-      console.error('[Webhook] Error:', err?.message ?? err);
+    } catch (err: unknown) {
+      console.error('[Webhook] Error:', err instanceof Error ? err.message : String(err));
       res.sendStatus(500);
     }
   });

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -55,6 +55,7 @@ import { checkMemoPushScope } from './services/memo-push';
 import { setProposalAnnouncer } from './bot/proposal-adapter';
 import { announceProposal, reconcileProposalCards } from './bot/agent-bus';
 import type { ClientLike } from './bot/forum-post';
+import type { RecoveryClientLike } from './bot/forum-tag-recovery';
 import {
   loadCoreDef,
   listCoreIds,
@@ -179,8 +180,8 @@ try {
   if (generativeText) {
     console.log(`[Gemini] AI 초기화 완료 (surface=${generativeText.surface})`);
   }
-} catch (e: any) {
-  console.warn('[Gemini] 초기화 실패 (선택 기능):', e?.message ?? e);
+} catch (e: unknown) {
+  console.warn('[Gemini] 초기화 실패 (선택 기능):', e instanceof Error ? e.message : String(e));
 }
 
 function buildCtx() {
@@ -425,10 +426,10 @@ client.once('clientReady', async () => {
         console.log(
           `[ChannelProvision] ${guild.name}: 카테고리「${effectiveCategoryName(spec)}」/ 생성 ${r.created.length} · claim ${r.claimed.length} · 재사용 ${r.reused.length}`,
         );
-      } catch (e: any) {
+      } catch (e: unknown) {
         console.error(
           `[ChannelProvision] ${guild.name}(${guild.id}) reconcile 실패 — env 폴백:`,
-          e?.message ?? e,
+          e instanceof Error ? e.message : String(e),
         );
       }
     }
@@ -452,7 +453,7 @@ client.once('clientReady', async () => {
   // 기존 포스트의 appliedTags 가 stale ID 참조 → 태그 소실. 1회 전수 점검·복원.
   try {
     const { recoverForumTagsOnce } = await import('./bot/forum-tag-recovery.js');
-    await recoverForumTagsOnce(client as any, process.env);
+    await recoverForumTagsOnce(client as unknown as RecoveryClientLike, process.env);
   } catch (e) {
     console.error(
       '[ForumTagRecovery] 부팅 태그 복원 실패:',
@@ -481,14 +482,14 @@ client.once('clientReady', async () => {
   // 수단·수동: node memo/scripts/forum-dedupe.mjs). 부팅 1회 + 주기(기본 60분).
   try {
     const { auditForumDupsOnce } = await import('./bot/forum-dedup.js');
-    await auditForumDupsOnce(client as any, process.env);
+    await auditForumDupsOnce(client, process.env);
     const dedupMin = parseInt(
       process.env.YAWNBOT_FORUM_DEDUP_INTERVAL_MIN || '60',
       10,
     );
     const dedupTimer = setInterval(() => {
       void import('./bot/forum-dedup.js')
-        .then(({ auditForumDupsOnce: tick }) => tick(client as any, process.env))
+        .then(({ auditForumDupsOnce: tick }) => tick(client, process.env))
         .catch((err) =>
           console.error(
             '[ForumDedup] tick 실패:',
@@ -507,7 +508,7 @@ client.once('clientReady', async () => {
     if (channel && channel.isTextBased()) {
       const version = process.env.npm_package_version || '1.0.0';
       const greeting = gameData.getMessage('Server_Startup_Greeting', version);
-      await channel.send(greeting).catch((e: any) => console.error('[Startup] 인사 메시지 전송 실패:', e?.message ?? e));
+      await channel.send(greeting).catch((e: unknown) => console.error('[Startup] 인사 메시지 전송 실패:', e instanceof Error ? e.message : String(e)));
     }
   }
 
@@ -689,8 +690,8 @@ client.once('clientReady', async () => {
           console.error('[CoreSpeak] bus publish 실패', busErr instanceof Error ? busErr.message : busErr);
         }
         return true;
-      } catch (e: any) {
-        console.error('[CoreSpeak]', e?.message ?? e);
+      } catch (e: unknown) {
+        console.error('[CoreSpeak]', e instanceof Error ? e.message : String(e));
         return false;
       }
     });
@@ -734,8 +735,8 @@ client.once('clientReady', async () => {
         }
         const m = await ch.send(payload);
         return m.id;
-      } catch (e: any) {
-        console.error('[Dashboard]', e?.message ?? e);
+      } catch (e: unknown) {
+        console.error('[Dashboard]', e instanceof Error ? e.message : String(e));
         return null;
       }
     });
@@ -753,8 +754,8 @@ client.once('clientReady', async () => {
             if (!(ch instanceof TextChannel)) return null;
             const m = await ch.send({ content: content.slice(0, 1900) });
             return m.id;
-          } catch (e: any) {
-            console.error('[StatusBoard send]', e?.message ?? e);
+          } catch (e: unknown) {
+            console.error('[StatusBoard send]', e instanceof Error ? e.message : String(e));
             return null;
           }
         },
@@ -912,8 +913,8 @@ async function main() {
 
   try {
     await client.login(token);
-  } catch (e: any) {
-    if (e?.code === 'TokenInvalid') {
+  } catch (e: unknown) {
+    if (e !== null && typeof e === 'object' && 'code' in e && (e as { code: unknown }).code === 'TokenInvalid') {
       console.error(
         '[YawnBot] TokenInvalid — 토큰이 만료되었거나 잘못되었습니다. Discord Developer Portal에서 Bot Token을 재발급하고 .env 의 DISCORD_TOKEN을 갱신하세요.',
       );

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
@@ -107,10 +107,10 @@ export async function handleDigestCommit(
     let rawBody = '';
     try {
       rawBody = await fetchRepoFile(repoFullName, sha, digestFile);
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error(
         `[DigestWebhook] digest 본문 fetch 실패 (${repoFullName}@${sha.slice(0, 7)}/${digestFile}):`,
-        e?.message ?? e,
+        e instanceof Error ? e.message : String(e),
       );
       return;
     }
@@ -135,8 +135,8 @@ export async function handleDigestCommit(
         tag: 'yawnbot/digest',
       });
       yawnResponse = text.trim();
-    } catch (e: any) {
-      console.error('[DigestWebhook] AI 가공 실패:', e?.message ?? e);
+    } catch (e: unknown) {
+      console.error('[DigestWebhook] AI 가공 실패:', e instanceof Error ? e.message : String(e));
       // fallback: 원본 첫 500자 그대로
       yawnResponse = body.slice(0, 500) + (body.length > 500 ? '\n…' : '');
     }
@@ -162,15 +162,15 @@ export async function handleDigestCommit(
     for (const channelId of targetChannels) {
       const channel = await client.channels.fetch(channelId).catch(() => null);
       if (channel?.isSendable()) {
-        await channel.send({ embeds: [embed] }).catch((e: any) =>
-          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e?.message ?? e),
+        await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
         );
       }
     }
 
     console.log(`[DigestWebhook] ${dateLabel} digest 전송 완료 (${targetChannels.length} 채널)`);
-  } catch (e: any) {
-    console.error('[DigestWebhook] handleDigestCommit 예외:', e?.message ?? e);
+  } catch (e: unknown) {
+    console.error('[DigestWebhook] handleDigestCommit 예외:', e instanceof Error ? e.message : String(e));
   }
 }
 


### PR DESCRIPTION
## TASK-KL-088: catch (e: any) 3차 잔존 제거

KAR-150 신규 기능 커밋(forum-post/forum-dedup 등)이 KL-086(#156)/KL-087(#157) 이후 `catch (e: any)` 패턴을 재도입 — 13곳 → `unknown` + `instanceof Error` guard.

| 파일 | 위치 | 변경 |
|---|---|---|
| `main.ts` | L182 | Gemini 초기화 catch |
| `main.ts` | L428 | ChannelProvision reconcile catch |
| `main.ts` | L510 | Startup 인사 .catch |
| `main.ts` | L692 | CoreSpeak catch |
| `main.ts` | L737 | Dashboard catch |
| `main.ts` | L756 | StatusBoard send catch |
| `main.ts` | L915 | TokenInvalid catch (+ `e?.code` → `typeof e === 'object' && 'code' in e` guard) |
| `digest-webhook.ts` | L110 | fetch 실패 catch |
| `digest-webhook.ts` | L138 | AI 가공 실패 catch |
| `digest-webhook.ts` | L165 | 채널 전송 .catch |
| `digest-webhook.ts` | L172 | handleDigestCommit catch |
| `webhook.ts` | L190 | 채널 전송 .catch |
| `webhook.ts` | L197 | router catch |

## TASK-KL-089: cursor-local.ts as any + main.ts client as any

| 파일 | 위치 | 변경 |
|---|---|---|
| `cursor-local.ts` | L24/26 | `(o as any).X` → `(o as Record<string,unknown>).X` |
| `cursor-local.ts` | L25 | `const out: any` → `{ label: string; value: string; description?: string }` |
| `cursor-local.ts` | L32 | `(params as any).title` → `params.title` (`Record<string,unknown>` 직접) |
| `cursor-local.ts` | L35 | `selectOptions as any` → 제거 (타입 호환) |
| `cursor-local.ts` | L36 | `ActionRowBuilder()` → `ActionRowBuilder<StringSelectMenuBuilder>()`, `menu as any` 제거 |
| `cursor-local.ts` | L37 | `const reply: any = await (interaction as any).followUp` → 타입 추론 + `as Message<boolean>` |
| `cursor-local.ts` | L49/50 | `(comp as any).values[0]` / `.update()` → `comp.values[0]` / `comp.update()` |
| `main.ts` | L455 | `recoverForumTagsOnce(client as any)` → `as unknown as RecoveryClientLike` |
| `main.ts` | L484/491 | `auditForumDupsOnce(client as any)` → `client` 직접 (파라미터 `any` 직접 호환) |

## Test plan

- [ ] `cd apps/discord-bots && npm run typecheck` 0 errors
- [ ] CI `verify (master invariant)` 통과

TASK-KL-088, TASK-KL-089 / cloud-kl autopilot 2026-05-30

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsDExwtKqtavAKKgiJgSGP)_