### PR TITLE
fix(yawnbot): catch(e:any)→unknown 6차 sweep — main/music-player/webhook/digest-webhook

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/music-player.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/music-player.ts
@@ -125,10 +125,10 @@ async function resourceFromYtDlpExec(url: string): Promise<AudioResource> {
   try {
     const probe = await demuxProbe(stdout as any);
     return createAudioResource(probe.stream, { inputType: probe.type, silencePaddingFrames: 5 });
-  } catch (e: any) {
+  } catch (e: unknown) {
     child.kill('SIGKILL');
     const hint = stderrBuf.trim() ? ` (${stderrBuf.trim().slice(0, 500)})` : '';
-    throw new Error(`${e?.message ?? e}${hint}`);
+    throw new Error(`${e instanceof Error ? e.message : String(e)}${hint}`);
   }
 }
 
@@ -571,8 +571,8 @@ async function resourceFromPlayDlStream(yt: { stream: NodeJS.ReadableStream; typ
   try {
     const probe = await demuxProbe(yt.stream as any);
     return createAudioResource(probe.stream, { inputType: probe.type, silencePaddingFrames: 5 });
-  } catch (e: any) {
-    console.warn('[music] demuxProbe 실패:', e?.message ?? e);
+  } catch (e: unknown) {
+    console.warn('[music] demuxProbe 실패:', e instanceof Error ? e.message : String(e));
     const m = mapPlayDlTypeToStreamType(yt.type);
     if (m) {
       return createAudioResource(yt.stream as any, { inputType: m, silencePaddingFrames: 5 });
@@ -587,23 +587,23 @@ async function createYoutubeAudioResourceInner(url: string): Promise<AudioResour
 
   try {
     return await resourceFromYtDlpExec(canonical);
-  } catch (e: any) {
-    lastErrors.push(`yt-dlp: ${e?.message ?? e}`);
-    console.warn('[music] yt-dlp 실패, youtubei·play-dl 폴백:', e instanceof Error ? e.message : e);
+  } catch (e: unknown) {
+    lastErrors.push(`yt-dlp: ${e instanceof Error ? e.message : String(e)}`);
+    console.warn('[music] yt-dlp 실패, youtubei·play-dl 폴백:', e instanceof Error ? e.message : String(e));
   }
 
   try {
     const id = play.extractID(canonical);
     return await resourceFromYoutubei(id);
-  } catch (e: any) {
-    lastErrors.push(`youtubei.js: ${e?.message ?? e}`);
+  } catch (e: unknown) {
+    lastErrors.push(`youtubei.js: ${e instanceof Error ? e.message : String(e)}`);
   }
 
   try {
     const yt = await play.stream(canonical, { discordPlayerCompatibility: true });
     return resourceFromPlayDlStream(yt);
-  } catch (e: any) {
-    lastErrors.push(`play-dl: ${e?.message ?? e}`);
+  } catch (e: unknown) {
+    lastErrors.push(`play-dl: ${e instanceof Error ? e.message : String(e)}`);
     throw new Error(lastErrors.join(' | '));
   }
 }
@@ -674,8 +674,8 @@ async function playNext(guildId: string): Promise<void> {
       })();
     }
     void syncNowPlayingUi(guildId);
-  } catch (e: any) {
-    console.error('[music] 재생 실패:', item.kind === 'youtube' ? item.url : item.title, e?.message ?? e);
+  } catch (e: unknown) {
+    console.error('[music] 재생 실패:', item.kind === 'youtube' ? item.url : item.title, e instanceof Error ? e.message : String(e));
     const reason = e instanceof Error ? e.message : String(e);
     const ch = s.notifyTextChannelId;
     if (
@@ -730,13 +730,13 @@ async function appendToMusicQueue(
     }
 
     return { ok: true, position, started: wasIdle };
-  } catch (e: any) {
+  } catch (e: unknown) {
     try {
       leaveVoiceChannel(channel.guild.id);
     } catch {
       /* ignore */
     }
-    return { ok: false, error: e?.message || String(e) };
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }
 }
 

--- a/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/webhook.ts
@@ -194,8 +194,8 @@ export function createGithubWebhookApp(client: Client, gameData: GameDataService
       }
 
       res.sendStatus(200);
-    } catch (err: any) {
-      console.error('[Webhook] Error:', err?.message ?? err);
+    } catch (err: unknown) {
+      console.error('[Webhook] Error:', err instanceof Error ? err.message : String(err));
       res.sendStatus(500);
     }
   });

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -181,8 +181,8 @@ try {
   if (generativeText) {
     console.log(`[Gemini] AI 초기화 완료 (surface=${generativeText.surface})`);
   }
-} catch (e: any) {
-  console.warn('[Gemini] 초기화 실패 (선택 기능):', e?.message ?? e);
+} catch (e: unknown) {
+  console.warn('[Gemini] 초기화 실패 (선택 기능):', e instanceof Error ? e.message : String(e));
 }
 
 function buildCtx() {
@@ -427,10 +427,10 @@ client.once('clientReady', async () => {
         console.log(
           `[ChannelProvision] ${guild.name}: 카테고리「${effectiveCategoryName(spec)}」/ 생성 ${r.created.length} · claim ${r.claimed.length} · 재사용 ${r.reused.length}`,
         );
-      } catch (e: any) {
+      } catch (e: unknown) {
         console.error(
           `[ChannelProvision] ${guild.name}(${guild.id}) reconcile 실패 — env 폴백:`,
-          e?.message ?? e,
+          e instanceof Error ? e.message : String(e),
         );
       }
     }
@@ -693,8 +693,8 @@ client.once('clientReady', async () => {
           console.error('[CoreSpeak] bus publish 실패', busErr instanceof Error ? busErr.message : busErr);
         }
         return true;
-      } catch (e: any) {
-        console.error('[CoreSpeak]', e?.message ?? e);
+      } catch (e: unknown) {
+        console.error('[CoreSpeak]', e instanceof Error ? e.message : String(e));
         return false;
       }
     });
@@ -738,8 +738,8 @@ client.once('clientReady', async () => {
         }
         const m = await ch.send(payload);
         return m.id;
-      } catch (e: any) {
-        console.error('[Dashboard]', e?.message ?? e);
+      } catch (e: unknown) {
+        console.error('[Dashboard]', e instanceof Error ? e.message : String(e));
         return null;
       }
     });
@@ -757,8 +757,8 @@ client.once('clientReady', async () => {
             if (!(ch instanceof TextChannel)) return null;
             const m = await ch.send({ content: content.slice(0, 1900) });
             return m.id;
-          } catch (e: any) {
-            console.error('[StatusBoard send]', e?.message ?? e);
+          } catch (e: unknown) {
+            console.error('[StatusBoard send]', e instanceof Error ? e.message : String(e));
             return null;
           }
         },
@@ -916,8 +916,8 @@ async function main() {
 
   try {
     await client.login(token);
-  } catch (e: any) {
-    if (e?.code === 'TokenInvalid') {
+  } catch (e: unknown) {
+    if (e instanceof Error && (e as Error & { code?: string }).code === 'TokenInvalid') {
       console.error(
         '[YawnBot] TokenInvalid — 토큰이 만료되었거나 잘못되었습니다. Discord Developer Portal에서 Bot Token을 재발급하고 .env 의 DISCORD_TOKEN을 갱신하세요.',
       );

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
@@ -107,10 +107,10 @@ export async function handleDigestCommit(
     let rawBody = '';
     try {
       rawBody = await fetchRepoFile(repoFullName, sha, digestFile);
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error(
         `[DigestWebhook] digest 본문 fetch 실패 (${repoFullName}@${sha.slice(0, 7)}/${digestFile}):`,
-        e?.message ?? e,
+        e instanceof Error ? e.message : String(e),
       );
       return;
     }
@@ -135,8 +135,8 @@ export async function handleDigestCommit(
         tag: 'yawnbot/digest',
       });
       yawnResponse = text.trim();
-    } catch (e: any) {
-      console.error('[DigestWebhook] AI 가공 실패:', e?.message ?? e);
+    } catch (e: unknown) {
+      console.error('[DigestWebhook] AI 가공 실패:', e instanceof Error ? e.message : String(e));
       // fallback: 원본 첫 500자 그대로
       yawnResponse = body.slice(0, 500) + (body.length > 500 ? '\n…' : '');
     }
@@ -162,15 +162,15 @@ export async function handleDigestCommit(
     for (const channelId of targetChannels) {
       const channel = await client.channels.fetch(channelId).catch(() => null);
       if (channel?.isSendable()) {
-        await channel.send({ embeds: [embed] }).catch((e: any) =>
-          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e?.message ?? e),
+        await channel.send({ embeds: [embed] }).catch((e: unknown) =>
+          console.error('[DigestWebhook] 채널 전송 실패:', channelId, e instanceof Error ? e.message : String(e)),
         );
       }
     }
 
     console.log(`[DigestWebhook] ${dateLabel} digest 전송 완료 (${targetChannels.length} 채널)`);
-  } catch (e: any) {
-    console.error('[DigestWebhook] handleDigestCommit 예외:', e?.message ?? e);
+  } catch (e: unknown) {
+    console.error('[DigestWebhook] handleDigestCommit 예외:', e instanceof Error ? e.message : String(e));
   }
 }
 


### PR DESCRIPTION
## Summary

TASK-KL-099 — `catch (e: any)` → `catch (e: unknown)` 6차 sweep.

이전 5차 sweep 대상 파일(voice-connection, webhook-routes, channel-provision, unity-free, local-webhook)은 linter 자동 수정으로 master에 이미 반영됨. 본 PR = 그 외 잔존 17개 위반 수정.

### 변경 파일 (4개, 17 위반)

| 파일 | 위반 수 |
|---|---|
| `src/main.ts` | 6 |
| `src/bot/music-player.ts` | 7 |
| `src/bot/webhook.ts` | 1 |
| `src/services/digest-webhook.ts` | 4 |

### 수정 패턴

- `catch (e: any)` → `catch (e: unknown)`
- `e?.message ?? e` → `e instanceof Error ? e.message : String(e)`
- `main.ts` TokenInvalid 분기: `e?.code` → `(e as Error & { code?: string }).code`

## Test plan

- [ ] `grep -r "catch (e: any)" apps/discord-bots/apps/yawnbot/src` → 0 결과 확인
- [ ] CI verify (master invariant) GREEN — yawnbot은 verify 게이트 밖이나 karmolab/tauri/blog/typos 통과 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkVDjDx4LD8Bhy4J2FU5d7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 오류 처리의 안정성과 타입 안전성을 개선했습니다.
  * 에러 로깅 메커니즘을 강화하여 예외 상황에서 더욱 안정적으로 메시지를 처리하도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->