### PR TITLE
fix(TASK-KL-096): misc as any 제거 — core-game/digest-webhook/main/meme 타입 정확화

### DIFF
--- a/apps/discord-bots/apps/yawnbot/src/bot/meme.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/meme.ts
@@ -21,8 +21,7 @@ export async function handleMeme(message: Message): Promise<boolean> {
         .setImage(`attachment://${match}`)
         .setColor(0xffd700)
         .setFooter({ text: `Requested by ${message.author.username}`, iconURL: message.author.displayAvatarURL() });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if ('send' in message.channel) await (message.channel as any).send({ embeds: [embed], files: [path.join(MEME_DIR, match)] });
+      if (message.channel.isTextBased()) await message.channel.send({ embeds: [embed], files: [path.join(MEME_DIR, match)] });
       return true;
     }
   } catch {

--- a/apps/discord-bots/apps/yawnbot/src/bot/slash/core-game.ts
+++ b/apps/discord-bots/apps/yawnbot/src/bot/slash/core-game.ts
@@ -1,5 +1,5 @@
 import { EmbedBuilder, MessageFlags } from 'discord.js';
-import type { ChatInputCommandInteraction } from 'discord.js';
+import type { ChatInputCommandInteraction, InteractionReplyOptions } from 'discord.js';
 import { formatMoney, getLevelColor } from '../../services/gamedata';
 import { handleEnhance, handleSell } from '../game-ui';
 import type { BotContext } from './bot-context';
@@ -28,7 +28,7 @@ export async function handleInfo(ctx: BotContext, interaction: ChatInputCommandI
     .setColor(getLevelColor(user.sword.level));
 
   const attachment = getImageAttachment(user.sword.imageName);
-  const payload: any = { embeds: [embed] };
+  const payload: InteractionReplyOptions = { embeds: [embed] };
   if (attachment) {
     embed.setThumbnail(`attachment://${attachment.name}`);
     payload.files = [attachment.file];
@@ -49,7 +49,7 @@ export async function handleMoney(ctx: BotContext, interaction: ChatInputCommand
 export async function handleRank(ctx: BotContext, interaction: ChatInputCommandInteraction): Promise<void> {
   const { gameData, client } = ctx;
   const all = Object.entries(gameData.users)
-    .map(([id, u]) => ({ id, money: (u as any).money, level: (u as any).sword?.level || 0 }))
+    .map(([id, u]) => ({ id, money: u.money, level: u.sword.level }))
     .sort((a, b) => b.money - a.money)
     .slice(0, 10);
   let desc = '';
@@ -148,7 +148,7 @@ export async function handleBattle(ctx: BotContext, interaction: ChatInputComman
     attachment = getImageAttachment(r.battleImage);
   }
 
-  const payload: any = { embeds: [embed] };
+  const payload: InteractionReplyOptions = { embeds: [embed] };
   if (attachment) {
     embed.setThumbnail(`attachment://${attachment.name}`);
     payload.files = [attachment.file];

--- a/apps/discord-bots/apps/yawnbot/src/main.ts
+++ b/apps/discord-bots/apps/yawnbot/src/main.ts
@@ -721,7 +721,7 @@ client.once('clientReady', async () => {
           const recent = await ch.messages.fetch({ limit: 30 });
           const mine = recent.find((m) => {
             if (m.author?.id !== client.user?.id) return false;
-            const e0: any = m.embeds?.[0];
+            const e0 = m.embeds?.[0];
             if (!e0) return false;
             const a = e0.author?.name ?? '';
             const t = e0.title ?? '';

--- a/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
+++ b/apps/discord-bots/apps/yawnbot/src/services/digest-webhook.ts
@@ -62,6 +62,12 @@ export async function fetchRepoFile(
 /** 일자 digest 파일만 (digests/YYYY-MM-DD.md). INDEX.md/README.md 제외. */
 const DATED_DIGEST_RE = /^digests\/\d{4}-\d{2}-\d{2}\.md$/;
 
+interface DigestCommit {
+  message?: string | null;
+  added?: string[];
+  modified?: string[];
+}
+
 /**
  * push payload 의 commit 하나가 dev-digest commit 인지 판별.
  * 조건: message 첫 줄 "chore(digests):" + **added ∪ modified** 중
@@ -72,7 +78,7 @@ const DATED_DIGEST_RE = /^digests\/\d{4}-\d{2}-\d{2}\.md$/;
  * - 일자패턴 한정: `digests/INDEX.md`·`README.md` 오선택 차단(잘못된
  *   파일 fetch → 깨진 게시 방지).
  */
-export function isDigestCommit(commit: any): string | null {
+export function isDigestCommit(commit: DigestCommit): string | null {
   const firstLine = String(commit?.message ?? '').split('\n', 1)[0];
   if (!firstLine.startsWith('chore(digests):')) return null;
   const added: string[] = Array.isArray(commit?.added) ? commit.added : [];
@@ -91,7 +97,7 @@ export function isDigestCommit(commit: any): string | null {
  */
 export async function handleDigestCommit(
   client: Client,
-  commit: any,
+  commit: DigestCommit,
   repoFullName: string,
   channelIds: string[],
 ): Promise<void> {


### PR DESCRIPTION
## Closing — duplicate of PR #174

PR #174 (`feat/kl-096-as-any-misc`) was already merged today (2026-06-07T09:53:39Z) with the same KL-096 fixes (digest-webhook.ts, core-game.ts, main.ts, meme.ts). This PR is redundant.

TASK-KL-096 is already `done` in memo.

Original description:
- `core-game.ts`: `payload: any` 2곳 → `InteractionReplyOptions`, `(u as any)` → `u.money/u.sword.level`
- `digest-webhook.ts`: `DigestCommit` 인터페이스 신설, 파라미터 타입 명시
- `main.ts:724`: `e0: any` → 타입 추론
- `meme.ts:25`: `isTextBased()` 가드 후 직접 호출

TASK-KL-096