### PR TITLE
fix(KL-088+091): yawnbot catch(e:any) → catch(e:unknown) 통합 (fresh base)

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/music-player.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/music-player.ts
@@ -125,10 +125,10 @@ async function resourceFromYtDlpExec(url: string): Promise<AudioResource> {
   try {
     const probe = await demuxProbe(stdout as any);
     return createAudioResource(probe.stream, { inputType: probe.type, silencePaddingFrames: 5 });
-  } catch (e: any) {
+  } catch (e: unknown) {
     child.kill('SIGKILL');
     const hint = stderrBuf.trim() ? ` (${stderrBuf.trim().slice(0, 500)})` : '';
-    throw new Error(`${e?.message ?? e}${hint}`);
+    throw new Error(`${e instanceof Error ? e.message : String(e)}${hint}`);
   }
 }
 
@@ -571,8 +571,8 @@ async function resourceFromPlayDlStream(yt: { stream: NodeJS.ReadableStream; typ
   try {
     const probe = await demuxProbe(yt.stream as any);
     return createAudioResource(probe.stream, { inputType: probe.type, silencePaddingFrames: 5 });
-  } catch (e: any) {
-    console.warn('[music] demuxProbe 실패:', e?.message ?? e);
+  } catch (e: unknown) {
+    console.warn('[music] demuxProbe 실패:', e instanceof Error ? e.message : String(e));
     const m = mapPlayDlTypeToStreamType(yt.type);
     if (m) {
       return createAudioResource(yt.stream as any, { inputType: m, silencePaddingFrames: 5 });
@@ -587,23 +587,23 @@ async function createYoutubeAudioResourceInner(url: string): Promise<AudioResour
 
   try {
     return await resourceFromYtDlpExec(canonical);
-  } catch (e: any) {
-    lastErrors.push(`yt-dlp: ${e?.message ?? e}`);
-    console.warn('[music] yt-dlp 실패, youtubei·play-dl 폴백:', e instanceof Error ? e.message : e);
+  } catch (e: unknown) {
+    lastErrors.push(`yt-dlp: ${e instanceof Error ? e.message : String(e)}`);
+    console.warn('[music] yt-dlp 실패, youtubei·play-dl 폴백:', e instanceof Error ? e.message : String(e));
   }
 
   try {
     const id = play.extractID(canonical);
     return await resourceFromYoutubei(id);
-  } catch (e: any) {
-    lastErrors.push(`youtubei.js: ${e?.message ?? e}`);
+  } catch (e: unknown) {
+    lastErrors.push(`youtubei.js: ${e instanceof Error ? e.message : String(e)}`);
   }
 
   try {
     const yt = await play.stream(canonical, { discordPlayerCompatibility: true });
     return resourceFromPlayDlStream(yt);
-  } catch (e: any) {
-    lastErrors.push(`play-dl: ${e?.message ?? e}`);
+  } catch (e: unknown) {
+    lastErrors.push(`play-dl: ${e instanceof Error ? e.message : String(e)}`);
     throw new Error(lastErrors.join(' | '));
   }
 }
@@ -674,9 +674,9 @@ async function playNext(guildId: string): Promise<void> {
       })();
     }
     void syncNowPlayingUi(guildId);
-  } catch (e: any) {
-    console.error('[music] 재생 실패:', item.kind === 'youtube' ? item.url : item.title, e?.message ?? e);
+  } catch (e: unknown) {
     const reason = e instanceof Error ? e.message : String(e);
+    console.error('[music] 재생 실패:', item.kind === 'youtube' ? item.url : item.title, reason);
     const ch = s.notifyTextChannelId;
     if (
       ch &&
@@ -730,13 +730,13 @@ async function appendToMusicQueue(
     }
 
     return { ok: true, position, started: wasIdle };
-  } catch (e: any) {
+  } catch (e: unknown) {
     try {
       leaveVoiceChannel(channel.guild.id);
     } catch {
       /* ignore */
     }
-    return { ok: false, error: e?.message || String(e) };
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }
 }
 

--- a/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
@@ -187,15 +187,15 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
       for (const channelId of channelIds) {
         const channel = await client.channels.fetch(channelId).catch(() => null);
         if (channel?.isSendable()) {
-          await channel.send({ embeds: [embed] }).catch((e: any) =>
-            console.error('[Webhook] 채널 전송 실패:', channelId, e?.message ?? e),
+          await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+            console.error('[Webhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
           );
         }
       }
 
       res.sendStatus(200);
-    } catch (err: any) {
-      console.error('[Webhook] Error:', err?.message ?? err);
+    } catch (err: unknown) {
+      console.error('[Webhook] Error:', err instanceof Error ? err.message : String(err));
       res.sendStatus(500);
     }
   });

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -181,8 +181,8 @@ try {
   if (generativeText) {
     console.log(`[Gemini] AI 초기화 완료 (surface=${generativeText.surface})`);
   }
-} catch (e: any) {
-  console.warn('[Gemini] 초기화 실패 (선택 기능):', e?.message ?? e);
+} catch (e: unknown) {
+  console.warn('[Gemini] 초기화 실패 (선택 기능):', e instanceof Error ? e.message : String(e));
 }
 
 function buildCtx() {
@@ -427,10 +427,10 @@ client.once('clientReady', async () => {
         console.log(
           `[ChannelProvision] ${guild.name}: 카테고리「${effectiveCategoryName(spec)}」/ 생성 ${r.created.length} · claim ${r.claimed.length} · 재사용 ${r.reused.length}`,
         );
-      } catch (e: any) {
+      } catch (e: unknown) {
         console.error(
           `[ChannelProvision] ${guild.name}(${guild.id}) reconcile 실패 — env 폴백:`,
-          e?.message ?? e,
+          e instanceof Error ? e.message : String(e),
         );
       }
     }
@@ -511,7 +511,7 @@ client.once('clientReady', async () => {
     if (channel && channel.isTextBased()) {
       const version = process.env.npm_package_version || '1.0.0';
       const greeting = gameData.getMessage('Server_Startup_Greeting', version);
-      await channel.send(greeting).catch((e: any) => console.error('[Startup] 인사 메시지 전송 실패:', e?.message ?? e));
+      await channel.send(greeting).catch((e: unknown) => console.error('[Startup] 인사 메시지 전송 실패:', e instanceof Error ? e.message : String(e)));
     }
   }
 
@@ -693,8 +693,8 @@ client.once('clientReady', async () => {
           console.error('[CoreSpeak] bus publish 실패', busErr instanceof Error ? busErr.message : busErr);
         }
         return true;
-      } catch (e: any) {
-        console.error('[CoreSpeak]', e?.message ?? e);
+      } catch (e: unknown) {
+        console.error('[CoreSpeak]', e instanceof Error ? e.message : String(e));
         return false;
       }
     });
@@ -738,8 +738,8 @@ client.once('clientReady', async () => {
         }
         const m = await ch.send(payload);
         return m.id;
-      } catch (e: any) {
-        console.error('[Dashboard]', e?.message ?? e);
+      } catch (e: unknown) {
+        console.error('[Dashboard]', e instanceof Error ? e.message : String(e));
         return null;
       }
     });
@@ -757,8 +757,8 @@ client.once('clientReady', async () => {
             if (!(ch instanceof TextChannel)) return null;
             const m = await ch.send({ content: content.slice(0, 1900) });
             return m.id;
-          } catch (e: any) {
-            console.error('[StatusBoard send]', e?.message ?? e);
+          } catch (e: unknown) {
+            console.error('[StatusBoard send]', e instanceof Error ? e.message : String(e));
             return null;
           }
         },
@@ -916,8 +916,8 @@ async function main() {
 
   try {
     await client.login(token);
-  } catch (e: any) {
-    if (e?.code === 'TokenInvalid') {
+  } catch (e: unknown) {
+    if (typeof e === 'object' && e !== null && 'code' in e && (e as Record<string, unknown>).code === 'TokenInvalid') {
       console.error(
         '[YawnBot] TokenInvalid — 토큰이 만료되었거나 잘못되었습니다. Discord Developer Portal에서 Bot Token을 재발급하고 .env 의 DISCORD_TOKEN을 갱신하세요.',
       );

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
@@ -107,10 +107,10 @@ export async function handleDigestCommit(
     let rawBody = '';
     try {
       rawBody = await fetchRepoFile(repoFullName, sha, digestFile);
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error(
         `[DigestWebhook] digest 본문 fetch 실패 (${repoFullName}@${sha.slice(0, 7)}/${digestFile}):`,
-        e?.message ?? e,
+        e instanceof Error ? e.message : String(e),
       );
       return;
     }
@@ -135,8 +135,8 @@ export async function handleDigestCommit(
         tag: 'yawnbot/digest',
       });
       yawnResponse = text.trim();
-    } catch (e: any) {
-      console.error('[DigestWebhook] AI 가공 실패:', e?.message ?? e);
+    } catch (e: unknown) {
+      console.error('[DigestWebhook] AI 가공 실패:', e instanceof Error ? e.message : String(e));
       // fallback: 원본 첫 500자 그대로
       yawnResponse = body.slice(0, 500) + (body.length > 500 ? '\n…' : '');
     }
@@ -162,15 +162,15 @@ export async function handleDigestCommit(
     for (const channelId of targetChannels) {
       const channel = await client.channels.fetch(channelId).catch(() => null);
       if (channel?.isSendable()) {
-        await channel.send({ embeds: [embed] }).catch((e: any) =>
-          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e?.message ?? e),
+        await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
         );
       }
     }
 
     console.log(`[DigestWebhook] ${dateLabel} digest 전송 완료 (${targetChannels.length} 채널)`);
-  } catch (e: any) {
-    console.error('[DigestWebhook] handleDigestCommit 예외:', e?.message ?? e);
+  } catch (e: unknown) {
+    console.error('[DigestWebhook] handleDigestCommit 예외:', e instanceof Error ? e.message : String(e));
   }
 }
 

--- a/apps/discord-bots/packages/discord-bot-common/src/discord/deferNotify.ts
+++ b/apps/discord-bots/packages/discord-bot-common/src/discord/deferNotify.ts
@@ -84,9 +84,9 @@ export async function startDeferElapsedTicker(
     try {
       if (cancelled) return;
       await interaction.editReply({ content: null as any, embeds: [embed] } as any);
-    } catch (e: any) {
-      const code = e && typeof e === 'object' && 'code' in e ? (e as any).code : undefined;
-      if (code !== 50006) console.error('[defer ticker] editReply 실패:', e?.message ?? e);
+    } catch (e: unknown) {
+      const code = e && typeof e === 'object' && 'code' in e ? (e as Record<string, unknown>).code : undefined;
+      if (code !== 50006) console.error('[defer ticker] editReply 실패:', e instanceof Error ? e.message : String(e));
     } finally {
       inFlight--;
     }
@@ -125,8 +125,8 @@ export async function notifyDeferCompletion(
     } else {
       await interaction.followUp({ content: line, flags: MessageFlags.Ephemeral } as any);
     }
-  } catch (e: any) {
-    console.error('[notifyDeferCompletion] followUp 실패:', e?.message ?? e);
+  } catch (e: unknown) {
+    console.error('[notifyDeferCompletion] followUp 실패:', e instanceof Error ? e.message : String(e));
   }
 }
 


### PR DESCRIPTION
## Summary

TASK-KL-088 + TASK-KL-091 통합 처리 — fresh base (PR #162/#165/#166 의 stale base 대체).

기존 PR #162(KL-088+089), #165(KL-088), #166(KL-091) 은 base `556177f` 기준으로, 이후 KL-094 머지(#169)로 `main.ts` 가 변경돼 stale 상태. 본 PR 이 현재 master HEAD 기준으로 통합 처리.

### TASK-KL-088: try-catch 16곳

| 파일 | 변경 수 |
|---|---|
| `main.ts` | 6곳 (Gemini / ChannelProvision / CoreSpeak / Dashboard / StatusBoard / TokenInvalid) |
| `digest-webhook.ts` | 3곳 (fetch / AI 가공 / handleDigestCommit) |
| `webhook.ts` | 1곳 (router) |
| `music-player.ts` | 7곳 (yt-dlp / youtubei / play-dl / demuxProbe / 재생 실패 / join) |
| `deferNotify.ts` | 2곳 (editReply / followUp) |

### TASK-KL-091: 인라인 .catch() 3곳

| 파일 | 변경 수 |
|---|---|
| `main.ts` | 1곳 (Startup 인사 메시지) |
| `digest-webhook.ts` | 1곳 (채널 전송) |
| `webhook.ts` | 1곳 (채널 전송) |

### 적용 패턴

```typescript
// Before
} catch (e: any) { console.error('...', e?.message ?? e) }
.catch((e: any) => console.error('...', e?.message ?? e))

// After
} catch (e: unknown) { console.error('...', e instanceof Error ? e.message : String(e)) }
.catch((e: unknown) => console.error('...', e instanceof Error ? e.message : String(e)))
```

특수 케이스:
- `main.ts` TokenInvalid: `typeof e === 'object' && e !== null && 'code' in e && (e as Record<string, unknown>).code === 'TokenInvalid'`
- `deferNotify.ts` code 체크: `(e as Record<string, unknown>).code` 패턴 적용

## Supersedes

- PR #162 (KL-088+089, stale base `27687974`)
- PR #165 (KL-088, stale base `556177f`)
- PR #166 (KL-091, stale base `556177f`)

## Verification

- 변경 파일 내 `catch (e: any)` / `.catch((e: any)` 잔존 0 (`grep` 검증 완료)
- pre-existing 에러 (missing node_modules: discord.js/@types/node 등) 와 본 PR 무관
- `npm run verify` CI 통과 확인 필요

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ry5FTBNo2aYBUGbRym12Sw)_