### PR TITLE
fix(TASK-KL-091): game-ui.ts as any 제거 — InteractionReplyOptions + MessageComponentInteraction

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/game-ui.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/game-ui.ts
@@ -1,5 +1,7 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, MessageFlags, type ButtonInteraction } from 'discord.js';
-import type { ChatInputCommandInteraction } from 'discord.js';
+import {
+  ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, MessageFlags,
+  type ButtonInteraction, type ChatInputCommandInteraction, type InteractionReplyOptions, type MessageComponentInteraction,
+} from 'discord.js';
 import { formatMoney } from '../services/gamedata';
 import type { BotContext } from './slash/bot-context';
 
@@ -60,15 +62,12 @@ export async function showHelpPage(
       .setDisabled(pageIndex === pages.length - 1),
   );
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const payload: any = { embeds: [embed], components: [row] };
+  const payload: InteractionReplyOptions = { embeds: [embed], components: [row] };
   if (!isUpdate && ephemeral) {
     payload.flags = MessageFlags.Ephemeral;
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (isUpdate && 'update' in interaction) await (interaction as any).update(payload);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  else await (interaction as any).reply(payload);
+  if (isUpdate && 'update' in interaction) await (interaction as MessageComponentInteraction).update(payload);
+  else await interaction.reply(payload);
 }
 
 export async function handleEnhance(
@@ -163,16 +162,13 @@ export async function handleEnhance(
   // Suppress unused variable warning
   void userName;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const payload: any = { embeds: [embed], components };
+  const payload: InteractionReplyOptions = { embeds: [embed], components };
   if (attachment) {
     embed.setThumbnail(`attachment://${attachment.name}`);
     payload.files = [attachment.file];
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (isUpdate && 'update' in interaction) await (interaction as any).update(payload);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  else await (interaction as any).reply(payload);
+  if (isUpdate && 'update' in interaction) await (interaction as MessageComponentInteraction).update(payload);
+  else await interaction.reply(payload);
 }
 
 export async function handleSell(
@@ -204,10 +200,7 @@ export async function handleSell(
       ),
     ];
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const payload: any = { embeds: [embed], components };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (isUpdate && 'update' in interaction) await (interaction as any).update(payload);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  else await (interaction as any).reply(payload);
+  const payload: InteractionReplyOptions = { embeds: [embed], components };
+  if (isUpdate && 'update' in interaction) await (interaction as MessageComponentInteraction).update(payload);
+  else await interaction.reply(payload);
 }


### PR DESCRIPTION
## Summary

- `game-ui.ts` 의 `as any` 캐스트 6곳 + `payload: any` 3곳 제거
- `payload: any` → `payload: InteractionReplyOptions` (discord.js 정확한 타입)
- `(interaction as any).update(payload)` → `(interaction as MessageComponentInteraction).update(payload)`
- `(interaction as any).reply(payload)` → `interaction.reply(payload)` (union 양쪽 모두 reply 있으므로 캐스트 불필요)
- `// eslint-disable-next-line @typescript-eslint/no-explicit-any` 주석 전량 제거

## Checklist

- [x] game-ui.ts `as any` 0개 확인
- [x] meme.ts, core-game.ts 이미 클린 (선행 세션에서 완료)
- [ ] npx tsc --noEmit 통과 (CI 검증)

TASK-KL-091

---
_Generated by [Claude Code](https://claude.ai/code/session_01ND3K7yEStkr8rJ5sCM9Buf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **리팩토링**
  * 디스코드 봇의 게임 UI에서 도움말, 강화, 판매 기능의 응답 처리 로직을 최적화했습니다.
  * 코드 안정성 및 유지보수성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->