### PR TITLE
chore(KL-094): forum-dedup client: any -> ForumDedupClientLike

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/forum-dedup.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/forum-dedup.ts
@@ -36,6 +36,42 @@ export interface DedupThread {
   archived: boolean;
 }
 
+// ── Discord.js 구조적 부분집합 (페이크 테스트 호환, KL-094) ──
+// `forum-tag-recovery.ts` 의 RecoveryClientLike 패턴 정합 — 본 모듈이 *실제로 만지는*
+// 필드만 명시. discord.js Client 는 `as unknown as ForumDedupClientLike` 로 주입.
+
+interface ForumThreadLike {
+  id: string;
+  name?: string;
+  archived?: boolean;
+  archivedTimestamp?: number | null;
+  setArchived?: (archived: boolean, reason?: string) => Promise<unknown>;
+}
+
+interface ForumThreadCollectionLike {
+  values(): Iterable<ForumThreadLike>;
+}
+
+interface ForumThreadManagerLike {
+  fetchActive(): Promise<{ threads: ForumThreadCollectionLike }>;
+  fetchArchived(opts: {
+    type?: 'public' | 'private';
+    before?: unknown;
+    limit?: number;
+  }): Promise<{ threads: ForumThreadCollectionLike; hasMore: boolean }>;
+  fetch(id: string): Promise<ForumThreadLike | null>;
+}
+
+interface ForumChannelLike {
+  threads: ForumThreadManagerLike;
+}
+
+export interface ForumDedupClientLike {
+  channels: {
+    fetch(id: string): Promise<ForumChannelLike | null>;
+  };
+}
+
 /**
  * 순수 — 스레드 목록을 taskId 별로 묶고 대표(canonical)/중복(dup) 계산.
  * canonical = 그룹 내 가장 최신(snowflake 최대) — backfill/reconciler 의 latest 정합.
@@ -77,7 +113,7 @@ export function planDedup(
 }
 
 /** discord.js ForumChannel 의 active+archived 전체 스레드 열거 (best-effort, 읽기전용). */
-async function listAllForumThreads(channel: any): Promise<DedupThread[]> {
+async function listAllForumThreads(channel: ForumChannelLike): Promise<DedupThread[]> {
   const out: DedupThread[] = [];
   try {
     const active = await channel.threads.fetchActive();
@@ -88,13 +124,14 @@ async function listAllForumThreads(channel: any): Promise<DedupThread[]> {
   }
   let before: unknown = undefined;
   for (let guard = 0; guard < 200; guard += 1) {
-    let page: any;
+    let page: { threads: ForumThreadCollectionLike; hasMore: boolean } | undefined;
     try {
       page = await channel.threads.fetchArchived({ type: 'public', before, limit: 100 });
     } catch {
       break;
     }
-    const vals = [...page.threads.values()];
+    if (!page) break;
+    const vals: ForumThreadLike[] = [...page.threads.values()];
     for (const t of vals) out.push({ id: t.id, name: t.name ?? '', archived: true });
     if (!page.hasMore || vals.length === 0) break;
     const last = vals[vals.length - 1];
@@ -131,7 +168,7 @@ const MAX_ARCHIVE_PER_RUN = 400;
  * env `YAWNBOT_FORUM_DEDUP_ARCHIVE=0` = 감지만. 매 run healthy log.
  */
 export async function auditForumDupsOnce(
-  client: any,
+  client: ForumDedupClientLike,
   env: NodeJS.ProcessEnv,
   deps: AuditDeps = {},
 ): Promise<AuditResult> {
@@ -230,7 +267,7 @@ export async function auditForumDupsOnce(
  * 실패(채널 미설정/fetch 실패) = 빈 맵(backfill 은 원장 fallback).
  */
 export async function buildForumGroundTruth(
-  client: any,
+  client: ForumDedupClientLike,
   env: NodeJS.ProcessEnv,
 ): Promise<Map<string, string>> {
   const channelId = channelIdFor('agent-work', env);

--- a/apps/discord-bots/apps/yawnbot/src/bot/task-forum-backfill.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/task-forum-backfill.ts
@@ -26,7 +26,7 @@ import {
   lookupTaskForumLinkByTaskId,
   forumTitleForTask,
 } from './task-forum-bridge';
-import { buildForumGroundTruth } from './forum-dedup';
+import { buildForumGroundTruth, type ForumDedupClientLike } from './forum-dedup';
 import { channelIdFor } from '../services/channel-provision';
 
 /** memo 하위 TASK 디렉토리. task-status-sync.ts § TASK_DIRS 와 정합. */
@@ -196,9 +196,10 @@ export async function runTaskForumBackfillOnce(
   };
   // ground-truth dedup (KAR-150): Discord 실제 스레드 = 진실. 원장이 비어/손상돼도
   // 이미 forum 에 있는 TASK 는 재생성 X (원장 단일실패점 보강). 실패=빈 맵(원장 fallback).
-  const groundTruth = await buildForumGroundTruth(client, env).catch(
-    () => new Map<string, string>(),
-  );
+  const groundTruth = await buildForumGroundTruth(
+    client as unknown as ForumDedupClientLike,
+    env,
+  ).catch(() => new Map<string, string>());
   const channelId = channelIdFor('agent-work', env);
   for (const t of tasks) {
     const inLedger = Boolean(lookupTaskForumLinkByTaskId(env, t.taskId));

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -55,6 +55,8 @@ import { checkMemoPushScope } from './services/memo-push';
 import { setProposalAnnouncer } from './bot/proposal-adapter';
 import { announceProposal, reconcileProposalCards } from './bot/agent-bus';
 import type { ClientLike } from './bot/forum-post';
+import type { RecoveryClientLike } from './bot/forum-tag-recovery';
+import type { ForumDedupClientLike } from './bot/forum-dedup';
 import {
   loadCoreDef,
   listCoreIds,
@@ -452,7 +454,7 @@ client.once('clientReady', async () => {
   // 기존 포스트의 appliedTags 가 stale ID 참조 → 태그 소실. 1회 전수 점검·복원.
   try {
     const { recoverForumTagsOnce } = await import('./bot/forum-tag-recovery.js');
-    await recoverForumTagsOnce(client as any, process.env);
+    await recoverForumTagsOnce(client as unknown as RecoveryClientLike, process.env);
   } catch (e) {
     console.error(
       '[ForumTagRecovery] 부팅 태그 복원 실패:',
@@ -481,14 +483,16 @@ client.once('clientReady', async () => {
   // 수단·수동: node memo/scripts/forum-dedupe.mjs). 부팅 1회 + 주기(기본 60분).
   try {
     const { auditForumDupsOnce } = await import('./bot/forum-dedup.js');
-    await auditForumDupsOnce(client as any, process.env);
+    await auditForumDupsOnce(client as unknown as ForumDedupClientLike, process.env);
     const dedupMin = parseInt(
       process.env.YAWNBOT_FORUM_DEDUP_INTERVAL_MIN || '60',
       10,
     );
     const dedupTimer = setInterval(() => {
       void import('./bot/forum-dedup.js')
-        .then(({ auditForumDupsOnce: tick }) => tick(client as any, process.env))
+        .then(({ auditForumDupsOnce: tick }) =>
+          tick(client as unknown as ForumDedupClientLike, process.env),
+        )
         .catch((err) =>
           console.error(
             '[ForumDedup] tick 실패:',


### PR DESCRIPTION
## 목적

TASK-KL-094 — quality-loop 자동감지(2026-06-03)로 잡힌 KAR-150 forum-dedup/forum-tag-recovery 신규 코드의 `client: any` / `client as any` 5건을, `forum-tag-recovery.ts` 의 `RecoveryClientLike` 패턴과 동일한 구조 부분집합 인터페이스로 정리.

## 변경

- **`apps/discord-bots/apps/yawnbot/src/bot/forum-dedup.ts`**
  - 신규 구조 인터페이스: `ForumThreadLike` / `ForumThreadCollectionLike` / `ForumThreadManagerLike` / `ForumChannelLike` / `ForumDedupClientLike` (실제 사용 필드만: `channels.fetch` · `threads.fetchActive/fetchArchived/fetch` · 스레드 `id/name/archived/archivedTimestamp/setArchived`)
  - `auditForumDupsOnce(client: any, ...)` → `client: ForumDedupClientLike`
  - `buildForumGroundTruth(client: any, ...)` → `client: ForumDedupClientLike`
  - `listAllForumThreads(channel: any)` → `channel: ForumChannelLike` (+ 내부 `let page: any` → 명시 타입)
- **`apps/discord-bots/apps/yawnbot/src/main.ts`**
  - `recoverForumTagsOnce(client as any, ...)` → `as unknown as RecoveryClientLike` (455)
  - `auditForumDupsOnce(client as any, ...)` → `as unknown as ForumDedupClientLike` (484)
  - `tick(client as any, ...)` → `as unknown as ForumDedupClientLike` (491)
  - `import type { RecoveryClientLike, ForumDedupClientLike }` 추가
- **`apps/discord-bots/apps/yawnbot/src/bot/task-forum-backfill.ts`**
  - `buildForumGroundTruth(client, env)` 호출의 `ClientLike → ForumDedupClientLike` 인터페이스 차이를 같은 패턴(`as unknown as ForumDedupClientLike`) 으로 정정 + `import { ..., type ForumDedupClientLike }`
  - ※ 스펙에는 미명시(spec 누락) — `ClientLike.threads` 가 `create/fetch` 만 가지고 `fetchActive/fetchArchived` 없어 타입 좁힌 후 빌드 RED. 동일 캐스트 패턴으로 정정.

## 검증

- `cd apps/discord-bots && npx tsc --noEmit -p apps/yawnbot/tsconfig.json` → **exit 0** (yawnbot 타입에러 0)
- `cd apps/discord-bots/apps/yawnbot && npx vitest run src/bot/forum-dedup.test.ts` → **10/10 pass** (planDedup 4 + auditForumDupsOnce 5 + buildForumGroundTruth 1; 기존 fake forum client 가 새 구조 인터페이스에 자연 호환 — 캐스트 0)
- `npm run verify` (master invariant 단일 게이트) → **OK** (packages/karmolab-ai dist 재사용, apps/karmolab build 통과, ACL/server-monitor/origin audit 모두 통과, Rust toolchain 없어 cargo check skip → CI 가 정본)

## Test plan

- [x] `npx tsc --noEmit` 통과 (yawnbot 전체)
- [x] `forum-dedup.test.ts` 10건 통과 (구조 인터페이스 도입에도 fake forum 호환)
- [x] `npm run verify` 통과
- [ ] CI verify (push 후 GitHub Actions 자동 발동)
- [ ] runtime smoke — 봇 부팅 시 `[ForumDedup] ... taskIds=… dupGroups=…` 정상 로그 + `[forum-tag-recovery] 완료 — checked=… fixed=… skipped=…` 정상 (prod 봇 재기동 시 관측)

관련 TASK: TASK-KL-088, TASK-KL-092, TASK-KL-093 (yawnbot quality-loop as-any 정리 시리즈) / TASK-KAR-150 (원인 모듈 — forum-dedup/recovery)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * Discord 포럼 중복 제거 기능의 타입 안정성을 개선했습니다.
  * 클라이언트 인터페이스 타입을 구체화하여 코드 견고성을 강화했습니다.
  * 포럼 백필 작업 및 메인 부팅 프로세스의 타입 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->