### PR TITLE
fix(KAR-097): memo-push nothing-to-commit race → silent skip

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/services/memo-push.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/memo-push.ts
@@ -310,7 +310,19 @@ export async function commitAndPushMemoFile(
       }
     }
     await git.add(cfg, rel);
-    await git.commit(cfg, rel, message);
+    try {
+      await git.commit(cfg, rel, message);
+    } catch (commitErr) {
+      const cmsg = commitErr instanceof Error ? commitErr.message : String(commitErr);
+      // KAR-097: 4 worker daemon 이 동일 파일을 동시 statusFile check 통과 후
+      // 첫 worker 가 commit 하면 나머지는 "nothing to commit" 로 fail.
+      // race 결과 = 이미 박힘 → silent skip (error log 아님).
+      if (cmsg.toLowerCase().includes('nothing to commit')) {
+        logger.log(`[memo-push] skipped:no-change (race — another worker already committed ${rel})`);
+        return { outcome: 'skipped:no-change', detail: 'nothing to commit (race with another worker)' };
+      }
+      throw commitErr;
+    }
     if (deps.dryRun) {
       const sha = await git.headSha(cfg);
       return { outcome: 'skipped:dryrun', detail: 'commit only (dryRun=true)', pushedSha: sha };


### PR DESCRIPTION
## 요약

TASK-KAR-097 — cross-worker commit race fix.

4개 worker daemon (`kar/kl/wm-support/wm-worker`)이 동일 파일을 동시에 `statusFile` check 통과한 후, 첫 번째 worker commit 완료 시 나머지가 "nothing to commit" 에러를 발생시켜 stderr에 `[memo-push] error` 로그를 남김.

## 근본 진단 (가설 B 확정)

```
agent-worker-kl-prod STDERR: [memo-push] error: Command failed: git commit ... nothing to commit
agent-worker-wm-worker-prod STDERR: [memo-push] error: Command failed: git commit ... nothing to commit
```

`statusFile` check (변경 감지) 시점과 `commit` 시점 사이에 race window 존재. 첫 worker가 commit하면 나머지는 이미 clean 상태 → "nothing to commit".

기존 catch 에서는 모든 에러를 `outcome:error` + `logger.warn` 처리.

## Fix

`commitAndPushMemoFile` 의 `git commit` 래핑:

```typescript
try {
  await git.commit(cfg, rel, message);
} catch (commitErr) {
  const cmsg = ...;
  if (cmsg.toLowerCase().includes('nothing to commit')) {
    logger.log(`[memo-push] skipped:no-change (race — another worker already committed)`);
    return { outcome: 'skipped:no-change', detail: 'nothing to commit (race)' };
  }
  throw commitErr; // 진짜 에러는 바깥 catch로
}
```

- "nothing to commit" = 이미 다른 worker가 commit = 정상 race 결과 → `skipped:no-change`
- 다른 git 에러는 기존 catch로 전파

## 완료 조건

- [x] 진단 확정
- [x] fix 구현
- [ ] behavior-verify (laptop 4 daemon stderr 30분 관측 필요)

## 관련

- TASK-KAR-097
- KAR-096 multi-process 분리 후 가시화된 race

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZTsVsjpEX4rckVZ1kTui9)_