### PR TITLE
chore(KL-096): yawnbot as-any 7건 타입 정리

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/meme.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/meme.ts
@@ -21,8 +21,7 @@ export async function handleMeme(message: Message): Promise<boolean> {
         .setImage(`attachment://${match}`)
         .setColor(0xffd700)
         .setFooter({ text: `Requested by ${message.author.username}`, iconURL: message.author.displayAvatarURL() });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if ('send' in message.channel) await (message.channel as any).send({ embeds: [embed], files: [path.join(MEME_DIR, match)] });
+      if (message.channel.isTextBased()) await message.channel.send({ embeds: [embed], files: [path.join(MEME_DIR, match)] });
       return true;
     }
   } catch {

--- a/apps/discord-bots/apps/yawnbot/src/bot/slash/core-game.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/slash/core-game.ts
@@ -1,6 +1,7 @@
 import { EmbedBuilder, MessageFlags } from 'discord.js';
-import type { ChatInputCommandInteraction } from 'discord.js';
+import type { ChatInputCommandInteraction, InteractionReplyOptions } from 'discord.js';
 import { formatMoney, getLevelColor } from '../../services/gamedata';
+import type { UserData } from '../../services/gamedata';
 import { handleEnhance, handleSell } from '../game-ui';
 import type { BotContext } from './bot-context';
 
@@ -28,7 +29,7 @@ export async function handleInfo(ctx: BotContext, interaction: ChatInputCommandI
     .setColor(getLevelColor(user.sword.level));
 
   const attachment = getImageAttachment(user.sword.imageName);
-  const payload: any = { embeds: [embed] };
+  const payload: InteractionReplyOptions = { embeds: [embed] };
   if (attachment) {
     embed.setThumbnail(`attachment://${attachment.name}`);
     payload.files = [attachment.file];
@@ -49,7 +50,7 @@ export async function handleMoney(ctx: BotContext, interaction: ChatInputCommand
 export async function handleRank(ctx: BotContext, interaction: ChatInputCommandInteraction): Promise<void> {
   const { gameData, client } = ctx;
   const all = Object.entries(gameData.users)
-    .map(([id, u]) => ({ id, money: (u as any).money, level: (u as any).sword?.level || 0 }))
+    .map(([id, u]: [string, UserData]) => ({ id, money: u.money, level: u.sword?.level || 0 }))
     .sort((a, b) => b.money - a.money)
     .slice(0, 10);
   let desc = '';
@@ -148,7 +149,7 @@ export async function handleBattle(ctx: BotContext, interaction: ChatInputComman
     attachment = getImageAttachment(r.battleImage);
   }
 
-  const payload: any = { embeds: [embed] };
+  const payload: InteractionReplyOptions = { embeds: [embed] };
   if (attachment) {
     embed.setThumbnail(`attachment://${attachment.name}`);
     payload.files = [attachment.file];

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -7,7 +7,7 @@ import './install-console-timestamps';
 import dns from 'node:dns';
 import { generateDependencyReport } from '@discordjs/voice';
 import sodium from 'libsodium-wrappers';
-import { Client, GatewayIntentBits, Partials, TextChannel, type MessageReaction, type PartialMessageReaction, type User, type PartialUser } from 'discord.js';
+import { Client, GatewayIntentBits, Partials, TextChannel, type Embed, type MessageReaction, type PartialMessageReaction, type User, type PartialUser } from 'discord.js';
 import { parseCommaSeparatedEnv } from '@discord-bots/common';
 import { destroyAllVoiceConnections } from './bot/voice-connection';
 import { destroyAllMusicPlayers, setMusicDiscordClient, setMusicPlayFailureReporter } from './bot/music-player';
@@ -721,7 +721,7 @@ client.once('clientReady', async () => {
           const recent = await ch.messages.fetch({ limit: 30 });
           const mine = recent.find((m) => {
             if (m.author?.id !== client.user?.id) return false;
-            const e0: any = m.embeds?.[0];
+            const e0: Embed | undefined = m.embeds?.[0];
             if (!e0) return false;
             const a = e0.author?.name ?? '';
             const t = e0.title ?? '';

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
@@ -11,6 +11,15 @@ import type { Client } from 'discord.js';
 import { EmbedBuilder } from 'discord.js';
 import { generateBlobTextFromEnvWithOptions } from 'karmolab-ai/node';
 import { channelIdFor } from './channel-provision';
+
+interface GitHubCommit {
+  id: string;
+  message: string;
+  added: string[];
+  modified: string[];
+  url: string;
+}
+
 const MAX_PLAIN_CHARS = 1800;
 const MAX_FETCH_CHARS = 8000;
 
@@ -72,7 +81,7 @@ const DATED_DIGEST_RE = /^digests\/\d{4}-\d{2}-\d{2}\.md$/;
  * - 일자패턴 한정: `digests/INDEX.md`·`README.md` 오선택 차단(잘못된
  *   파일 fetch → 깨진 게시 방지).
  */
-export function isDigestCommit(commit: any): string | null {
+export function isDigestCommit(commit: GitHubCommit): string | null {
   const firstLine = String(commit?.message ?? '').split('\n', 1)[0];
   if (!firstLine.startsWith('chore(digests):')) return null;
   const added: string[] = Array.isArray(commit?.added) ? commit.added : [];
@@ -91,7 +100,7 @@ export function isDigestCommit(commit: any): string | null {
  */
 export async function handleDigestCommit(
   client: Client,
-  commit: any,
+  commit: GitHubCommit,
   repoFullName: string,
   channelIds: string[],
 ): Promise<void> {


### PR DESCRIPTION
## 요약

TASK-KL-096 — yawnbot 잔존 `as any` / `: any` 7건 타입 정리.

quality-loop 자동 감지 (2026-06-04) 대상 파일 4개 전부 처리.

## 변경 내용

### `services/digest-webhook.ts`

```typescript
// Before
export function isDigestCommit(commit: any): string | null
export async function handleDigestCommit(client, commit: any, ...): Promise<void>

// After — GitHubCommit 인터페이스 정의 + 타입 명시
interface GitHubCommit { id: string; message: string; added: string[]; modified: string[]; url: string; }
export function isDigestCommit(commit: GitHubCommit): string | null
export async function handleDigestCommit(client, commit: GitHubCommit, ...): Promise<void>
```

### `bot/slash/core-game.ts`

```typescript
// Before
const payload: any = { embeds: [embed] };   // ×2
.map(([id, u]) => ({ id, money: (u as any).money, level: (u as any).sword?.level || 0 }))

// After
const payload: InteractionReplyOptions = { embeds: [embed] };   // ×2
.map(([id, u]: [string, UserData]) => ({ id, money: u.money, level: u.sword?.level || 0 }))
```

### `main.ts`

```typescript
// Before
const e0: any = m.embeds?.[0];

// After
const e0: Embed | undefined = m.embeds?.[0];
```

### `bot/meme.ts`

```typescript
// Before
// eslint-disable-next-line @typescript-eslint/no-explicit-any
if ('send' in message.channel) await (message.channel as any).send(...)

// After — Discord.js isTextBased() 타입가드
if (message.channel.isTextBased()) await message.channel.send(...)
```

## 관련

- TASK-KL-096
- TASK-KL-094 (forum-dedup client:any → interface, 직전 완료 패턴 동일)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZTsVsjpEX4rckVZ1kTui9)_