### PR TITLE
chore(KL-090): yawnbot 테스트 as any 47건 정리

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/agent-daemon.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/agent-daemon.test.ts
@@ -35,7 +35,7 @@ function fakeLLM(resp: string | (() => string)): GenerativeTextClient {
     async generateFromPrompt(): Promise<string> {
       return typeof resp === 'function' ? resp() : resp;
     },
-  } as any;
+  } as unknown as GenerativeTextClient;
 }
 
 async function freshRoots(label: string): Promise<{ bus: string; memo: string }> {
@@ -416,7 +416,7 @@ describe('decideUtterance (LLM prompt 구성)', () => {
       async generateFromPrompt(): Promise<string> {
         throw new Error('quota exceeded');
       },
-    } as any;
+    } as unknown as GenerativeTextClient;
     const r = await decideUtterance(llm, core, [], {
       ts: new Date().toISOString(),
       type: 'channel-msg',

--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-thread-router.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-thread-router.test.ts
@@ -2,7 +2,7 @@
 // + TASK-KAR-018-THR: 재기동-중복 root fix (이름검색 dedup) ·
 //   proposal-id(pXXX) thread key · findThreadByName 분기.
 import { describe, it, expect } from 'vitest';
-import { ChannelType } from 'discord.js';
+import { ChannelType, type Client } from 'discord.js';
 import {
   extractTaskId,
   chunkForDiscord,
@@ -123,7 +123,7 @@ describe('makeThreadRouter 재기동-중복 root fix (TASK-KAR-018-THR)', () => 
     const sends: string[] = [];
     const threadSends: Record<string, string[]> = {};
     let seq = 0;
-    const channel: any = {
+    const channel = {
       type: ChannelType.GuildText,
       threads: {
         create: async ({ name }: { name: string }) => {
@@ -143,7 +143,7 @@ describe('makeThreadRouter 재기동-중복 root fix (TASK-KAR-018-THR)', () => 
         sends.push(m);
       },
     };
-    const client: any = {
+    const client = {
       channels: {
         fetch: async (id: string) => {
           if (id === 'CH') return channel;
@@ -157,7 +157,7 @@ describe('makeThreadRouter 재기동-중복 root fix (TASK-KAR-018-THR)', () => 
           };
         },
       },
-    };
+    } as unknown as Client;
     return { client, created, sends, threadSends };
   }
 
@@ -206,7 +206,7 @@ describe('makeThreadRouter 재기동-중복 root fix (TASK-KAR-018-THR)', () => 
 describe('onMissingTask: silent — 사용자 정신없음 fix (2026-05-23)', () => {
   function makeFakeClient() {
     const sends: string[] = [];
-    const channel: any = {
+    const channel = {
       type: ChannelType.GuildText,
       threads: {
         create: async () => ({ id: 'should-not-create' }),
@@ -221,11 +221,11 @@ describe('onMissingTask: silent — 사용자 정신없음 fix (2026-05-23)', ()
         sends.push(m);
       },
     };
-    const client: any = {
+    const client = {
       channels: {
         fetch: async () => channel,
       },
-    };
+    } as unknown as Client;
     return { client, sends, channel };
   }
 

--- a/apps/discord-bots/apps/yawnbot/src/bot/proposal.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/proposal.test.ts
@@ -165,7 +165,8 @@ describe('parseProposalEnvelope — fence robustness (2026-05-23 prod parse-fail
     const raw = '```json\n' + JSON.stringify(tricky);
     const e = parseProposalEnvelope(raw);
     expect(e?.kind).toBe('task');
-    expect((e?.payload as any).title).toBe('has } brace');
+    if (e?.kind !== 'task') throw new Error('kind narrowing 실패');
+    expect(e.payload.title).toBe('has } brace');
   });
 
   it('JSON 자체가 깨짐 (잘린 본문) — null (날조 0)', () => {

--- a/apps/discord-bots/apps/yawnbot/src/services/agent-bus.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/agent-bus.test.ts
@@ -28,12 +28,12 @@ async function wait(ms: number): Promise<void> {
 describe('agent-bus', () => {
   describe('resolveBusRoot', () => {
     it('env override 우선', () => {
-      expect(resolveBusRoot({ LAPTOP_AGENT_BUS_ROOT: '/tmp/foo' } as any)).toBe(
-        '/tmp/foo',
-      );
+      expect(
+        resolveBusRoot({ LAPTOP_AGENT_BUS_ROOT: '/tmp/foo' } as unknown as NodeJS.ProcessEnv),
+      ).toBe('/tmp/foo');
     });
     it('default = ~/.karmoddrine/agent-bus', () => {
-      const r = resolveBusRoot({} as any);
+      const r = resolveBusRoot({} as unknown as NodeJS.ProcessEnv);
       expect(r).toContain('.karmoddrine');
       expect(r).toContain('agent-bus');
     });

--- a/apps/discord-bots/apps/yawnbot/src/services/channel-provision.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/channel-provision.test.ts
@@ -253,14 +253,22 @@ describe('reconcileGuildChannels — GuildForum (TASK-KAR-018-LT-FORUM)', () => 
 
 describe('isProvisioningEnabled — 기본 ON, =0 opt-out (prod 무관)', () => {
   it('prod 여도 기본 ON (옛 채널 폐기 — dev먼저 철회)', () => {
-    expect(isProvisioningEnabled({ YAWNBOT_ENV: 'prod' } as any)).toBe(true);
+    expect(
+      isProvisioningEnabled({ YAWNBOT_ENV: 'prod' } as unknown as NodeJS.ProcessEnv),
+    ).toBe(true);
   });
   it('dev 도 기본 ON', () => {
-    expect(isProvisioningEnabled({ YAWNBOT_ENV: 'dev' } as any)).toBe(true);
+    expect(
+      isProvisioningEnabled({ YAWNBOT_ENV: 'dev' } as unknown as NodeJS.ProcessEnv),
+    ).toBe(true);
   });
   it('YAWNBOT_CHANNEL_PROVISION=0 비상 비활성', () => {
-    expect(isProvisioningEnabled({ YAWNBOT_CHANNEL_PROVISION: '0' } as any)).toBe(false);
-    expect(isProvisioningEnabled({ YAWNBOT_CHANNEL_PROVISION: 'off' } as any)).toBe(false);
+    expect(
+      isProvisioningEnabled({ YAWNBOT_CHANNEL_PROVISION: '0' } as unknown as NodeJS.ProcessEnv),
+    ).toBe(false);
+    expect(
+      isProvisioningEnabled({ YAWNBOT_CHANNEL_PROVISION: 'off' } as unknown as NodeJS.ProcessEnv),
+    ).toBe(false);
   });
 });
 
@@ -280,7 +288,7 @@ describe('shouldProvisionGuild — 허용 길드 한정 (친구 서버 사고 �
     expect(shouldProvisionGuild('g3', env)).toBe(false);
   });
   it('둘 다 없으면 아무 길드도 프로비저닝 X (안전 default)', () => {
-    expect(shouldProvisionGuild('아무거나', {} as any)).toBe(false);
+    expect(shouldProvisionGuild('아무거나', {} as unknown as NodeJS.ProcessEnv)).toBe(false);
   });
 });
 

--- a/apps/discord-bots/apps/yawnbot/src/services/character-state-snapshot.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/character-state-snapshot.test.ts
@@ -190,8 +190,8 @@ describe('writeSnapshotOnce — Contents API GET sha → PUT', () => {
   });
 
   it('변경됨 + GET 200 → 그 sha 로 PUT, body=base64 JSON+branch', async () => {
-    const calls: Array<{ url: string; opts: any }> = [];
-    const fetchImpl = vi.fn(async (url: string, opts: any) => {
+    const calls: Array<{ url: string; opts: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string, opts: RequestInit) => {
       calls.push({ url, opts });
       if (opts.method === 'GET') return res(200, { sha: 'oldsha123' });
       return res(200, { commit: { sha: 'newsha' } });
@@ -216,8 +216,8 @@ describe('writeSnapshotOnce — Contents API GET sha → PUT', () => {
   });
 
   it('브랜치 존재 + 파일 없음(Contents 404, ref 200) → 부트스트랩 X, sha 없이 PUT', async () => {
-    const calls: Array<{ url: string; opts: any }> = [];
-    const fetchImpl = vi.fn(async (url: string, opts: any) => {
+    const calls: Array<{ url: string; opts: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string, opts: RequestInit) => {
       calls.push({ url, opts });
       if (url.includes('/git/ref/heads/')) return res(200, { ref: 'refs/heads/x' });
       if (url.includes('/contents/') && opts.method === 'GET') return res(404);
@@ -237,8 +237,8 @@ describe('writeSnapshotOnce — Contents API GET sha → PUT', () => {
   });
 
   it('브랜치 부재(Contents 404, ref 404) → orphan 부트스트랩 후 sha 없이 PUT', async () => {
-    const calls: Array<{ url: string; opts: any }> = [];
-    const fetchImpl = vi.fn(async (url: string, opts: any) => {
+    const calls: Array<{ url: string; opts: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string, opts: RequestInit) => {
       calls.push({ url, opts });
       if (url.includes('/git/ref/heads/')) return res(404);
       if (url.includes('/git/commits')) return res(201, { sha: 'orphan_commit_sha' });
@@ -280,7 +280,7 @@ describe('writeSnapshotOnce — Contents API GET sha → PUT', () => {
   });
 
   it('PUT 실패(409 sha 충돌 등) → throw', async () => {
-    const fetchImpl = vi.fn(async (_u: string, opts: any) =>
+    const fetchImpl = vi.fn(async (_u: string, opts: RequestInit) =>
       opts.method === 'GET' ? res(200, { sha: 's' }) : res(409),
     );
     await expect(
@@ -297,7 +297,7 @@ describe('writeSnapshotOnce — Contents API GET sha → PUT', () => {
 
 describe('runSnapshotTick — 상태 전이 alert + hash carry', () => {
   const okFetch = (): typeof fetch =>
-    vi.fn(async (_u: string, opts: any) =>
+    vi.fn(async (_u: string, opts: RequestInit) =>
       opts.method === 'GET' ? res(200, { sha: 's' }) : res(200),
     ) as unknown as typeof fetch;
   const failFetch = (): typeof fetch => vi.fn(async () => res(500)) as unknown as typeof fetch;
@@ -387,7 +387,7 @@ describe('startCharacterStateSnapshot — 스케줄링', () => {
   });
 
   it('즉시 1회 + interval 간격마다 tick (GET+PUT = 2 fetch/tick)', async () => {
-    const fetchImpl = vi.fn(async (_u: string, opts: any) =>
+    const fetchImpl = vi.fn(async (_u: string, opts: RequestInit) =>
       opts.method === 'GET' ? res(200, { sha: 's' }) : res(200),
     );
     const handle = startCharacterStateSnapshot({
@@ -406,7 +406,7 @@ describe('startCharacterStateSnapshot — 스케줄링', () => {
   });
 
   it('intervalMin 0 → 최소 1분 clamp', async () => {
-    const fetchImpl = vi.fn(async (_u: string, opts: any) =>
+    const fetchImpl = vi.fn(async (_u: string, opts: RequestInit) =>
       opts.method === 'GET' ? res(200, { sha: 's' }) : res(200),
     );
     startCharacterStateSnapshot({
@@ -423,7 +423,7 @@ describe('startCharacterStateSnapshot — 스케줄링', () => {
   });
 
   it('stopCharacterStateSnapshot → 이후 tick 중단', async () => {
-    const fetchImpl = vi.fn(async (_u: string, opts: any) =>
+    const fetchImpl = vi.fn(async (_u: string, opts: RequestInit) =>
       opts.method === 'GET' ? res(200, { sha: 's' }) : res(200),
     );
     startCharacterStateSnapshot({

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.test.ts
@@ -45,36 +45,36 @@ describe('isDigestCommit', () => {
 
 describe('fetchRepoFile — private memo 인증 분기 (송신0 근본 fix)', () => {
   it('토큰 있으면 GitHub API contents + Bearer + raw Accept (private OK)', async () => {
-    const calls: any[] = [];
-    vi.stubGlobal('fetch', async (url: string, opts: any) => {
+    const calls: Array<{ url: string; opts: RequestInit }> = [];
+    vi.stubGlobal('fetch', async (url: string, opts: RequestInit) => {
       calls.push({ url, opts });
-      return { ok: true, text: async () => '본문' } as any;
+      return { ok: true, text: async () => '본문' } as unknown as Response;
     });
     const body = await fetchRepoFile('mascari4615/memo', 'abc123', 'digests/2026-05-17.md', {
       MEMO_GITHUB_PAT: 'tok_x',
-    } as any);
+    } as unknown as NodeJS.ProcessEnv);
     expect(body).toBe('본문');
     expect(calls[0].url).toBe(
       'https://api.github.com/repos/mascari4615/memo/contents/digests/2026-05-17.md?ref=abc123',
     );
-    expect(calls[0].opts.headers.Authorization).toBe('Bearer tok_x');
-    expect(calls[0].opts.headers.Accept).toBe('application/vnd.github.raw');
+    expect((calls[0].opts.headers as Record<string, string>).Authorization).toBe('Bearer tok_x');
+    expect((calls[0].opts.headers as Record<string, string>).Accept).toBe('application/vnd.github.raw');
   });
 
   it('토큰 없으면 raw.githubusercontent fallback (public 호환)', async () => {
-    const calls: any[] = [];
+    const calls: string[] = [];
     vi.stubGlobal('fetch', async (url: string) => {
       calls.push(url);
-      return { ok: true, text: async () => 'pub' } as any;
+      return { ok: true, text: async () => 'pub' } as unknown as Response;
     });
-    await fetchRepoFile('mascari4615/x', 'sha1', 'a.md', {} as any);
+    await fetchRepoFile('mascari4615/x', 'sha1', 'a.md', {} as unknown as NodeJS.ProcessEnv);
     expect(calls[0]).toBe('https://raw.githubusercontent.com/mascari4615/x/sha1/a.md');
   });
 
   it('!ok = throw (caller graceful return) — private 무토큰 404 가 송신0 근본', async () => {
-    vi.stubGlobal('fetch', async () => ({ ok: false, status: 404 }) as any);
+    vi.stubGlobal('fetch', async () => ({ ok: false, status: 404 }) as unknown as Response);
     await expect(
-      fetchRepoFile('mascari4615/memo', 's', 'd.md', {} as any),
+      fetchRepoFile('mascari4615/memo', 's', 'd.md', {} as unknown as NodeJS.ProcessEnv),
     ).rejects.toThrow(/404.*토큰\(MEMO_GITHUB_PAT\) 필요/);
   });
 });

--- a/apps/discord-bots/apps/yawnbot/src/services/github-orphan-branch.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/github-orphan-branch.test.ts
@@ -32,8 +32,8 @@ function res(status: number, json?: unknown): Response {
 
 describe('ensureOrphanBranch', () => {
   it('ref 존재(200) → no-op exists, commit/refs POST 0', async () => {
-    const calls: Array<{ url: string; opts: any }> = [];
-    const fetchImpl = vi.fn(async (url: string, opts: any) => {
+    const calls: Array<{ url: string; opts: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string, opts: RequestInit) => {
       calls.push({ url, opts });
       return res(200, { ref: 'refs/heads/yawnbot-character-state' });
     });
@@ -49,8 +49,8 @@ describe('ensureOrphanBranch', () => {
   });
 
   it('ref 부재(404) → empty-tree orphan 커밋 + ref 생성 → created', async () => {
-    const calls: Array<{ url: string; opts: any }> = [];
-    const fetchImpl = vi.fn(async (url: string, opts: any) => {
+    const calls: Array<{ url: string; opts: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string, opts: RequestInit) => {
       calls.push({ url, opts });
       if (url.includes('/git/ref/heads/')) return res(404);
       if (url.includes('/git/commits')) return res(201, { sha: 'commit_abc' });

--- a/apps/discord-bots/apps/yawnbot/src/services/heartbeat.test.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/heartbeat.test.ts
@@ -38,8 +38,8 @@ function res(status: number, json?: unknown): Response {
 
 describe('writeHeartbeatOnce — Contents API GET sha → PUT', () => {
   it('기존 파일(GET 200) → 그 sha 로 PUT, body=base64 JSON+branch', async () => {
-    const calls: Array<{ url: string; opts: any }> = [];
-    const fetchImpl = vi.fn(async (url: string, opts: any) => {
+    const calls: Array<{ url: string; opts: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string, opts: RequestInit) => {
       calls.push({ url, opts });
       if (opts.method === 'GET') return res(200, { sha: 'oldsha123' });
       return res(200, { commit: { sha: 'newsha' } });
@@ -63,8 +63,8 @@ describe('writeHeartbeatOnce — Contents API GET sha → PUT', () => {
   });
 
   it('브랜치 존재 + 파일 없음(Contents 404, ref 200) → 부트스트랩 X, sha 없이 PUT', async () => {
-    const calls: Array<{ url: string; opts: any }> = [];
-    const fetchImpl = vi.fn(async (url: string, opts: any) => {
+    const calls: Array<{ url: string; opts: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string, opts: RequestInit) => {
       calls.push({ url, opts });
       if (url.includes('/git/ref/heads/')) return res(200, { ref: 'refs/heads/x' });
       if (url.includes('/contents/') && opts.method === 'GET') return res(404);
@@ -84,8 +84,8 @@ describe('writeHeartbeatOnce — Contents API GET sha → PUT', () => {
   });
 
   it('브랜치 부재(Contents 404, ref 404) → orphan 부트스트랩 후 sha 없이 PUT', async () => {
-    const calls: Array<{ url: string; opts: any }> = [];
-    const fetchImpl = vi.fn(async (url: string, opts: any) => {
+    const calls: Array<{ url: string; opts: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string, opts: RequestInit) => {
       calls.push({ url, opts });
       if (url.includes('/git/ref/heads/')) return res(404);
       if (url.includes('/git/commits')) return res(201, { sha: 'orphan_commit_sha' });
@@ -125,7 +125,7 @@ describe('writeHeartbeatOnce — Contents API GET sha → PUT', () => {
   });
 
   it('PUT 실패(409 sha 충돌 등) → throw', async () => {
-    const fetchImpl = vi.fn(async (_u: string, opts: any) =>
+    const fetchImpl = vi.fn(async (_u: string, opts: RequestInit) =>
       opts.method === 'GET' ? res(200, { sha: 's' }) : res(409),
     );
     await expect(
@@ -140,7 +140,7 @@ describe('writeHeartbeatOnce — Contents API GET sha → PUT', () => {
 
 describe('runHeartbeatTick — 상태 전이 alert', () => {
   const okFetch = () =>
-    vi.fn(async (_u: string, opts: any) =>
+    vi.fn(async (_u: string, opts: RequestInit) =>
       opts.method === 'GET' ? res(200, { sha: 's' }) : res(200),
     ) as unknown as typeof fetch;
   const failFetch = () => vi.fn(async () => res(500)) as unknown as typeof fetch;
@@ -246,7 +246,7 @@ describe('startHeartbeat — 스케줄링', () => {
   });
 
   it('즉시 1회 + interval 간격마다 tick (GET+PUT = 2 fetch/tick)', async () => {
-    const fetchImpl = vi.fn(async (_u: string, opts: any) =>
+    const fetchImpl = vi.fn(async (_u: string, opts: RequestInit) =>
       opts.method === 'GET' ? res(200, { sha: 's' }) : res(200),
     );
     const handle = startHeartbeat({
@@ -262,7 +262,7 @@ describe('startHeartbeat — 스케줄링', () => {
   });
 
   it('intervalMin 0 → 최소 1분 clamp', async () => {
-    const fetchImpl = vi.fn(async (_u: string, opts: any) =>
+    const fetchImpl = vi.fn(async (_u: string, opts: RequestInit) =>
       opts.method === 'GET' ? res(200, { sha: 's' }) : res(200),
     );
     startHeartbeat({
@@ -277,7 +277,7 @@ describe('startHeartbeat — 스케줄링', () => {
   });
 
   it('stopHeartbeat → 이후 tick 중단', async () => {
-    const fetchImpl = vi.fn(async (_u: string, opts: any) =>
+    const fetchImpl = vi.fn(async (_u: string, opts: RequestInit) =>
       opts.method === 'GET' ? res(200, { sha: 's' }) : res(200),
     );
     startHeartbeat({


### PR DESCRIPTION
## Summary

quality-loop 자동 감지(2026-05-31) 후속 — yawnbot 테스트 파일에서 발견된 `as any` / `: any` 47건을 5 패턴으로 정리. KL-089 와 분리된 테스트 전용 any.

- **fetch mock `opts: any` → `RequestInit`** (heartbeat·character-state·orphan-branch·digest-webhook, 19건)
- **env partial mock `{...} as any` → `as unknown as NodeJS.ProcessEnv`** (agent-bus·channel-provision·digest-webhook, 9건)
- **Discord.js mock `channel/client: any` → 추론 + `as unknown as Client` 캐스트** (agent-thread-router, 4건)
- **fetch Response mock `} as any` → `as unknown as Response`** (agent-daemon·digest-webhook, 6건)
- **payload `as any` → kind narrowing(if + throw)** (proposal, 1건)

생산 코드 변경 X. as-cast 자체는 유지하되 의도를 명확화하는 `as unknown as T` double-cast 방향.

## Test plan

- [x] `npx tsc --noEmit -p apps/discord-bots/apps/yawnbot/tsconfig.json` 통과
- [x] `npm run verify` 통과 (master invariant)
- [x] yawnbot vitest run 836/863 통과 (27 skip, 1건 pre-existing 'no test suite' 무관)
- [x] 남은 `as any` / `: any` 0건 (`apps/discord-bots/apps/yawnbot/src/**/*.test.ts` grep)

Commit: `369aef88`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 테스트
- **TypeScript 타입 안정성 강화**
  - 테스트 파일의 제네릭 타입 캐스팅을 `any`에서 `RequestInit`, `NodeJS.ProcessEnv`, `Client` 등 구체적인 타입으로 개선
  - 런타임 동작 및 검증 로직에는 변경 없음
  - 9개 테스트 파일의 타입 정확성 향상으로 코드 품질 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->