### PR TITLE
fix(kl-091): yawnbot inline .catch() (e: any) → (e: unknown)

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
@@ -187,8 +187,8 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
       for (const channelId of channelIds) {
         const channel = await client.channels.fetch(channelId).catch(() => null);
         if (channel?.isSendable()) {
-          await channel.send({ embeds: [embed] }).catch((e: any) =>
-            console.error('[Webhook] 채널 전송 실패:', channelId, e?.message ?? e),
+          await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+            console.error('[Webhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
           );
         }
       }
@@ -202,4 +202,3 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
 
   return app;
 }
-

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -507,7 +507,7 @@ client.once('clientReady', async () => {
     if (channel && channel.isTextBased()) {
       const version = process.env.npm_package_version || '1.0.0';
       const greeting = gameData.getMessage('Server_Startup_Greeting', version);
-      await channel.send(greeting).catch((e: any) => console.error('[Startup] 인사 메시지 전송 실패:', e?.message ?? e));
+      await channel.send(greeting).catch((e: unknown) => console.error('[Startup] 인사 메시지 전송 실패:', e instanceof Error ? e.message : String(e)));
     }
   }
 

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
@@ -162,8 +162,8 @@ export async function handleDigestCommit(
     for (const channelId of targetChannels) {
       const channel = await client.channels.fetch(channelId).catch(() => null);
       if (channel?.isSendable()) {
-        await channel.send({ embeds: [embed] }).catch((e: any) =>
-          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e?.message ?? e),
+        await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
         );
       }
     }


### PR DESCRIPTION
## 개요

TASK-KL-091: yawnbot의 인라인 `.catch()` 콜백에서 `(e: any)` → `(e: unknown)` 타입 안전 변환.

## 변경 파일 (3개)

| 파일 | 변경 내용 |
|------|-----------|
| `apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts` | `handleDigestCommit` 채널 전송 `.catch()` |
| `apps/discord-bots/apps/yawnbot/src/bot/webhook.ts` | `createGithubWebhookApp` 전송 루프 `.catch()` |
| `apps/discord-bots/apps/yawnbot/src/main.ts` | 부팅 인사 메시지 전송 `.catch()` |

## 패턴

```typescript
// Before
.catch((e: any) => console.error('...', e?.message ?? e))

// After
.catch((e: unknown) => console.error('...', e instanceof Error ? e.message : String(e)))
```

## 범위 제한

- try-catch 블록의 `catch (e: any)` 는 TASK-KL-088 (in_review) 대상 — 본 PR 미포함
- 본 PR은 인라인 `.catch()` 콜백만 대상 (scope=S)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwiqCsXCe7V3NskbkyM5Wv)_