### PR TITLE
chore(KL-092,KL-093): yawnbot cursor-local·music-player as any 14건 타입안전화

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/cursor-local.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/cursor-local.ts
@@ -1,10 +1,17 @@
 import { spawn, execFile } from 'child_process';
-import type { ChatInputCommandInteraction, StringSelectMenuInteraction } from 'discord.js';
+import type { ChatInputCommandInteraction, Message, MessageComponentInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { ActionRowBuilder, EmbedBuilder, MessageFlags, StringSelectMenuBuilder } from 'discord.js';
 import { cursorRunnerScript, resolveCursorRepoDir } from '../paths';
 import { truncateDiscordDescription } from '@discord-bots/common';
 
 const CURSOR_RUNNER_PATH = cursorRunnerScript();
+
+interface CursorOption {
+  label?: unknown;
+  title?: unknown;
+  text?: unknown;
+  description?: unknown;
+}
 
 export function getCursorMaxPromptChars() {
   return parseInt(process.env.CURSOR_MAX_PROMPT_CHARS || '2000', 10);
@@ -17,37 +24,38 @@ export async function discordAnswerCursorQuestion(
   const params = payload.params || {};
   const raw = (params.options ?? params.choices ?? []) as unknown[];
   const lines = Array.isArray(raw) ? raw : [];
-  const selectOptions = lines.slice(0, 25).map((o, i) => {
+  const selectOptions: { label: string; value: string; description?: string }[] = lines.slice(0, 25).map((o, i) => {
     if (typeof o === 'string') {
       return { label: o.slice(0, 100), value: String(i) };
     }
-    const label = String((o as any).label ?? (o as any).title ?? (o as any).text ?? `선택 ${i + 1}`).slice(0, 100);
-    const out: any = { label, value: String(i) };
-    if ((o as any).description != null) out.description = String((o as any).description).slice(0, 100);
-    return out;
+    const opt = o as CursorOption;
+    const label = String(opt.label ?? opt.title ?? opt.text ?? `선택 ${i + 1}`).slice(0, 100);
+    const entry: { label: string; value: string; description?: string } = { label, value: String(i) };
+    if (opt.description != null) entry.description = String(opt.description).slice(0, 100);
+    return entry;
   });
   if (selectOptions.length === 0) {
     return { cancelled: true };
   }
-  const heading = (params as any).title || (params as any).question || '에이전트 질문';
+  const heading = String(params['title'] ?? params['question'] ?? '에이전트 질문');
   const embed = new EmbedBuilder().setTitle('에이전트 질문').setDescription(truncateDiscordDescription(String(heading))).setColor(0x5865f2);
   const customId = `cursor_q_${String(payload.rpcId)}`;
-  const menu = new StringSelectMenuBuilder().setCustomId(customId).setPlaceholder('답을 선택하세요').addOptions(selectOptions as any);
-  const row = new ActionRowBuilder().addComponents(menu as any);
-  const reply: any = await (interaction as any).followUp({
+  const menu = new StringSelectMenuBuilder().setCustomId(customId).setPlaceholder('답을 선택하세요').addOptions(selectOptions);
+  const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+  const reply = await interaction.followUp({
     embeds: [embed],
     components: [row],
     flags: MessageFlags.Ephemeral,
     fetchReply: true,
-  });
+  }) as Message;
   const uid = interaction.user.id;
   try {
     const comp = (await reply.awaitMessageComponent({
-      filter: (i: any): i is StringSelectMenuInteraction => i.user.id === uid && i.customId === customId,
+      filter: (i: MessageComponentInteraction): i is StringSelectMenuInteraction => i.user.id === uid && i.customId === customId,
       time: 600_000,
     })) as StringSelectMenuInteraction;
-    const idx = parseInt((comp as any).values[0], 10);
-    await (comp as any).update({ components: [] });
+    const idx = parseInt(comp.values[0], 10);
+    await comp.update({ components: [] });
     return { selectedIndex: idx };
   } catch {
     try {

--- a/apps/discord-bots/apps/yawnbot/src/bot/music-player.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/music-player.ts
@@ -123,7 +123,7 @@ async function resourceFromYtDlpExec(url: string): Promise<AudioResource> {
   }
 
   try {
-    const probe = await demuxProbe(stdout as any);
+    const probe = await demuxProbe(stdout);
     return createAudioResource(probe.stream, { inputType: probe.type, silencePaddingFrames: 5 });
   } catch (e: any) {
     child.kill('SIGKILL');
@@ -556,9 +556,9 @@ export async function fetchYoutubePlaylistEntries(playlistUrl: string): Promise<
 async function resourceFromYoutubei(videoId: string): Promise<AudioResource> {
   const innertube = await getInnertubeSingleton();
   const webStream = await innertube.download(videoId, { type: 'audio', quality: 'best' });
-  const nodeStream = Readable.fromWeb(webStream as any);
+  const nodeStream = Readable.fromWeb(webStream as import('node:stream/web').ReadableStream);
   try {
-    const probe = await demuxProbe(nodeStream as any);
+    const probe = await demuxProbe(nodeStream);
     return createAudioResource(probe.stream, { inputType: probe.type, silencePaddingFrames: 5 });
   } catch (e) {
     nodeStream.destroy();
@@ -567,17 +567,17 @@ async function resourceFromYoutubei(videoId: string): Promise<AudioResource> {
 }
 
 /** play-dl 스트림 → demuxProbe로 타입 확정 후 재생. 실패 시 play-dl 타입 매핑. */
-async function resourceFromPlayDlStream(yt: { stream: NodeJS.ReadableStream; type: unknown }): Promise<AudioResource> {
+async function resourceFromPlayDlStream(yt: { stream: Readable; type: StreamType }): Promise<AudioResource> {
   try {
-    const probe = await demuxProbe(yt.stream as any);
+    const probe = await demuxProbe(yt.stream);
     return createAudioResource(probe.stream, { inputType: probe.type, silencePaddingFrames: 5 });
   } catch (e: any) {
     console.warn('[music] demuxProbe 실패:', e?.message ?? e);
     const m = mapPlayDlTypeToStreamType(yt.type);
     if (m) {
-      return createAudioResource(yt.stream as any, { inputType: m, silencePaddingFrames: 5 });
+      return createAudioResource(yt.stream, { inputType: m, silencePaddingFrames: 5 });
     }
-    return createAudioResource(yt.stream as any, { inputType: yt.type as any, silencePaddingFrames: 5 });
+    return createAudioResource(yt.stream, { inputType: yt.type, silencePaddingFrames: 5 });
   }
 }
 


### PR DESCRIPTION
## Summary

- **TASK-KL-092**: `cursor-local.ts` — Discord.js interaction/component 타입 처리 `as any` 8건 제거
  - `CursorOption` 인터페이스 도입 (선택지 shape 정의)
  - `ActionRowBuilder<StringSelectMenuBuilder>` 제네릭 명시
  - `interaction.followUp` 에서 불필요한 `as any` 제거, 반환값 `as Message` 명시
  - `comp.values[0]`, `comp.update()` — `StringSelectMenuInteraction` 타입 이미 확보돼 `as any` 불필요
  - `filter` 콜백 파라미터 `MessageComponentInteraction` 명시

- **TASK-KL-093**: `music-player.ts` — @discordjs/voice 오디오 스트림 `as any` 6건 제거
  - `resourceFromPlayDlStream` 파라미터를 `{ stream: NodeJS.ReadableStream; type: unknown }` → `{ stream: Readable; type: StreamType }` 로 교체 (play-dl 클래스 stream 필드 실제 타입 = `Readable`)
  - `demuxProbe(stdout)` / `demuxProbe(nodeStream)` / `demuxProbe(yt.stream)` `as any` 제거
  - `createAudioResource(yt.stream)` / `inputType: yt.type` `as any` 제거
  - `webStream` → `node:stream/web` ReadableStream 명시 캐스트 (youtubei.js DOM 타입 ↔ Node.js 타입 불일치 해소)

## Verification

- `npx tsc --noEmit` (yawnbot tsconfig 기준): cursor-local.ts·music-player.ts 에러 0
- pre-existing `karmolab-ai/node` 모듈 미빌드 에러는 본 PR 과 무관

## Test plan

- [ ] cursor-local.ts: 에이전트 질문 Discord select menu 정상 동작 확인 (로컬 dev 환경)
- [ ] music-player.ts: YouTube 음악 재생 (`/music play`) 정상 동작 확인
- [ ] `npm run verify` CI 통과 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGEBg6WKb3UbQCbn3H9Hw6)_