### PR TITLE
fix(KAR-095): workerAutoEnabled 기본값 OFF — 안전 default

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/agent-cadence.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/agent-cadence.ts
@@ -1474,7 +1474,7 @@ export function startAgentCadence(env: NodeJS.ProcessEnv): void {
   }
   // KAR-095: 서브 기능 toggle env 로 초기화 (default OFF = 安全 — prod.txt 에서 opt-in).
   // 이후 /관리자 {에이전트자동|워커자동|자기수술자동} 으로 런타임 override 가능.
-  workerAutoEnabled = env.AGENT_CADENCE_WORKER_ENABLED?.trim() !== '0';
+  workerAutoEnabled = env.AGENT_CADENCE_WORKER_ENABLED?.trim() === '1';
   surgeryAutoEnabled = env.AGENT_CADENCE_SURGERY_ENABLED?.trim() === '1';
   // cadenceAutoEnabled (dialogue/producer timer gate) = 에이전트자동 slash 전용;
   // 초기값 = true (dialogue env 는 quiet 경로로 반영 — runCadenceTickOnce 내부).


### PR DESCRIPTION
## 요약

TASK-KAR-095 — 자가발전 cadence 분리 toggle 완료 마일스톤.

`AGENT_CADENCE_WORKER_ENABLED` 미지정 시 `workerAutoEnabled = true` (ON) 였음.
`surgeryAutoEnabled` 와 동일하게 `=== '1'` 패턴으로 통일 → 기본값 OFF (안전).

### 변경 내용

- `agent-cadence.ts:1477` — `!== '0'` → `=== '1'` (1줄)

```diff
- workerAutoEnabled = env.AGENT_CADENCE_WORKER_ENABLED?.trim() !== '0';
+ workerAutoEnabled = env.AGENT_CADENCE_WORKER_ENABLED?.trim() === '1';
```

### 왜 안전한가

- `config/yawnbot.prod.txt` 에 `AGENT_CADENCE_WORKER_ENABLED=1` 이미 명시 → 프로덕션 동작 **변경 없음**
- 새 배포 환경에서 env 없이 띄울 때 worker 가 의도치 않게 활성화되는 잠재 버그 fix
- `surgeryAutoEnabled` 와 동일 패턴 통일 (코드 일관성)

### 3 env var 현황 (KAR-095 scope)

| env var | 기본값 (미지정) | prod.txt | 역할 |
|---|---|---|---|
| `AGENT_CADENCE_DIALOGUE_ENABLED` | OFF (quiet 경로 내부 처리) | `0` | 발굴·대화·retro |
| `AGENT_CADENCE_WORKER_ENABLED` | **OFF ← 이번 fix** | `1` | worker 소화 타이머 |
| `AGENT_CADENCE_SURGERY_ENABLED` | OFF | `1` | self-surgery 12h |

## 완료 조건 현황

- [x] agent-cadence.ts 3 env var 분리 (default OFF)
- [x] prod.txt SURGERY/WORKER=1, DIALOGUE=0
- [x] /관리자 슬래시 3 toggle (에이전트자동·워커자동·자기수술자동)
- [ ] deploy 후 1 cycle 실제 관측 (사용자 확인 후)
- [x] memo/projects/yawnbot/README.md 문서화

## 관련

- TASK-KAR-095
- KAR-018 자가발전 loop 마지막 마일

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZTsVsjpEX4rckVZ1kTui9)_