### PR TITLE
refactor(TASK-KL-101): tierlist publish/render/storage `: any` 제거 — 단일 TierlistNamespace

### DIFF
--- a/apps/karmolab/src/toolbox.ts
+++ b/apps/karmolab/src/toolbox.ts
@@ -945,7 +945,7 @@ const Toolbox = (() => {
         }
     }
 
-    function switchTab(btn, tabId) {
+    function switchTab(btn, tabId?) {
         if (typeof btn === 'string') {
             tabId = btn;
             btn = document.querySelector(`[data-tab-id="${tabId}"]`);

--- a/apps/karmolab/src/widgets/tierlist/publish.ts
+++ b/apps/karmolab/src/widgets/tierlist/publish.ts
@@ -1,15 +1,15 @@
 (function () {
-    const T: any = (window.Tierlist = window.Tierlist || {});
+    const T = ((window.Tierlist = window.Tierlist || {}) as unknown) as TierlistNamespace;
 
-    let publishedIndexCache: any[] | null = null;
-    const publishedJsonCache = new Map<string, any>();
+    let publishedIndexCache: TlPublishedIndexItem[] | null = null;
+    const publishedJsonCache = new Map<string, TlPublishedData>();
 
     /**
      * 티어리스트 JSON(index·카탈로그)이 놓인 디렉터리 URL(끝에 슬래시 없음).
      * Jekyll: 앱은 permalink로 /karmolab/ 이지만 data 는 /apps/karmolab/data/ 에 그대로 출력됨.
      * 로컬 file://·/apps/karmolab/index.html 은 현재 문서 기준 디렉터리로 폴백.
      */
-    function karmolabPublishedDataRoot() {
+    function karmolabPublishedDataRoot(): string {
         const { origin, pathname } = location;
         const p = pathname.replace(/\/index\.html?$/i, '') || '/';
         if (p === '/karmolab' || p.startsWith('/karmolab/')) {
@@ -21,12 +21,12 @@
         return new URL('.', location.href).href.replace(/\/?$/, '');
     }
 
-    function publishedIndexUrl() {
+    function publishedIndexUrl(): string {
         const root = karmolabPublishedDataRoot();
         return new URL('data/tierlists/index.json', `${root}/`).toString();
     }
 
-    function resolvePublishedUrl(url: any) {
+    function resolvePublishedUrl(url: string | undefined | null): string {
         const s = String(url || '').trim();
         if (!s) return s;
         if (/^https?:\/\//i.test(s)) return s;
@@ -34,21 +34,22 @@
         return new URL(s, `${root}/`).toString();
     }
 
-    async function getPublishedIndex() {
+    async function getPublishedIndex(): Promise<TlPublishedIndexItem[]> {
         if (publishedIndexCache) return publishedIndexCache;
         const res = await fetch(publishedIndexUrl(), { cache: 'no-store' });
         if (!res.ok) throw new Error('index.json 로드 실패: ' + res.status);
         const items = await res.json();
-        publishedIndexCache = Array.isArray(items) ? items : [];
+        publishedIndexCache = Array.isArray(items) ? (items as TlPublishedIndexItem[]) : [];
         return publishedIndexCache;
     }
 
-    async function getPublishedJsonByUrl(relUrl: any) {
+    async function getPublishedJsonByUrl(relUrl: string): Promise<TlPublishedData> {
         const url = resolvePublishedUrl(relUrl);
-        if (publishedJsonCache.has(url)) return publishedJsonCache.get(url);
+        const cached = publishedJsonCache.get(url);
+        if (cached !== undefined) return cached;
         const r = await fetch(url, { cache: 'no-store' });
         if (!r.ok) throw new Error('JSON 로드 실패: ' + r.status);
-        const data = await r.json();
+        const data = (await r.json()) as TlPublishedData;
         publishedJsonCache.set(url, data);
         return data;
     }
@@ -59,27 +60,31 @@
         publishedJsonCache.clear();
     }
 
-    function collectRankingItemIds(list: any) {
-        const s = new Set();
-        Object.values(list.rankings || {}).forEach((arr: any) => {
-            (arr || []).forEach((id: any) => { if (id) s.add(id); });
+    function collectRankingItemIds(list: TlListInstance): Set<string> {
+        const s = new Set<string>();
+        Object.values(list.rankings || {}).forEach((arr) => {
+            (arr || []).forEach((id) => { if (id) s.add(id); });
         });
         return s;
     }
 
-    function mergeCatalogItemForHydrate(baseRaw: any, ovr: any, id: any) {
+    function mergeCatalogItemForHydrate(
+        baseRaw: TlItem | undefined,
+        ovr: Partial<TlItem> | undefined,
+        id: string
+    ): TlItem {
         const base = baseRaw
             ? { id, name: baseRaw.name || '', imageKey: baseRaw.imageKey ?? null }
             : null;
-        const hasOvr = ovr && typeof ovr === 'object' && Object.keys(ovr).length > 0;
+        const hasOvr = !!ovr && typeof ovr === 'object' && Object.keys(ovr).length > 0;
         if (!base && !hasOvr) return { id, name: '?', imageKey: null, tlOrigin: 'custom' };
         if (!base) {
-            const m = { name: '', imageKey: null, ...ovr, id };
+            const m: TlItem = { name: '', imageKey: null, ...(ovr as TlItem), id };
             m.tlOrigin = 'custom';
             delete m.tlEdited;
             return m;
         }
-        const merged = { ...base, ...(hasOvr ? ovr : {}), id };
+        const merged: TlItem = { ...base, ...(hasOvr ? ovr : {}), id };
         if (merged.tlOrigin === 'custom') {
             delete merged.tlEdited;
             return merged;
@@ -89,7 +94,7 @@
             && (merged.name || '') !== (base.name || '');
         const imgCh = hasOvr && Object.prototype.hasOwnProperty.call(ovr, 'imageKey')
             && (merged.imageKey ?? null) !== (base.imageKey ?? null);
-        const baseForLabels = { id, name: base.name, imageKey: base.imageKey };
+        const baseForLabels: TlItem = { id, name: base.name, imageKey: base.imageKey };
         const labelCh = hasOvr && normUserLabelIds(merged) !== normUserLabelIds(baseForLabels);
         /** 풀 대비 이름·이미지·라벨이 다르면 수정 뱃지(슬림에선 prune가 정본과 동일한 필드만 제거) */
         if (ovr?.tlEdited === true || nameCh || imgCh || labelCh) merged.tlEdited = true;
@@ -102,16 +107,16 @@
      * 1) 풀에 없는 id의 override·순위 제거(custom 출처만 예외)
      * 2) tlEdited 없을 때: name·imageKey는 풀 정본과 같을 때만 제거(중복). 다르면 인스턴스 표시 유지.
      */
-    function pruneSlimPayloadAgainstCatalog(data: any, catalogItems: any) {
+    function pruneSlimPayloadAgainstCatalog(data: TlPublishedData, catalogItems: Record<string, TlItem>) {
         const catIds = new Set(Object.keys(catalogItems || {}));
         const ov = data.itemOverrides;
         if (ov && typeof ov === 'object') {
-            Object.keys(ov).forEach((k: any) => {
+            Object.keys(ov).forEach((k) => {
                 if (catIds.has(k)) return;
                 if (ov[k]?.tlOrigin === 'custom') return;
                 delete ov[k];
             });
-            Object.keys(ov).forEach((k: any) => {
+            Object.keys(ov).forEach((k) => {
                 if (!catIds.has(k)) return;
                 const ovr = ov[k];
                 if (!ovr || typeof ovr !== 'object') {
@@ -120,7 +125,7 @@
                 }
                 if (ovr.tlEdited === true) return;
                 const cat = catalogItems[k];
-                const next = { ...ovr };
+                const next: Partial<TlItem> = { ...ovr };
                 if (Object.prototype.hasOwnProperty.call(next, 'name')) {
                     const cn = cat && typeof cat === 'object' ? String(cat.name ?? '') : '';
                     if (String(next.name ?? '') === cn) delete next.name;
@@ -129,17 +134,17 @@
                     const cik = cat && typeof cat === 'object' ? (cat.imageKey ?? null) : null;
                     if ((next.imageKey ?? null) === cik) delete next.imageKey;
                 }
-                const metaKeys = Object.keys(next).filter((x: any) => x !== 'id');
+                const metaKeys = Object.keys(next).filter((x) => x !== 'id');
                 if (!metaKeys.length) delete ov[k];
                 else ov[k] = next;
             });
         }
         const rk = data.list?.rankings;
         if (rk && typeof rk === 'object') {
-            Object.keys(rk).forEach((tid: any) => {
+            Object.keys(rk).forEach((tid) => {
                 const arr = rk[tid];
                 if (!Array.isArray(arr)) return;
-                rk[tid] = arr.filter((id: any) => {
+                rk[tid] = arr.filter((id) => {
                     if (!id) return false;
                     if (catIds.has(id)) return true;
                     return !!(ov && ov[id]?.tlOrigin === 'custom');
@@ -149,7 +154,7 @@
     }
 
     /** 슬림 순위 JSON(catalogRef + itemOverrides) → 풀과 합친 list + images */
-    async function hydrateSlimInstance(data: any) {
+    async function hydrateSlimInstance(data: TlPublishedData): Promise<{ list: TlListInstance; images: Record<string, string> }> {
         const rel = data.catalogRef?.url;
         if (!rel || typeof data.itemOverrides !== 'object') throw new Error('catalogRef.url 과 itemOverrides 가 필요합니다.');
         publishedJsonCache.delete(resolvePublishedUrl(rel));
@@ -158,14 +163,14 @@
         const catItems = cat.items || {};
         pruneSlimPayloadAgainstCatalog(data, catItems);
         const overrides = data.itemOverrides || {};
-        const list = JSON.parse(JSON.stringify(data.list || {}));
+        const list = JSON.parse(JSON.stringify(data.list || {})) as TlListInstance;
         /** 순위에 없어도 itemOverrides(라벨 등)만 있는 항목은 복원해야 함 */
-        const ids = new Set([
+        const ids = new Set<string>([
             ...collectRankingItemIds(list),
             ...Object.keys(overrides),
         ]);
-        const items: Record<string, any> = {};
-        ids.forEach((id: any) => {
+        const items: Record<string, TlItem> = {};
+        ids.forEach((id) => {
             const inCat = Object.prototype.hasOwnProperty.call(catItems, id);
             items[id] = mergeCatalogItemForHydrate(inCat ? catItems[id] : undefined, overrides[id], id);
             if (!inCat) {
@@ -177,16 +182,20 @@
         list.meta = { ...(list.meta || {}), catalogUrl: rel };
         T.state.reconcileListWithCatalogPayload(list, catItems);
         T.state.pruneStaleCatalogBindings(list, catItems);
-        const images = { ...(cat.images || {}), ...(data.images || {}) };
+        const images: Record<string, string> = { ...(cat.images || {}), ...(data.images || {}) };
         return { list, images };
     }
 
-    function isSlimInstancePayload(data: any) {
-        return data?.kind === 'instance' && data.catalogRef?.url && typeof data.itemOverrides === 'object' && data.list;
+    function isSlimInstancePayload(data: TlPublishedData | null | undefined): boolean {
+        return !!data
+            && data.kind === 'instance'
+            && !!data.catalogRef?.url
+            && typeof data.itemOverrides === 'object'
+            && !!data.list;
     }
 
     /** 목록 탭 임베드 카드용: JSON을 읽어 한 줄로 표시할 개수 문구 */
-    async function getPublishedPreviewCountLine(relUrl: any) {
+    async function getPublishedPreviewCountLine(relUrl: string): Promise<string> {
         if (!relUrl) return '';
         try {
             const data = await getPublishedJsonByUrl(relUrl);
@@ -195,12 +204,12 @@
                 return `총 ${n}개`;
             }
             if (isSlimInstancePayload(data)) {
-                let poolN = null;
+                let poolN: number | null = null;
                 try {
-                    const cat = await getPublishedJsonByUrl(data.catalogRef.url);
+                    const cat = await getPublishedJsonByUrl(data.catalogRef!.url!);
                     if (T.state.isCatalogPayload(cat)) poolN = Object.keys(cat.items || {}).length;
                 } catch (_) { /* 풀 URL 실패 */ }
-                const ranked = collectRankingItemIds(data.list).size;
+                const ranked = collectRankingItemIds(data.list as TlListInstance).size;
                 if (poolN != null) return `후보 풀 총 ${poolN}개 · 판 ${ranked}개`;
                 return ranked ? `판 ${ranked}개` : '';
             }
@@ -214,7 +223,7 @@
         return '';
     }
 
-    async function resolveCatalogIndexIdForUrl(catalogUrl: any) {
+    async function resolveCatalogIndexIdForUrl(catalogUrl: string): Promise<string> {
         try {
             const idx = await getPublishedIndex();
             const u = resolvePublishedUrl(catalogUrl);
@@ -226,22 +235,22 @@
         return '';
     }
 
-    function normUserLabelIds(it: any) {
+    function normUserLabelIds(it: TlItem | undefined | null): string {
         return JSON.stringify([...(it?.userLabelIds || [])].filter(Boolean).sort());
     }
 
-    function diffItemOverride(base: any, item: any) {
+    function diffItemOverride(base: TlItem | undefined, item: TlItem): Partial<TlItem> | null {
         if (!base) {
-            const o: any = {
+            const o: Partial<TlItem> = {
                 id: item.id,
                 name: item.name || '',
                 imageKey: item.imageKey ?? null,
                 tlOrigin: 'custom',
             };
-            if ((item.userLabelIds || []).length) o.userLabelIds = [...item.userLabelIds];
+            if ((item.userLabelIds || []).length) o.userLabelIds = [...(item.userLabelIds ?? [])];
             return o;
         }
-        const o: any = {};
+        const o: Partial<TlItem> = {};
         const nameCh = (item.name || '') !== (base.name || '');
         const ik = item.imageKey ?? null;
         const bk = base.imageKey ?? null;
@@ -262,10 +271,10 @@
      * 로컬 인스턴스: 풀 출처 카드 표시가 풀 정본과 다르면 tlEdited 맞춤(새로고침 뒤 뱃지 누락 방지).
      * 정본과 완전히 같으면 tlEdited 제거.
      */
-    function syncCatalogItemEditedFlags(list: any, catItems: any) {
+    function syncCatalogItemEditedFlags(list: TlListInstance, catItems: Record<string, TlItem>): boolean {
         if (!list?.items || !catItems || typeof catItems !== 'object') return false;
         let changed = false;
-        Object.keys(list.items).forEach((id: any) => {
+        Object.keys(list.items).forEach((id) => {
             const it = list.items[id];
             if (!it || it.tlOrigin === 'custom') return;
             const base = catItems[id];
@@ -288,10 +297,10 @@
     }
 
     /** meta.catalogUrl 이 있고 풀을 fetch 할 수 있으면 슬림 페이로드, 아니면 null */
-    async function tryBuildSlimInstanceExport(list: any, meta: any) {
+    async function tryBuildSlimInstanceExport(list: TlListInstance, meta: TlCurrentMetaView): Promise<TlPublishedData | null> {
         const catalogUrl = String(list.meta?.catalogUrl || '').trim();
         if (!catalogUrl) return null;
-        let cat;
+        let cat: TlPublishedData;
         try {
             cat = await getPublishedJsonByUrl(catalogUrl);
         } catch (_) {
@@ -299,17 +308,17 @@
         }
         if (!T.state.isCatalogPayload(cat)) return null;
         const catalogItems = cat.items || {};
-        const overrides: Record<string, any> = {};
+        const overrides: Record<string, Partial<TlItem>> = {};
         for (const [id, item] of Object.entries(list.items || {})) {
             const diff = diffItemOverride(catalogItems[id], item);
             if (diff) overrides[id] = diff;
         }
-        const imageKeys = new Set();
-        Object.values(overrides).forEach((o: any) => {
+        const imageKeys = new Set<string>();
+        Object.values(overrides).forEach((o) => {
             if (o && o.imageKey) imageKeys.add(o.imageKey);
         });
         const images = await T.db.getMany([...imageKeys]);
-        const listCopy = JSON.parse(JSON.stringify(list));
+        const listCopy = JSON.parse(JSON.stringify(list)) as Omit<TlListInstance, 'items'> & { items?: Record<string, TlItem> };
         delete listCopy.items;
         const refId = await resolveCatalogIndexIdForUrl(catalogUrl);
         return {
@@ -318,12 +327,12 @@
             title: meta.title || list.title,
             catalogRef: { id: refId, url: catalogUrl },
             itemOverrides: overrides,
-            list: listCopy,
+            list: listCopy as TlListInstance,
             images,
         };
     }
 
-    async function openPublishedDirect(relUrl: any, meta: any) {
+    async function openPublishedDirect(relUrl: string, meta: TlPublishedMeta | null | undefined): Promise<void> {
         const data = await getPublishedJsonByUrl(relUrl);
         if (T.state.isCatalogPayload(data)) {
             T.state.openPublished({ ...(meta || {}), url: relUrl }, data);
@@ -355,19 +364,21 @@
         await T.render.renderAll();
     }
 
-    async function buildExportPayload(): Promise<any> {
+    async function buildExportPayload(): Promise<TlPublishedData | null> {
         if (T.state.isPublishedCatalogMode()) {
             const snap = T.state.getPublishedCatalogSnapshot();
             const d = snap?.data;
             if (!d) return null;
-            const imageKeys = Object.values(d.items || {}).filter((i: any) => i.imageKey).map((i: any) => i.imageKey);
+            const imageKeys = Object.values(d.items || {})
+                .filter((i) => i.imageKey)
+                .map((i) => i.imageKey as string);
             const images = await T.db.getMany(imageKeys);
             return {
                 version: 2,
                 kind: 'catalog',
                 exportedAt: Date.now(),
                 title: snap.meta?.title || d.title || '후보 풀',
-                items: JSON.parse(JSON.stringify(d.items || {})),
+                items: JSON.parse(JSON.stringify(d.items || {})) as Record<string, TlItem>,
                 images,
             };
         }
@@ -380,19 +391,21 @@
                 return { ...slim, exportedAt: Date.now() };
             }
         } catch (_) { /* 풀 fetch 실패 시 아래 전체보내기 */ }
-        const imageKeys = Object.values(list.items || {}).filter((i: any) => i.imageKey).map((i: any) => i.imageKey);
+        const imageKeys = Object.values(list.items || {})
+            .filter((i) => i.imageKey)
+            .map((i) => i.imageKey as string);
         const images = await T.db.getMany(imageKeys);
         return {
             version: 2,
             kind: 'instance',
             exportedAt: Date.now(),
             title: meta.title || list.title,
-            list: JSON.parse(JSON.stringify(list)),
+            list: JSON.parse(JSON.stringify(list)) as TlListInstance,
             images,
         };
     }
 
-    function downloadJson(filename: any, obj: any) {
+    function downloadJson(filename: string, obj: unknown) {
         const blob = new Blob([JSON.stringify(obj, null, 2)], { type: 'application/json' });
         const link = document.createElement('a');
         link.download = filename;
@@ -404,7 +417,7 @@
     async function showJsonPreview() {
         const data = await buildExportPayload();
         if (!data) {
-            Toolbox.showToast('보낼 데이터가 없습니다.', 'error');
+            Toolbox.showToast?.('보낼 데이터가 없습니다.', 'error');
             return;
         }
         const jsonText = JSON.stringify(data, null, 2);
@@ -427,23 +440,24 @@
                     <button class="tl-btn" id="tl-json-close">닫기</button>
                 </div>
             `,
-            onMount: ({ dialog, close }: any) => {
-                const ta = dialog.querySelector('#tl-json-preview');
+            onMount: ({ dialog, close }) => {
+                const ta = dialog.querySelector<HTMLTextAreaElement>('#tl-json-preview');
+                if (!ta) return;
                 ta.value = jsonText;
-                dialog.querySelector('#tl-json-close').onclick = close;
-                dialog.querySelector('#tl-json-copy').onclick = async () => {
+                dialog.querySelector<HTMLButtonElement>('#tl-json-close')!.onclick = close;
+                dialog.querySelector<HTMLButtonElement>('#tl-json-copy')!.onclick = async () => {
                     try {
                         await navigator.clipboard.writeText(jsonText);
-                        Toolbox.showToast('클립보드에 복사됨');
+                        Toolbox.showToast?.('클립보드에 복사됨');
                     } catch (_) {
                         ta.focus(); ta.select(); document.execCommand('copy');
-                        Toolbox.showToast('클립보드에 복사됨');
+                        Toolbox.showToast?.('클립보드에 복사됨');
                     }
                 };
-                dialog.querySelector('#tl-json-download').onclick = () => {
-                    const base = (data.title || 'tierlist').replace(/[\\/:*?"<>|]+/g, '-');
+                dialog.querySelector<HTMLButtonElement>('#tl-json-download')!.onclick = () => {
+                    const base = String(data.title || 'tierlist').replace(/[\\/:*?"<>|]+/g, '-');
                     downloadJson(base + '.json', data);
-                    Toolbox.showToast('JSON 다운로드 시작');
+                    Toolbox.showToast?.('JSON 다운로드 시작');
                 };
             }
         });
@@ -455,19 +469,22 @@
         const boardEl = document.querySelector('#tl-editor-board');
         if (!boardEl) return;
 
-        Toolbox.showToast('이미지 생성 중...');
-        if (!(window as any).html2canvas) {
-            await new Promise((res: any, rej: any) => {
+        type Html2CanvasFn = (el: Element, opts: { backgroundColor?: string; scale?: number; useCORS?: boolean }) => Promise<HTMLCanvasElement>;
+        const win = window as Window & { html2canvas?: Html2CanvasFn };
+
+        Toolbox.showToast?.('이미지 생성 중...');
+        if (!win.html2canvas) {
+            await new Promise<void>((resolve, reject) => {
                 const s = document.createElement('script');
                 s.src = 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js';
-                s.onload = res;
-                s.onerror = rej;
+                s.onload = () => resolve();
+                s.onerror = () => reject(new Error('html2canvas load failed'));
                 document.head.appendChild(s);
             });
         }
 
         try {
-            const canvas = await (window as any).html2canvas(boardEl, {
+            const canvas = await win.html2canvas!(boardEl, {
                 backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--bg-tertiary').trim() || '#1a1a2e',
                 scale: 2,
                 useCORS: true,
@@ -476,19 +493,19 @@
             link.download = (list.title || 'tierlist') + '.png';
             link.href = canvas.toDataURL('image/png');
             link.click();
-            Toolbox.showToast('이미지 저장됨');
+            Toolbox.showToast?.('이미지 저장됨');
         } catch (err) {
-            Toolbox.showToast('이미지 생성 실패', 'error', err);
+            Toolbox.showToast?.('이미지 생성 실패', 'error', err);
         }
     }
 
-    async function saveImagesMap(images: any) {
+    async function saveImagesMap(images: Record<string, string> | undefined) {
         for (const [k, url] of Object.entries(images || {})) {
             if (url) await T.db.save(k, url);
         }
     }
 
-    async function forkPublishedCatalogToLocal() {
+    async function forkPublishedCatalogToLocal(): Promise<TlListInstance | null> {
         const snap = T.state.getPublishedCatalogSnapshot();
         if (!snap?.data) return null;
         await saveImagesMap(snap.data.images);
@@ -496,7 +513,7 @@
         return inst;
     }
 
-    async function reconcileImportedInstanceList(list: any) {
+    async function reconcileImportedInstanceList(list: TlListInstance | null | undefined) {
         if (!list) return;
         const st = T.state.getState();
         if (list.catalogId && st.catalogs[list.catalogId]) {
@@ -517,7 +534,7 @@
         } catch (_) { /* 로컬 파일/오프라인 */ }
     }
 
-    async function importFromDataObject(data: any) {
+    async function importFromDataObject(data: TlPublishedData & { lists?: Record<string, TlListInstance> }) {
         clearPublishedFetchCache();
         const st = T.state.getState();
 
@@ -526,9 +543,9 @@
             st.catalogs[id] = {
                 id,
                 title: data.title || '가져온 후보 풀',
-                category: data.category || '',
+                category: typeof data.category === 'string' ? data.category : '',
                 updatedAt: Date.now(),
-                items: JSON.parse(JSON.stringify(data.items || {})),
+                items: JSON.parse(JSON.stringify(data.items || {})) as Record<string, TlItem>,
             };
             await saveImagesMap(data.images);
             T.state.closePublished?.();
@@ -537,10 +554,10 @@
             return;
         }
 
-        if (data.version >= 2 && data.lists && typeof data.lists === 'object' && Object.keys(data.lists).length) {
-            const newIds = [];
+        if ((data.version ?? 0) >= 2 && data.lists && typeof data.lists === 'object' && Object.keys(data.lists).length) {
+            const newIds: string[] = [];
             for (const [, list] of Object.entries(data.lists)) {
-                const copy = JSON.parse(JSON.stringify(list));
+                const copy = JSON.parse(JSON.stringify(list)) as TlListInstance;
                 const newId = 'tl-' + T.state.uid();
                 copy.id = newId;
                 copy.createdAt = Date.now();
@@ -570,7 +587,7 @@
                 ...(h.list.meta || {}),
                 source: 'import',
                 dirty: true,
-                catalogUrl: data.catalogRef.url,
+                catalogUrl: data.catalogRef!.url,
             };
             st.instances[newLid] = h.list;
             await saveImagesMap(h.images);
@@ -583,7 +600,7 @@
 
         if (data.kind === 'instance' && data.list) {
             const newLid = 'tl-' + T.state.uid();
-            const list = {
+            const list: TlListInstance = {
                 ...data.list,
                 id: newLid,
                 createdAt: Date.now(),
@@ -602,7 +619,7 @@
 
         if (data.list) {
             const newLid = 'tl-' + T.state.uid();
-            const list = {
+            const list: TlListInstance = {
                 ...data.list,
                 id: newLid,
                 createdAt: Date.now(),
@@ -631,11 +648,11 @@
             if (!file) return;
             try {
                 const text = await file.text();
-                const data = JSON.parse(text);
+                const data = JSON.parse(text) as TlPublishedData & { lists?: Record<string, TlListInstance> };
                 await importFromDataObject(data);
-                Toolbox.showToast('가져오기 완료');
+                Toolbox.showToast?.('가져오기 완료');
             } catch (err) {
-                Toolbox.showToast('가져오기 실패', 'error', err);
+                Toolbox.showToast?.('가져오기 실패', 'error', err);
             }
         };
         input.click();
@@ -645,7 +662,7 @@
      * 로컬 순위 편집 시: 연결된 카탈로그와 동기화하고,
      * 풀에서 사라진 id는 후보 출처 카드·override 잔여를 걷어낸다(직접 추가 custom 만 유지).
      */
-    async function syncInstanceItemOriginsWithCatalogIfNeeded() {
+    async function syncInstanceItemOriginsWithCatalogIfNeeded(): Promise<boolean> {
         if (T.state.isPublishedMode()) return false;
         const list = T.state.currentList();
         if (!list) return false;
@@ -675,16 +692,16 @@
         return changed;
     }
 
-    async function resetItemToCatalogDefault(itemId: any) {
+    async function resetItemToCatalogDefault(itemId: string): Promise<boolean> {
         if (!confirm('이름·이미지·라벨을 후보 풀 기준으로 되돌릴까요?')) return false;
         T.state.ensureWritableList?.('resetItem');
         const list = T.state.currentList();
         if (!list?.items?.[itemId]) {
-            Toolbox.showToast('항목을 찾을 수 없어요.', 'error');
+            Toolbox.showToast?.('항목을 찾을 수 없어요.', 'error');
             return false;
         }
         const st = T.state.getState();
-        let entry = null;
+        let entry: TlItem | null = null;
         if (list.catalogId && st.catalogs[list.catalogId]?.items?.[itemId]) {
             entry = st.catalogs[list.catalogId].items[itemId];
         }
@@ -698,14 +715,14 @@
             }
         }
         if (!entry) {
-            Toolbox.showToast('후보 풀에 없는 항목이거나 풀을 불러올 수 없어요.', 'error');
+            Toolbox.showToast?.('후보 풀에 없는 항목이거나 풀을 불러올 수 없어요.', 'error');
             return false;
         }
         if (!T.state.applyCatalogEntryToItem(list, itemId, entry)) {
-            Toolbox.showToast('되돌리기에 실패했어요.', 'error');
+            Toolbox.showToast?.('되돌리기에 실패했어요.', 'error');
             return false;
         }
-        Toolbox.showToast('후보 풀 기준으로 되돌렸어요.');
+        Toolbox.showToast?.('후보 풀 기준으로 되돌렸어요.');
         return true;
     }
 

--- a/apps/karmolab/src/widgets/tierlist/render.ts
+++ b/apps/karmolab/src/widgets/tierlist/render.ts
@@ -1,21 +1,21 @@
 (function () {
-    const T: any = (window.Tierlist = window.Tierlist || {});
+    const T = ((window.Tierlist = window.Tierlist || {}) as unknown) as TierlistNamespace;
 
-    let editorContainer: any = null;
-    let listContainer: any = null;
-    let statsContainer: any = null;
+    let editorContainer: HTMLElement | null = null;
+    let listContainer: HTMLElement | null = null;
+    let statsContainer: HTMLElement | null = null;
     /** 편집기: 카드 클릭으로 삭제 */
     let editorDeleteMode = false;
     let editorDeleteModeEscBound = false;
     let lastQuickDeleteBlockedToastAt = 0;
-    function setContainers({ editor, list, stats }: any) {
+    function setContainers({ editor, list, stats }: { editor?: HTMLElement | null; list?: HTMLElement | null; stats?: HTMLElement | null }) {
         if (editor !== undefined) editorContainer = editor;
         if (list !== undefined) listContainer = list;
         if (stats !== undefined) statsContainer = stats;
     }
 
     /** index.json 행: 후보 풀(catalog) vs 사이트에 올린 순위판(karmo). 미표기는 카탈로그. */
-    function publishedIndexGroup(it: any) {
+    function publishedIndexGroup(it: TlPublishedIndexItem): string {
         const g = String(it?.tierlistGroup ?? it?.group ?? '')
             .toLowerCase()
             .trim();
@@ -28,29 +28,31 @@
         try {
             if (typeof Toolbox !== 'undefined' && Toolbox.switchPage && Toolbox.switchTab) {
                 Toolbox.switchPage('tierlist', { pushHistory: false });
-                (Toolbox.switchTab as any)('tl-edit');
+                Toolbox.switchTab('tl-edit');
             }
         } catch (_) {}
     }
 
-    function optionsFromPublishedRows(rows: any, meta: any) {
+    function optionsFromPublishedRows(rows: TlPublishedIndexItem[], meta: TlCurrentMetaView): string {
         if (!rows.length) return '<option disabled>(항목 없음)</option>';
         return [...rows]
-            .sort((a: any, b: any) => String(a.title || '').localeCompare(String(b.title || ''), 'ko-KR'))
-            .map((it: any) => {
+            .sort((a, b) => String(a.title || '').localeCompare(String(b.title || ''), 'ko-KR'))
+            .map((it) => {
                 const selected = T.state.isPublishedMode() && meta.url === it.url;
-                return `<option value="blog:${Toolbox.escapeHtml(it.url || '')}" ${selected ? 'selected' : ''}>${Toolbox.escapeHtml(it.title || it.id || 'tierlist')}</option>`;
+                const esc = Toolbox.escapeHtml ?? ((s: string) => s);
+                return `<option value="blog:${esc(it.url || '')}" ${selected ? 'selected' : ''}>${esc(it.title || it.id || 'tierlist')}</option>`;
             })
             .join('');
     }
 
-    async function buildListSelectorHtml(st: any, meta: any) {
+    async function buildListSelectorHtml(st: TlState, meta: TlCurrentMetaView): Promise<string> {
+        const esc = Toolbox.escapeHtml ?? ((s: string) => s);
         const localInst = Object.values(st.instances || {})
-            .sort((a: any, b: any) => String(a.title || '').localeCompare(String(b.title || ''), 'ko-KR'))
-            .map((l: any) => {
+            .sort((a, b) => String(a.title || '').localeCompare(String(b.title || ''), 'ko-KR'))
+            .map((l) => {
                 const val = `local:${l.id}`;
                 const sel = !T.state.isPublishedMode() && l.id === st.currentInstanceId;
-                return `<option value="${Toolbox.escapeHtml(val)}" ${sel ? 'selected' : ''}>${Toolbox.escapeHtml(l.title || '(제목 없음)')}</option>`;
+                return `<option value="${esc(val)}" ${sel ? 'selected' : ''}>${esc(l.title || '(제목 없음)')}</option>`;
             }).join('');
         const localOptgroup = localInst
             ? `<optgroup label="로컬 순위">${localInst}</optgroup>`
@@ -60,9 +62,9 @@
         let karmoOpts = '<option disabled>(항목 없음)</option>';
         try {
             const publishedRows = await T.publish.getPublishedIndex();
-            const catalogRows: any[] = [];
-            const karmoRows: any[] = [];
-            publishedRows.forEach((it: any) => {
+            const catalogRows: TlPublishedIndexItem[] = [];
+            const karmoRows: TlPublishedIndexItem[] = [];
+            publishedRows.forEach((it) => {
                 (publishedIndexGroup(it) === 'karmo' ? karmoRows : catalogRows).push(it);
             });
             catalogOpts = optionsFromPublishedRows(catalogRows, meta);
@@ -80,8 +82,9 @@
     }
 
     function bindListSelectChange() {
-        editorContainer.querySelector('#tl-list-select')?.addEventListener('change', async (e: any) => {
-            const v = String(e.target.value || '');
+        editorContainer?.querySelector('#tl-list-select')?.addEventListener('change', async (e) => {
+            const target = e.target as HTMLSelectElement | null;
+            const v = String(target?.value || '');
             if (v.startsWith('local:')) {
                 const id = v.slice('local:'.length);
                 T.state.switchToInstance(id);
@@ -92,7 +95,7 @@
                 const rel = v.slice('blog:'.length);
                 try {
                     const items = await T.publish.getPublishedIndex();
-                    const row = items.find((x: any) => x.url === rel);
+                    const row = items.find((x) => x.url === rel);
                     const g = row ? publishedIndexGroup(row) : 'catalog';
                     await T.publish.openPublishedDirect(rel, {
                         id: row?.id || '',
@@ -100,33 +103,34 @@
                         url: rel,
                         tierlistGroup: g === 'karmo' ? 'karmo' : 'catalog',
                     });
-                } catch (err) { Toolbox.showToast('사이트 데이터 열기 실패', 'error', err); }
+                } catch (err) { Toolbox.showToast?.('사이트 데이터 열기 실패', 'error', err); }
             }
         });
     }
 
     async function renderEditor() {
         if (!editorContainer) return;
+        const esc = Toolbox.escapeHtml ?? ((s: string) => s);
 
         const st = T.state.getState();
         const meta = T.state.currentMeta();
 
         if (T.state.isPublishedCatalogMode()) {
             const snap = T.state.getPublishedCatalogSnapshot();
-            const d = snap?.data || {};
+            const d = snap?.data || {} as TlPublishedData;
             const items = d.items || {};
             const fileImages = d.images || {};
-            const keys = Object.values(items).filter((i: any) => i.imageKey).map((i: any) => i.imageKey);
+            const keys = Object.values(items).filter((i) => i.imageKey).map((i) => i.imageKey as string);
             const dbMap = await T.db.getMany(keys);
 
-            function cardHtmlCatalog(itemId: any) {
+            function cardHtmlCatalog(itemId: string): string {
                 const item = items[itemId];
                 if (!item) return '';
                 const imgData = item.imageKey ? (fileImages[item.imageKey] || dbMap[item.imageKey]) : null;
                 const inner = imgData
-                    ? `<img src="${imgData}" alt="${Toolbox.escapeHtml(item.name || '')}">`
-                    : `<div class="tl-item-text">${Toolbox.escapeHtml(item.name || '?')}</div>`;
-                const nameTag = item.name ? `<div class="tl-item-name">${Toolbox.escapeHtml(item.name)}</div>` : '';
+                    ? `<img src="${imgData}" alt="${esc(item.name || '')}">`
+                    : `<div class="tl-item-text">${esc(item.name || '?')}</div>`;
+                const nameTag = item.name ? `<div class="tl-item-name">${esc(item.name)}</div>` : '';
                 return `<div class="tl-item tl-item--static" data-item-id="${itemId}">${inner}${nameTag}</div>`;
             }
 
@@ -154,10 +158,10 @@
             editorContainer.querySelector('#tl-fork-catalog')?.addEventListener('click', async () => {
                 try {
                     await T.publish.forkPublishedCatalogToLocal();
-                    Toolbox.showToast('새 순위 인스턴스를 만들었어요');
+                    Toolbox.showToast?.('새 순위 인스턴스를 만들었어요');
                     await renderAll();
                 } catch (err) {
-                    Toolbox.showToast('만들기 실패', 'error', err);
+                    Toolbox.showToast?.('만들기 실패', 'error', err);
                 }
             });
             editorContainer.querySelector('#tl-btn-export-json')?.addEventListener('click', () => T.publish.showJsonPreview());
@@ -172,7 +176,7 @@
                 <div>열린 순위 인스턴스가 없습니다</div>
                 <div style="margin-top:12px;"><button class="tl-btn tl-btn-primary" id="tl-empty-create">새 순위 만들기</button></div>
             </div></div>`;
-            editorContainer.querySelector('#tl-empty-create')?.addEventListener('click', T.dialogs.showNewListDialog);
+            editorContainer.querySelector('#tl-empty-create')?.addEventListener('click', () => T.dialogs.showNewListDialog?.());
             return;
         }
 
@@ -187,51 +191,51 @@
             } catch (_) {}
         });
 
-        const allImageKeys = Object.values(list.items || {}).filter((i: any) => i.imageKey).map((i: any) => i.imageKey);
+        const allImageKeys = Object.values(list.items || {}).filter((i) => i.imageKey).map((i) => i.imageKey as string);
         const imgMap = await T.db.getMany(allImageKeys);
         const embeddedImages = T.state.getPublishedEmbeddedImages();
 
-        function itemUserLabelsHtml(item: any) {
-            const defs = list.userLabels || {};
+        function itemUserLabelsHtml(item: TlItem): string {
+            const defs = list!.userLabels || {};
             const ids = item.userLabelIds || [];
             if (!ids.length) return '';
             const maxShow = 3;
             const shown = ids.slice(0, maxShow);
             const more = ids.length - shown.length;
-            const pills = [];
-            shown.forEach((lid: any) => {
+            const pills: string[] = [];
+            shown.forEach((lid) => {
                 const d = defs[lid];
                 if (!d) return;
-                const bg = Toolbox.escapeHtml(d.color || '#666');
-                const nm = Toolbox.escapeHtml(d.name || '');
+                const bg = esc(d.color || '#666');
+                const nm = esc(d.name || '');
                 pills.push(`<span class="tl-item-userlabel" style="background:${bg}" title="${nm}">${nm}</span>`);
             });
             if (more > 0) {
-                const rest = ids.slice(maxShow).map((lid: any) => defs[lid]?.name || lid).join(', ');
-                pills.push(`<span class="tl-item-userlabel tl-item-userlabel--more" title="${Toolbox.escapeHtml(rest)}">+${more}</span>`);
+                const rest = ids.slice(maxShow).map((lid) => defs[lid]?.name || lid).join(', ');
+                pills.push(`<span class="tl-item-userlabel tl-item-userlabel--more" title="${esc(rest)}">+${more}</span>`);
             }
             return pills.length ? `<div class="tl-item-userlabels">${pills.join('')}</div>` : '';
         }
 
-        function itemOriginBadge(item: any) {
+        function itemOriginBadge(item: TlItem | undefined): string {
             if (!item || (item.tlOrigin !== 'custom' && !item.tlEdited)) return '';
             const isAdd = item.tlOrigin === 'custom';
             const label = isAdd ? '추가' : '수정';
             const tip = isAdd ? '직접 추가한 항목입니다.' : '후보 풀에서 가져온 뒤 이름 등을 바꾼 항목입니다.';
             const cls = isAdd ? 'tl-item-badge tl-item-badge--add' : 'tl-item-badge tl-item-badge--edit';
-            return `<span class="${cls}" title="${Toolbox.escapeHtml(tip)}">${Toolbox.escapeHtml(label)}</span>`;
+            return `<span class="${cls}" title="${esc(tip)}">${esc(label)}</span>`;
         }
 
-        function cardHtml(itemId: any) {
-            const item = list.items[itemId];
+        function cardHtml(itemId: string): string {
+            const item = list!.items[itemId];
             if (!item) return '';
             const imgData = item.imageKey
                 ? (embeddedImages[item.imageKey] || imgMap[item.imageKey])
                 : null;
             const inner = imgData
-                ? `<img src="${imgData}" alt="${Toolbox.escapeHtml(item.name || '')}">`
-                : `<div class="tl-item-text">${Toolbox.escapeHtml(item.name || '?')}</div>`;
-            const nameTag = item.name ? `<div class="tl-item-name">${Toolbox.escapeHtml(item.name)}</div>` : '';
+                ? `<img src="${imgData}" alt="${esc(item.name || '')}">`
+                : `<div class="tl-item-text">${esc(item.name || '?')}</div>`;
+            const nameTag = item.name ? `<div class="tl-item-name">${esc(item.name)}</div>` : '';
             return `<div class="tl-item" data-item-id="${itemId}">${itemOriginBadge(item)}${itemUserLabelsHtml(item)}${inner}${nameTag}</div>`;
         }
 
@@ -244,10 +248,10 @@
         const localBadge = !isPublished && list ? '<span class="tl-badge tl-badge-local">로컬 순위</span>' : '';
         const wrapClass = `${isPublished ? 'tl-wrap tl-wrap--embedded' : 'tl-wrap'} tl-wrap--toc-dock`;
 
-        const tocChips = `${(list.tiers || []).map((tier: any) => {
-            const col = Toolbox.escapeHtml(tier.color || '#ccc');
-            const lab = Toolbox.escapeHtml(tier.label || '?');
-            const tid = Toolbox.escapeHtml(tier.id);
+        const tocChips = `${(list.tiers || []).map((tier) => {
+            const col = esc(tier.color || '#ccc');
+            const lab = esc(tier.label || '?');
+            const tid = esc(tier.id);
             return `<button type="button" class="tl-dropzone tl-toc-chip" data-tier-id="${tid}" data-toc-drop="1" style="background:${col}" title="${lab} 티어 맨 뒤로">${lab}</button>`;
         }).join('')}
                 <button type="button" class="tl-dropzone tl-toc-chip tl-toc-pool" data-tier-id="_pool" data-toc-drop="1" title="미배치 풀 맨 뒤로">미배치</button>`;
@@ -271,10 +275,10 @@
             </div>
             <div class="tl-board" id="tl-editor-board">`;
 
-        (list.tiers || []).forEach((tier: any) => {
+        (list.tiers || []).forEach((tier) => {
             const rowItems = (list.rankings?.[tier.id] || []).map(cardHtml).join('');
             html += `<div class="tl-row">
-                <div class="tl-label" style="background:${tier.color};color:#000;">${Toolbox.escapeHtml(tier.label)}</div>
+                <div class="tl-label" style="background:${tier.color};color:#000;">${esc(tier.label)}</div>
                 <div class="tl-dropzone" data-tier-id="${tier.id}">${rowItems}</div>
             </div>`;
         });
@@ -289,38 +293,41 @@
 
         editorContainer.innerHTML = html;
 
-        const wrap = editorContainer.querySelector('.tl-wrap');
+        const wrap = editorContainer.querySelector('.tl-wrap') as HTMLElement | null;
+        if (!wrap) return;
         if (editorDeleteMode) wrap.classList.add('tl-delete-mode');
 
-        function toastTierlistDrop(itemId: any, tierId: any, insertIdx: any) {
-            const item = list.items[itemId];
+        function toastTierlistDrop(itemId: string, tierId: string | undefined, insertIdx: number) {
+            const item = list!.items[itemId];
             const raw = String(item?.name || '').trim();
             const disp = raw.length > 30 ? raw.slice(0, 27) + '…' : (raw || '이름 없음');
             const tocAppend = Number(insertIdx) >= 999999;
-            let dest;
+            let dest: string;
             if (tierId === '_pool') {
                 dest = tocAppend ? '미배치 풀 맨 뒤' : '미배치';
             } else {
-                const t = (list.tiers || []).find((x: any) => x.id === tierId);
+                const t = (list!.tiers || []).find((x) => x.id === tierId);
                 const lab = String(t?.label || '').trim() || '티어';
                 dest = tocAppend ? `${lab} 맨 뒤` : lab;
             }
-            Toolbox.showToast(`「${disp}」→ ${dest}`);
+            Toolbox.showToast?.(`「${disp}」→ ${dest}`);
         }
 
         T.dnd.initDnD(wrap, {
-            onDrop: ({ itemId, tierId, insertIdx }: any) => {
-                if (T.state.moveItem(itemId, tierId, insertIdx)) toastTierlistDrop(itemId, tierId, insertIdx);
+            onDrop: ({ itemId, tierId, insertIdx }) => {
+                if (tierId && T.state.moveItem(itemId, tierId, insertIdx)) toastTierlistDrop(itemId, tierId, insertIdx);
                 renderAll();
             },
-            shouldBlockDragStart(e: any) {
+            shouldBlockDragStart(e) {
                 return editorDeleteMode || !!(e.ctrlKey || e.metaKey);
             },
         });
 
-        wrap.querySelector('.tl-toc')?.addEventListener('click', (e: any) => {
-            const chip = e.target.closest('.tl-toc-chip');
-            if (!chip || e.button !== 0) return;
+        wrap.querySelector('.tl-toc')?.addEventListener('click', (e) => {
+            const me = e as MouseEvent;
+            const target = me.target as Element | null;
+            const chip = target?.closest('.tl-toc-chip');
+            if (!chip || me.button !== 0) return;
             const tid = chip.getAttribute('data-tier-id');
             if (!tid) return;
             if (tid === '_pool') {
@@ -328,32 +335,34 @@
                 return;
             }
             const board = wrap.querySelector('#tl-editor-board');
-            const dz = board && [...board.querySelectorAll('.tl-dropzone[data-tier-id]')].find((z: any) => z.getAttribute('data-tier-id') === tid && !z.classList.contains('tl-toc-chip'));
+            const dz = board && [...board.querySelectorAll('.tl-dropzone[data-tier-id]')].find((z) => z.getAttribute('data-tier-id') === tid && !z.classList.contains('tl-toc-chip'));
             dz?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         });
 
         wrap.addEventListener(
             'click',
-            (e: any) => {
-                const itemEl = e.target.closest('.tl-item');
+            (e) => {
+                const me = e as MouseEvent;
+                const target = me.target as Element | null;
+                const itemEl = target?.closest('.tl-item') as HTMLElement | null;
                 if (!itemEl || itemEl.classList.contains('tl-item--static')) return;
                 const itemId = itemEl.dataset.itemId;
                 if (!itemId) return;
-                const useDelete = editorDeleteMode || e.ctrlKey || e.metaKey;
+                const useDelete = editorDeleteMode || me.ctrlKey || me.metaKey;
                 if (!useDelete) return;
-                const item = list.items[itemId];
+                const item = list!.items[itemId];
                 if (item?.tlOrigin !== 'custom') {
                     const now = Date.now();
                     if (now - lastQuickDeleteBlockedToastAt > 2000) {
                         lastQuickDeleteBlockedToastAt = now;
-                        Toolbox.showToast('풀 출처 카드는 삭제할 수 없어요. 직접 추가한 카드만 삭제 모드·Ctrl+클릭으로 지울 수 있어요.', 'error');
+                        Toolbox.showToast?.('풀 출처 카드는 삭제할 수 없어요. 직접 추가한 카드만 삭제 모드·Ctrl+클릭으로 지울 수 있어요.', 'error');
                     }
                     return;
                 }
-                e.preventDefault();
-                e.stopPropagation();
+                me.preventDefault();
+                me.stopPropagation();
                 if (!T.state.removeItem(itemId)) {
-                    Toolbox.showToast('후보 풀 카드는 삭제할 수 없어요.', 'error');
+                    Toolbox.showToast?.('후보 풀 카드는 삭제할 수 없어요.', 'error');
                     return;
                 }
                 renderAll();
@@ -363,53 +372,56 @@
 
         bindListSelectChange();
 
-        editorContainer.querySelector('#tl-btn-tiers')?.addEventListener('click', T.dialogs.showTierSettingsDialog);
-        editorContainer.querySelector('#tl-btn-userlabels')?.addEventListener('click', T.dialogs.showUserLabelsManagerDialog);
-        editorContainer.querySelector('#tl-btn-add')?.addEventListener('click', T.dialogs.showAddItemDialog);
+        editorContainer.querySelector('#tl-btn-tiers')?.addEventListener('click', () => T.dialogs.showTierSettingsDialog?.());
+        editorContainer.querySelector('#tl-btn-userlabels')?.addEventListener('click', () => T.dialogs.showUserLabelsManagerDialog?.());
+        editorContainer.querySelector('#tl-btn-add')?.addEventListener('click', () => T.dialogs.showAddItemDialog?.());
         editorContainer.querySelector('#tl-btn-delete-mode')?.addEventListener('click', () => {
             editorDeleteMode = !editorDeleteMode;
             renderAll();
         });
-        editorContainer.querySelector('#tl-btn-export-img')?.addEventListener('click', T.publish.exportAsImage);
+        editorContainer.querySelector('#tl-btn-export-img')?.addEventListener('click', () => T.publish.exportAsImage());
         editorContainer.querySelector('#tl-btn-export-json')?.addEventListener('click', () => T.publish.showJsonPreview());
 
-        wrap.addEventListener('contextmenu', (e: any) => {
-            const itemEl = e.target.closest('.tl-item');
+        wrap.addEventListener('contextmenu', (e) => {
+            const me = e as MouseEvent;
+            const target = me.target as Element | null;
+            const itemEl = target?.closest('.tl-item') as HTMLElement | null;
             if (!itemEl) return;
-            e.preventDefault();
+            me.preventDefault();
             const itemId = itemEl.dataset.itemId;
-            const menu: any[] = [
-                { label: '편집', action: () => T.dialogs.showEditItemDialog(itemId) },
-                { label: '라벨…', action: () => T.dialogs.showAssignUserLabelsDialog(itemId) },
+            if (!itemId) return;
+            const menu: Array<{ label: string; danger?: boolean; action: () => void } | 'sep'> = [
+                { label: '편집', action: () => T.dialogs.showEditItemDialog?.(itemId) },
+                { label: '라벨…', action: () => T.dialogs.showAssignUserLabelsDialog?.(itemId) },
             ];
-            if (T.state.canResetItemFromPool(list, itemId)) {
+            if (T.state.canResetItemFromPool(list!, itemId)) {
                 menu.push({
                     label: '수정 초기화',
                     action: () => {
-                        T.publish.resetItemToCatalogDefault(itemId).then((ok: any) => { if (ok) renderAll(); });
+                        T.publish.resetItemToCatalogDefault(itemId).then((ok) => { if (ok) renderAll(); });
                     },
                 });
             }
-            if (T.state.isItemRemovable(list, itemId)) {
+            if (T.state.isItemRemovable(list!, itemId)) {
                 menu.push('sep');
                 menu.push({
                     label: '삭제',
                     danger: true,
                     action: () => {
                         if (!T.state.removeItem(itemId)) {
-                            Toolbox.showToast('삭제할 수 없어요.', 'error');
+                            Toolbox.showToast?.('삭제할 수 없어요.', 'error');
                             return;
                         }
                         renderAll();
                     },
                 });
             }
-            T.ui.showContextMenu(e.clientX, e.clientY, menu);
+            T.ui.showContextMenu(me.clientX, me.clientY, menu);
         });
 
         if (!editorDeleteModeEscBound) {
             editorDeleteModeEscBound = true;
-            document.addEventListener('keydown', (ev: any) => {
+            document.addEventListener('keydown', (ev) => {
                 if (ev.key !== 'Escape' || !editorDeleteMode) return;
                 editorDeleteMode = false;
                 renderAll();
@@ -419,6 +431,7 @@
 
     function renderListTab() {
         if (!listContainer) return;
+        const esc = Toolbox.escapeHtml ?? ((s: string) => s);
         const st = T.state.getState();
         const meta = T.state.currentMeta();
 
@@ -450,16 +463,16 @@
 
         listContainer.innerHTML = html;
 
-        listContainer.querySelector('#tl-list-new-cat')?.addEventListener('click', T.dialogs.showNewCatalogDialog);
-        listContainer.querySelector('#tl-list-new')?.addEventListener('click', T.dialogs.showNewListDialog);
-        listContainer.querySelector('#tl-list-import')?.addEventListener('click', T.publish.importFromJSONFilePicker);
+        listContainer.querySelector('#tl-list-new-cat')?.addEventListener('click', () => T.dialogs.showNewCatalogDialog?.());
+        listContainer.querySelector('#tl-list-new')?.addEventListener('click', () => T.dialogs.showNewListDialog?.());
+        listContainer.querySelector('#tl-list-import')?.addEventListener('click', () => T.publish.importFromJSONFilePicker());
 
         const gridEmbedCatalog = listContainer.querySelector('#tl-grid-embed-catalog');
         const gridEmbedKarmo = listContainer.querySelector('#tl-grid-embed-karmo');
         const gridLocalPools = listContainer.querySelector('#tl-grid-local-pools');
         const instGrid = listContainer.querySelector('#tl-grid-instances');
 
-        async function embedIndexCardHtml(it: any) {
+        async function embedIndexCardHtml(it: TlPublishedIndexItem): Promise<string> {
             const title = it.title || it.id || 'tierlist';
             const rel = it.url || '';
             const grp = publishedIndexGroup(it);
@@ -469,30 +482,30 @@
                 try { countLine = await T.publish.getPublishedPreviewCountLine(rel); } catch (_) { /* 무시 */ }
             }
             const metaLine = countLine
-                ? `${Toolbox.escapeHtml(countLine)} · ${Toolbox.escapeHtml(it.updatedAt || '—')}`
-                : `index.json · ${Toolbox.escapeHtml(it.updatedAt || '—')}`;
+                ? `${esc(countLine)} · ${esc(it.updatedAt || '—')}`
+                : `index.json · ${esc(it.updatedAt || '—')}`;
             const pillClass = grp === 'karmo' ? 'tl-pill-karmo' : 'tl-pill-catalog';
             const pillLabel = grp === 'karmo' ? 'Karmo 순위' : '카탈로그';
             const karmoCls = grp === 'karmo' ? ' tl-list-card-embed--karmo' : '';
-            return `<div class="tl-list-card tl-list-card-embed${karmoCls}${activeEmbed ? ' active' : ''}" data-embed-url="${Toolbox.escapeHtml(rel)}" data-embed-title="${Toolbox.escapeHtml(title)}" data-embed-id="${Toolbox.escapeHtml(it.id || '')}" data-embed-group="${Toolbox.escapeHtml(grp)}">
+            return `<div class="tl-list-card tl-list-card-embed${karmoCls}${activeEmbed ? ' active' : ''}" data-embed-url="${esc(rel)}" data-embed-title="${esc(title)}" data-embed-id="${esc(it.id || '')}" data-embed-group="${esc(grp)}">
                 <div class="tl-list-pill-row"><span class="tl-pill ${pillClass}">${pillLabel}</span></div>
-                <div class="tl-list-card-title">${Toolbox.escapeHtml(title)}</div>
+                <div class="tl-list-card-title">${esc(title)}</div>
                 <div class="tl-list-card-meta">${metaLine}</div>
             </div>`;
         }
 
         (async () => {
             let blogErr = false;
-            let blogItems = [];
+            let blogItems: TlPublishedIndexItem[] = [];
             try {
                 blogItems = await T.publish.getPublishedIndex();
             } catch (_) {
                 blogErr = true;
             }
 
-            const catalogItems: any[] = [];
-            const karmoItems: any[] = [];
-            blogItems.forEach((it: any) => {
+            const catalogItems: TlPublishedIndexItem[] = [];
+            const karmoItems: TlPublishedIndexItem[] = [];
+            blogItems.forEach((it) => {
                 (publishedIndexGroup(it) === 'karmo' ? karmoItems : catalogItems).push(it);
             });
 
@@ -512,14 +525,14 @@
                 }
             }
 
-            const catalogs = Object.values(st.catalogs || {}).sort((a: any, b: any) => (b.updatedAt || 0) - (a.updatedAt || 0));
+            const catalogs = Object.values(st.catalogs || {}).sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
             let catHtml = '';
-            catalogs.forEach((c: any) => {
+            catalogs.forEach((c) => {
                 const n = Object.keys(c.items || {}).length;
                 const date = new Date(c.updatedAt || Date.now());
-                catHtml += `<div class="tl-list-card tl-list-card-catalog" data-catalog-id="${Toolbox.escapeHtml(c.id)}">
+                catHtml += `<div class="tl-list-card tl-list-card-catalog" data-catalog-id="${esc(c.id)}">
                     <div class="tl-list-pill-row"><span class="tl-pill tl-pill-cache">로컬 후보 풀</span></div>
-                    <div class="tl-list-card-title">${Toolbox.escapeHtml(c.title || '(이름 없음)')}</div>
+                    <div class="tl-list-card-title">${esc(c.title || '(이름 없음)')}</div>
                     <div class="tl-list-card-meta">총 ${n}개 · ${date.toLocaleDateString()} · 클릭 시 새 순위 생성</div>
                 </div>`;
             });
@@ -538,16 +551,16 @@
                 gridLocalPools.innerHTML = catHtml || emptyLocal;
             }
 
-            const instances = Object.values(st.instances || {}).sort((a: any, b: any) => (b.updatedAt || 0) - (a.updatedAt || 0));
+            const instances = Object.values(st.instances || {}).sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
             let instHtml = '';
-            instances.forEach((inst: any) => {
+            instances.forEach((inst) => {
                 const ic = Object.keys(inst.items || {}).length;
-                const rc = Object.entries(inst.rankings || {}).filter(([k]: any) => k !== '_pool').reduce((s: any, [, arr]: any) => s + (Array.isArray(arr) ? arr.length : 0), 0);
+                const rc = Object.entries(inst.rankings || {}).filter(([k]) => k !== '_pool').reduce((s, [, arr]) => s + (Array.isArray(arr) ? arr.length : 0), 0);
                 const date = new Date(inst.updatedAt || Date.now());
                 const active = !T.state.isPublishedMode() && inst.id === st.currentInstanceId;
-                instHtml += `<div class="tl-list-card tl-list-card-instance${active ? ' active' : ''}" data-instance-id="${Toolbox.escapeHtml(inst.id)}">
+                instHtml += `<div class="tl-list-card tl-list-card-instance${active ? ' active' : ''}" data-instance-id="${esc(inst.id)}">
                     <div class="tl-list-pill-row"><span class="tl-pill tl-pill-cache">순위</span></div>
-                    <div class="tl-list-card-title">${Toolbox.escapeHtml(inst.title || '(제목 없음)')}</div>
+                    <div class="tl-list-card-title">${esc(inst.title || '(제목 없음)')}</div>
                     <div class="tl-list-card-meta">아이템 ${ic} · 배치 ${rc} · ${date.toLocaleDateString()}</div>
                 </div>`;
             });
@@ -557,7 +570,7 @@
                 instGrid.innerHTML = instHtml;
             }
 
-            listContainer.querySelectorAll('.tl-list-card-embed[data-embed-url]').forEach((card: any) => {
+            listContainer!.querySelectorAll<HTMLElement>('.tl-list-card-embed[data-embed-url]').forEach((card) => {
                 card.addEventListener('click', async () => {
                     const rel = card.getAttribute('data-embed-url');
                     if (!rel) return;
@@ -571,34 +584,35 @@
                             url: rel,
                             tierlistGroup: grp === 'karmo' ? 'karmo' : 'catalog',
                         });
-                        Toolbox.showToast('사이트 JSON을 열었어요');
+                        Toolbox.showToast?.('사이트 JSON을 열었어요');
                         await renderAll();
                         goToTierlistEditTab();
                     } catch (err) {
-                        Toolbox.showToast('불러오기 실패', 'error', err);
+                        Toolbox.showToast?.('불러오기 실패', 'error', err);
                     }
                 });
             });
 
-            gridLocalPools?.querySelectorAll('.tl-list-card-catalog[data-catalog-id]').forEach((card: any) => {
+            gridLocalPools?.querySelectorAll<HTMLElement>('.tl-list-card-catalog[data-catalog-id]').forEach((card) => {
                 card.addEventListener('click', async () => {
                     const cid = card.dataset.catalogId;
                     if (!cid) return;
                     const c = T.state.getState().catalogs[cid];
                     if (!c || !Object.keys(c.items || {}).length) {
-                        Toolbox.showToast('후보가 비어 있어요. 우클릭으로 항목을 추가하세요.', 'error');
+                        Toolbox.showToast?.('후보가 비어 있어요. 우클릭으로 항목을 추가하세요.', 'error');
                         return;
                     }
                     T.state.createInstanceFromLocalCatalog(cid);
-                    Toolbox.showToast('새 순위 인스턴스를 만들었어요');
+                    Toolbox.showToast?.('새 순위 인스턴스를 만들었어요');
                     await renderAll();
                     goToTierlistEditTab();
                 });
-                card.addEventListener('contextmenu', (e: any) => {
+                card.addEventListener('contextmenu', (e) => {
                     e.preventDefault();
                     const cid = card.dataset.catalogId;
+                    if (!cid) return;
                     T.ui.showContextMenu(e.clientX, e.clientY, [
-                        { label: '항목 추가', action: () => T.dialogs.showAddCatalogItemDialog(cid) },
+                        { label: '항목 추가', action: () => T.dialogs.showAddCatalogItemDialog?.(cid) },
                         {
                             label: '삭제',
                             danger: true,
@@ -606,14 +620,14 @@
                                 if (!confirm('이 후보 풀과 이미지를 삭제할까요?')) return;
                                 T.state.deleteCatalog(cid);
                                 void renderAll();
-                                Toolbox.showToast('후보 풀 삭제됨');
+                                Toolbox.showToast?.('후보 풀 삭제됨');
                             },
                         },
                     ]);
                 });
             });
 
-            instGrid?.querySelectorAll('.tl-list-card-instance[data-instance-id]').forEach((card: any) => {
+            instGrid?.querySelectorAll<HTMLElement>('.tl-list-card-instance[data-instance-id]').forEach((card) => {
                 card.addEventListener('click', async () => {
                     const iid = card.dataset.instanceId;
                     if (!iid) return;
@@ -621,16 +635,17 @@
                     await renderAll();
                     goToTierlistEditTab();
                 });
-                card.addEventListener('contextmenu', (e: any) => {
+                card.addEventListener('contextmenu', (e) => {
                     e.preventDefault();
                     const iid = card.dataset.instanceId;
+                    if (!iid) return;
                     T.ui.showContextMenu(e.clientX, e.clientY, [
                         {
                             label: '복제',
                             action: () => {
                                 T.state.duplicateList(iid);
                                 void renderAll().then(() => goToTierlistEditTab());
-                                Toolbox.showToast('복제됨');
+                                Toolbox.showToast?.('복제됨');
                             },
                         },
                         {
@@ -640,7 +655,7 @@
                                 if (!confirm('이 순위와 이미지를 삭제할까요?')) return;
                                 T.state.deleteList(iid);
                                 void renderAll().then(() => goToTierlistEditTab());
-                                Toolbox.showToast('삭제됨');
+                                Toolbox.showToast?.('삭제됨');
                             },
                         },
                     ]);
@@ -651,6 +666,7 @@
 
     function renderStats() {
         if (!statsContainer) return;
+        const esc = Toolbox.escapeHtml ?? ((s: string) => s);
         const bundles = T.state.iterAllInstances();
 
         if (!bundles.length) {
@@ -661,10 +677,10 @@
         let totalItems = 0, totalRanked = 0;
         const tierCounts: Record<string, { count: number; color: string }> = {};
 
-        bundles.forEach(({ list: l }: any) => {
+        bundles.forEach(({ list: l }) => {
             const itemCount = Object.keys(l.items || {}).length;
             totalItems += itemCount;
-            (l.tiers || []).forEach((t: any) => {
+            (l.tiers || []).forEach((t) => {
                 const count = (l.rankings?.[t.id] || []).length;
                 totalRanked += count;
                 const key = String(t.label || t.id || '?').toUpperCase();
@@ -673,7 +689,7 @@
             });
         });
 
-        const maxCount = Math.max(1, ...Object.values(tierCounts).map((v: any) => v.count));
+        const maxCount = Math.max(1, ...Object.values(tierCounts).map((v) => v.count));
 
         let html = `<div class="tl-stats">
             <div class="tl-stat-cards">
@@ -688,8 +704,8 @@
         for (const [label, { count, color }] of Object.entries(tierCounts)) {
             const pct = Math.round((count / maxCount) * 100);
             html += `<div class="tl-bar-row">
-                <div class="tl-bar-label" style="color:${Toolbox.escapeHtml(color)}">${Toolbox.escapeHtml(label)}</div>
-                <div class="tl-bar-track"><div class="tl-bar-fill" style="width:${pct}%;background:${Toolbox.escapeHtml(color)};"><span class="tl-bar-count">${count}</span></div></div>
+                <div class="tl-bar-label" style="color:${esc(color)}">${esc(label)}</div>
+                <div class="tl-bar-track"><div class="tl-bar-fill" style="width:${pct}%;background:${esc(color)};"><span class="tl-bar-count">${count}</span></div></div>
             </div>`;
         }
 
@@ -700,7 +716,7 @@
                     <thead><tr><th>출처</th><th>제목</th><th>카테고리</th><th>아이템</th><th>배치</th><th>최근 수정</th></tr></thead>
                     <tbody>`;
 
-        function sourceLabel(l: any) {
+        function sourceLabel(l: TlListInstance): string {
             const s = l.meta?.source || 'local';
             if (s === 'from-local-catalog') return '로컬 후보 풀';
             if (s === 'from-catalog') return '사이트 후보 풀';
@@ -710,13 +726,13 @@
             return s;
         }
 
-        bundles.sort((a: any, b: any) => (b.list.updatedAt || 0) - (a.list.updatedAt || 0)).forEach(({ list: l }: any) => {
+        bundles.sort((a, b) => (b.list.updatedAt || 0) - (a.list.updatedAt || 0)).forEach(({ list: l }) => {
             const ic = Object.keys(l.items || {}).length;
-            const rc = Object.entries(l.rankings || {}).filter(([k]: any) => k !== '_pool').reduce((s: any, [, arr]: any) => s + (Array.isArray(arr) ? arr.length : 0), 0);
+            const rc = Object.entries(l.rankings || {}).filter(([k]) => k !== '_pool').reduce((s, [, arr]) => s + (Array.isArray(arr) ? arr.length : 0), 0);
             html += `<tr>
-                <td>${Toolbox.escapeHtml(sourceLabel(l))}</td>
-                <td>${Toolbox.escapeHtml(l.title || '(제목 없음)')}</td>
-                <td>${Toolbox.escapeHtml(l.category || '-')}</td>
+                <td>${esc(sourceLabel(l))}</td>
+                <td>${esc(l.title || '(제목 없음)')}</td>
+                <td>${esc(l.category || '-')}</td>
                 <td>${ic}</td>
                 <td>${rc}</td>
                 <td>${new Date(l.updatedAt || Date.now()).toLocaleDateString()}</td>
@@ -742,4 +758,3 @@
         publishedIndexGroup,
     };
 })();
-

--- a/apps/karmolab/src/widgets/tierlist/storage.ts
+++ b/apps/karmolab/src/widgets/tierlist/storage.ts
@@ -1,9 +1,9 @@
 (function () {
-    const T: any = (window.Tierlist = window.Tierlist || {});
+    const T = ((window.Tierlist = window.Tierlist || {}) as unknown) as TierlistNamespace;
 
     const STORAGE_KEY = 'toolbox_tierlists';
 
-    const DEFAULT_TIERS = [
+    const DEFAULT_TIERS: TlTierDef[] = [
         { id: 's', label: 'S', color: '#ff7f7f' },
         { id: 'a', label: 'A', color: '#ffbf7f' },
         { id: 'b', label: 'B', color: '#ffdf7f' },
@@ -12,69 +12,71 @@
         { id: 'f', label: 'F', color: '#7fbfff' },
     ];
 
-    const TierDB = (() => {
+    const TierDB: TlDbAPI = (() => {
         const DB_NAME = 'toolbox_tierlist_images';
         const STORE = 'images';
         const VER = 1;
-        const cache = new Map<string, any>();
+        const cache = new Map<string, string>();
 
         function open(): Promise<IDBDatabase> {
-            return new Promise((res, rej) => {
+            return new Promise<IDBDatabase>((resolve, reject) => {
                 const r = indexedDB.open(DB_NAME, VER);
-                r.onupgradeneeded = (e: any) => {
-                    const db = e.target.result;
+                r.onupgradeneeded = () => {
+                    const db = r.result;
                     if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE, { keyPath: 'id' });
                 };
-                r.onsuccess = () => res(r.result);
-                r.onerror = () => rej(r.error);
+                r.onsuccess = () => resolve(r.result);
+                r.onerror = () => reject(r.error);
             });
         }
 
-        async function save(id: any, dataUrl: any) {
+        async function save(id: string, dataUrl: string): Promise<void> {
             const db = await open();
             try {
-                await new Promise((res: any, rej: any) => {
+                await new Promise<void>((resolve, reject) => {
                     const tx = db.transaction(STORE, 'readwrite');
                     tx.objectStore(STORE).put({ id, dataUrl });
-                    tx.oncomplete = () => res();
-                    tx.onerror = () => rej(tx.error);
+                    tx.oncomplete = () => resolve();
+                    tx.onerror = () => reject(tx.error);
                 });
                 cache.set(id, dataUrl);
             } finally { db.close(); }
         }
 
-        async function get(id: any) {
-            if (cache.has(id)) return cache.get(id);
+        async function get(id: string): Promise<string | null> {
+            const cached = cache.get(id);
+            if (cached !== undefined) return cached;
             const db = await open();
             try {
-                const item: any = await new Promise((res: any, rej: any) => {
+                const item = await new Promise<{ id: string; dataUrl?: string } | undefined>((resolve, reject) => {
                     const tx = db.transaction(STORE, 'readonly');
                     const req = tx.objectStore(STORE).get(id);
-                    req.onsuccess = () => res(req.result);
-                    req.onerror = () => rej(req.error);
+                    req.onsuccess = () => resolve(req.result as { id: string; dataUrl?: string } | undefined);
+                    req.onerror = () => reject(req.error);
                 });
                 if (item?.dataUrl) { cache.set(id, item.dataUrl); return item.dataUrl; }
                 return null;
             } finally { db.close(); }
         }
 
-        async function remove(id: any) {
+        async function remove(id: string): Promise<void> {
             cache.delete(id);
             const db = await open();
             try {
-                await new Promise((res: any, rej: any) => {
+                await new Promise<void>((resolve, reject) => {
                     const tx = db.transaction(STORE, 'readwrite');
                     tx.objectStore(STORE).delete(id);
-                    tx.oncomplete = () => res();
-                    tx.onerror = () => rej(tx.error);
+                    tx.oncomplete = () => resolve();
+                    tx.onerror = () => reject(tx.error);
                 });
             } finally { db.close(); }
         }
 
-        async function getMany(ids: any) {
-            const results: Record<string, any> = {};
-            const missing = ids.filter((id: any) => {
-                if (cache.has(id)) { results[id] = cache.get(id); return false; }
+        async function getMany(ids: string[]): Promise<Record<string, string>> {
+            const results: Record<string, string> = {};
+            const missing = ids.filter((id) => {
+                const c = cache.get(id);
+                if (c !== undefined) { results[id] = c; return false; }
                 return true;
             });
             if (!missing.length) return results;
@@ -83,16 +85,17 @@
             try {
                 const tx = db.transaction(STORE, 'readonly');
                 const store = tx.objectStore(STORE);
-                await Promise.all(missing.map((id: any) => new Promise((res: any, rej: any) => {
+                await Promise.all(missing.map((id) => new Promise<void>((resolve, reject) => {
                     const req = store.get(id);
                     req.onsuccess = () => {
-                        if (req.result?.dataUrl) {
-                            cache.set(id, req.result.dataUrl);
-                            results[id] = req.result.dataUrl;
+                        const row = req.result as { dataUrl?: string } | undefined;
+                        if (row?.dataUrl) {
+                            cache.set(id, row.dataUrl);
+                            results[id] = row.dataUrl;
                         }
-                        res();
+                        resolve();
                     };
-                    req.onerror = () => rej(req.error);
+                    req.onerror = () => reject(req.error);
                 })));
             } finally { db.close(); }
             return results;
@@ -101,15 +104,16 @@
         return { save, get, remove, getMany };
     })();
 
-    let state: any = { catalogs: {}, instances: {}, currentInstanceId: null };
-    let publishedCurrent: any = null;
+    let state: TlState = { catalogs: {}, instances: {}, currentInstanceId: null };
+    let publishedCurrent: TlPublishedCurrent | null = null;
 
     function uid() { return Date.now().toString(36) + Math.random().toString(36).slice(2, 8); }
 
-    function isCatalogPayload(data: any) {
+    function isCatalogPayload(data: unknown): boolean {
         if (!data || typeof data !== 'object') return false;
-        if (data.kind === 'catalog') return true;
-        if (data.version >= 2 && data.items && typeof data.items === 'object' && !data.list) return true;
+        const d = data as TlPublishedData;
+        if (d.kind === 'catalog') return true;
+        if ((d.version ?? 0) >= 2 && d.items && typeof d.items === 'object' && !d.list) return true;
         return false;
     }
 
@@ -117,22 +121,22 @@
         state.catalogs = state.catalogs || {};
         state.instances = state.instances || {};
 
-        const pickCurrentId = (preserved: any) => {
+        const pickCurrentId = (preserved: string | null | undefined) => {
             if (preserved && state.instances[preserved]) state.currentInstanceId = preserved;
             else if (!state.currentInstanceId) {
-                const first: any = Object.values(state.instances).sort((a: any, b: any) => (b.updatedAt || 0) - (a.updatedAt || 0))[0];
+                const first = Object.values(state.instances).sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))[0];
                 state.currentInstanceId = first?.id || null;
             }
         };
 
-        const ingestList = (list: any) => {
+        const ingestList = (list: TlListInstance | undefined) => {
             if (!list || !list.id) return;
-            state.instances[list.id] = JSON.parse(JSON.stringify(list));
+            state.instances[list.id] = JSON.parse(JSON.stringify(list)) as TlListInstance;
         };
 
         if (state.datasets && typeof state.datasets === 'object' && Object.keys(state.datasets).length) {
             const preserved = state.currentListId || state.currentInstanceId;
-            Object.values(state.datasets).forEach((ds: any) => {
+            Object.values(state.datasets).forEach((ds) => {
                 Object.values(ds.lists || {}).forEach(ingestList);
             });
             delete state.datasets;
@@ -152,9 +156,9 @@
         }
     }
 
-    function catalogEntryToListItem(entry: any) {
+    function catalogEntryToListItem(entry: TlItem | undefined | null): TlItem | null {
         if (!entry || typeof entry !== 'object') return null;
-        const it = JSON.parse(JSON.stringify(entry));
+        const it = JSON.parse(JSON.stringify(entry)) as TlItem;
         it.id = entry.id;
         it.tlOrigin = 'catalog';
         delete it.tlEdited;
@@ -162,7 +166,7 @@
     }
 
     /** 후보 풀 기준 되돌리기 가능 여부(로컬 풀·URL 풀·풀 출처 카드) */
-    function canResetItemFromPool(list: any, itemId: any) {
+    function canResetItemFromPool(list: TlListInstance, itemId: string): boolean {
         const it = list?.items?.[itemId];
         if (!it) return false;
         if (list.catalogId && state.catalogs[list.catalogId]?.items?.[itemId]) return true;
@@ -171,11 +175,12 @@
     }
 
     /** 연결된 후보 풀 항목으로 덮어쓰기(이름·이미지·라벨·수정 표시 제거). catalogEntry 는 풀 items[id] 원본 */
-    function applyCatalogEntryToItem(list: any, itemId: any, catalogEntry: any) {
+    function applyCatalogEntryToItem(list: TlListInstance, itemId: string, catalogEntry: TlItem): boolean {
         if (!list?.items?.[itemId] || !catalogEntry) return false;
         const old = list.items[itemId];
         const oldKey = old.imageKey ?? null;
         const stamped = catalogEntryToListItem(catalogEntry);
+        if (!stamped) return false;
         list.items[itemId] = stamped;
         const newKey = stamped.imageKey ?? null;
         if (oldKey && oldKey !== newKey) {
@@ -190,19 +195,19 @@
      * 카탈로그에 있는 id는 list.items에 없으면 채우고, 어떤 티어·_pool에도 없으면 _pool 끝에 추가.
      * @returns {boolean} 변경 여부
      */
-    function ensureAllCatalogItemsOnBoard(list: any, catalogItems: any) {
+    function ensureAllCatalogItemsOnBoard(list: TlListInstance, catalogItems: Record<string, TlItem>): boolean {
         if (!list || !catalogItems || typeof catalogItems !== 'object') return false;
         list.items = list.items || {};
         list.rankings = list.rankings || {};
         list.rankings._pool = list.rankings._pool || [];
 
-        const seenRank = new Set();
-        Object.values(list.rankings).forEach((arr: any) => {
-            (arr || []).forEach((id: any) => { if (id) seenRank.add(id); });
+        const seenRank = new Set<string>();
+        Object.values(list.rankings).forEach((arr) => {
+            (arr || []).forEach((id) => { if (id) seenRank.add(id); });
         });
 
         let changed = false;
-        Object.keys(catalogItems).forEach((id: any) => {
+        Object.keys(catalogItems).forEach((id) => {
             const src = catalogItems[id];
             if (!src || typeof src !== 'object') return;
             if (!list.items[id]) {
@@ -222,21 +227,21 @@
     }
 
     /** 동일 id가 여러 줄에 있으면 티어 표시 순·_pool 순으로 한 곳만 남김 */
-    function dedupeRankingPlacements(list: any) {
+    function dedupeRankingPlacements(list: TlListInstance): boolean {
         if (!list?.rankings) return false;
-        const seen = new Set();
-        const order: any[] = [];
-        (list.tiers || []).forEach((t: any) => order.push(t.id));
+        const seen = new Set<string>();
+        const order: string[] = [];
+        (list.tiers || []).forEach((t) => order.push(t.id));
         order.push('_pool');
-        Object.keys(list.rankings).forEach((k: any) => {
+        Object.keys(list.rankings).forEach((k) => {
             if (!order.includes(k)) order.push(k);
         });
         let changed = false;
-        order.forEach((tid: any) => {
+        order.forEach((tid) => {
             const arr = list.rankings[tid];
             if (!Array.isArray(arr)) return;
-            const next: any[] = [];
-            arr.forEach((id: any) => {
+            const next: string[] = [];
+            arr.forEach((id) => {
                 if (!id) return;
                 if (seen.has(id)) {
                     changed = true;
@@ -255,7 +260,7 @@
      * 카탈로그 items 맵과 순위 판 동기화(누락 항목·배치·중복·떠 있는 custom 정리).
      * @returns {boolean} 변경 여부
      */
-    function reconcileListWithCatalogPayload(list: any, catalogItems: any) {
+    function reconcileListWithCatalogPayload(list: TlListInstance, catalogItems: Record<string, TlItem>): boolean {
         if (!list || !catalogItems || typeof catalogItems !== 'object') return false;
         let ch = ensureAllCatalogItemsOnBoard(list, catalogItems);
         ch = dedupeRankingPlacements(list) || ch;
@@ -264,7 +269,7 @@
         return ch;
     }
 
-    function isItemRemovable(list: any, itemId: any) {
+    function isItemRemovable(list: TlListInstance, itemId: string): boolean {
         const it = list?.items?.[itemId];
         return !!(it && it.tlOrigin === 'custom');
     }
@@ -273,15 +278,15 @@
      * items에는 있는데 티어·미배치 어디에도 없는 id → _pool에 한 번만 추가.
      * @returns {boolean} 변경 여부
      */
-    function ensureFloatingItemsInPool(list: any) {
+    function ensureFloatingItemsInPool(list: TlListInstance): boolean {
         if (!list?.items) return false;
-        const seen = new Set();
-        Object.values(list.rankings || {}).forEach((arr: any) => {
-            (arr || []).forEach((id: any) => { if (id) seen.add(id); });
+        const seen = new Set<string>();
+        Object.values(list.rankings || {}).forEach((arr) => {
+            (arr || []).forEach((id) => { if (id) seen.add(id); });
         });
         const pool = list.rankings._pool = list.rankings._pool || [];
         let changed = false;
-        Object.keys(list.items).forEach((id: any) => {
+        Object.keys(list.items).forEach((id) => {
             if (seen.has(id)) return;
             if (!pool.includes(id)) {
                 pool.push(id);
@@ -299,7 +304,7 @@
         const catalogs = state.catalogs || {};
         const instances = state.instances || {};
         let any = false;
-        Object.values(instances).forEach((list: any) => {
+        Object.values(instances).forEach((list) => {
             if (!list?.id) return;
             let changed = false;
             const cid = list.catalogId;
@@ -307,12 +312,12 @@
                 delete list.catalogId;
                 changed = true;
                 const pool = list.rankings._pool = list.rankings._pool || [];
-                Object.keys(list.items || {}).forEach((itemId: any) => {
+                Object.keys(list.items || {}).forEach((itemId) => {
                     const it = list.items[itemId];
                     if (!it || it.tlOrigin !== 'catalog') return;
                     it.tlOrigin = 'custom';
                     delete it.tlEdited;
-                    Object.keys(list.rankings || {}).forEach((tid: any) => {
+                    Object.keys(list.rankings || {}).forEach((tid) => {
                         if (tid === '_pool') return;
                         const arr = list.rankings[tid];
                         if (!Array.isArray(arr)) return;
@@ -335,7 +340,7 @@
     function reconcileInstancesWithLinkedCatalogs() {
         const catalogs = state.catalogs || {};
         let any = false;
-        Object.values(state.instances || {}).forEach((list: any) => {
+        Object.values(state.instances || {}).forEach((list) => {
             if (!list?.catalogId || !catalogs[list.catalogId]) return;
             const catItems = catalogs[list.catalogId].items || {};
             let ch = false;
@@ -349,14 +354,14 @@
         if (any) saveState();
     }
 
-    function touchInstance(list: any) {
+    function touchInstance(list: TlListInstance | null | undefined) {
         if (list) list.updatedAt = Date.now();
     }
 
     function loadState() {
         try {
             const raw = localStorage.getItem(STORAGE_KEY);
-            if (raw) state = JSON.parse(raw);
+            if (raw) state = JSON.parse(raw) as TlState;
         } catch (_) {}
         migrateIfNeeded();
         state.catalogs = state.catalogs || {};
@@ -364,7 +369,7 @@
         migrateDetachedCatalogInstances();
         reconcileInstancesWithLinkedCatalogs();
         if (state.currentInstanceId && !state.instances[state.currentInstanceId]) {
-            const next: any = Object.values(state.instances).sort((a: any, b: any) => (b.updatedAt || 0) - (a.updatedAt || 0))[0];
+            const next = Object.values(state.instances).sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))[0];
             state.currentInstanceId = next?.id || null;
         }
     }
@@ -373,24 +378,24 @@
         try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); } catch (_) {}
     }
 
-    function iterAllInstances() {
-        return Object.values(state.instances || {}).map((list: any) => ({ list, catalogTitle: null }));
+    function iterAllInstances(): Array<{ list: TlListInstance; catalogTitle: string | null }> {
+        return Object.values(state.instances || {}).map((list) => ({ list, catalogTitle: null }));
     }
 
-    function isPublishedMode() { return !!publishedCurrent; }
+    function isPublishedMode(): boolean { return !!publishedCurrent; }
 
-    function isPublishedCatalogMode() {
+    function isPublishedCatalogMode(): boolean {
         return !!publishedCurrent && isCatalogPayload(publishedCurrent.data);
     }
 
-    function currentList() {
+    function currentList(): TlListInstance | null {
         if (publishedCurrent?.data?.list) return publishedCurrent.data.list;
-        return state.instances[state.currentInstanceId] || null;
+        return state.instances[state.currentInstanceId ?? ''] || null;
     }
 
-    function currentMeta() {
+    function currentMeta(): TlCurrentMetaView {
         const list = currentList();
-        if (isPublishedCatalogMode()) {
+        if (isPublishedCatalogMode() && publishedCurrent) {
             const d = publishedCurrent.data;
             return {
                 id: publishedCurrent.meta?.id || '',
@@ -398,7 +403,7 @@
                 source: 'published-catalog',
                 dirty: false,
                 url: publishedCurrent.meta?.url || '',
-                catalogUrl: d.meta?.catalogUrl || '',
+                catalogUrl: (d as { meta?: { catalogUrl?: string } }).meta?.catalogUrl || '',
                 tierlistGroup: String(publishedCurrent.meta?.tierlistGroup || publishedCurrent.meta?.group || 'catalog'),
             };
         }
@@ -414,7 +419,7 @@
                 tierlistGroup: String(publishedCurrent.meta?.tierlistGroup || publishedCurrent.meta?.group || ''),
             };
         }
-        const local = state.instances[state.currentInstanceId];
+        const local = state.instances[state.currentInstanceId ?? ''];
         return {
             id: local?.id || list.id,
             title: local?.title || list.title,
@@ -426,21 +431,23 @@
         };
     }
 
-    function openPublished(meta: any, data: any) { publishedCurrent = { meta: meta || {}, data }; }
+    function openPublished(meta: TlPublishedMeta | null | undefined, data: TlPublishedData) {
+        publishedCurrent = { meta: meta || {}, data };
+    }
     function closePublished() { publishedCurrent = null; }
 
-    function getPublishedCatalogSnapshot() {
+    function getPublishedCatalogSnapshot(): TlPublishedCurrent | null {
         if (!isPublishedCatalogMode()) return null;
         return publishedCurrent;
     }
 
     /** 블로그 JSON 루트의 images 맵(data URL 등). 순위(list) 열람 시 IDB에 없어도 표시용 */
-    function getPublishedEmbeddedImages() {
+    function getPublishedEmbeddedImages(): Record<string, string> {
         if (!publishedCurrent?.data?.list) return {};
         return publishedCurrent.data.images || {};
     }
 
-    function ensureWritableList(reason: any) {
+    function ensureWritableList(reason: string): TlListInstance | null {
         if (!isPublishedMode()) return currentList();
         if (isPublishedCatalogMode()) return null;
 
@@ -451,15 +458,15 @@
         const newId = 'draft-' + uid();
         const now = Date.now();
         state.instances[newId] = {
-            ...JSON.parse(JSON.stringify(src)),
+            ...(JSON.parse(JSON.stringify(src)) as TlListInstance),
             id: newId,
             createdAt: now,
             updatedAt: now,
             meta: {
                 ...(src.meta || {}),
                 source: 'published-draft',
-                publishedId: publishedCurrent.meta?.id || '',
-                publishedUrl: publishedCurrent.meta?.url || '',
+                publishedId: publishedCurrent?.meta?.id || '',
+                publishedUrl: publishedCurrent?.meta?.url || '',
                 dirty: true,
                 dirtyReason: reason || '',
             },
@@ -471,9 +478,9 @@
     }
 
     /** 후보 풀에서 복사한 항목에 tlOrigin= catalog (뱃지용) */
-    function stampItemsFromCatalog(itemsRaw: any) {
-        const items = JSON.parse(JSON.stringify(itemsRaw || {}));
-        Object.values(items).forEach((it: any) => {
+    function stampItemsFromCatalog(itemsRaw: Record<string, TlItem> | undefined): Record<string, TlItem> {
+        const items = JSON.parse(JSON.stringify(itemsRaw || {})) as Record<string, TlItem>;
+        Object.values(items).forEach((it) => {
             if (it && typeof it === 'object') {
                 it.tlOrigin = 'catalog';
                 delete it.tlEdited;
@@ -483,20 +490,20 @@
     }
 
     /** 블로그 등에서 연 순수 후보 풀 → 로컬 순위 인스턴스 1개 생성(이미지는 publish에서 주입) */
-    function forkInstanceFromCatalogData(catalogData: any, meta: any) {
+    function forkInstanceFromCatalogData(catalogData: TlPublishedData, meta: TlPublishedMeta | undefined): TlListInstance {
         closePublished();
         const id = 'tl-' + uid();
         const now = Date.now();
-        const tiers = DEFAULT_TIERS.map((t: any) => ({ ...t }));
-        const rankings: any = {};
-        tiers.forEach((t: any) => { rankings[t.id] = []; });
+        const tiers: TlTierDef[] = DEFAULT_TIERS.map((t) => ({ ...t }));
+        const rankings: TlRankingMap = {};
+        tiers.forEach((t) => { rankings[t.id] = []; });
         rankings._pool = [];
-        const items = stampItemsFromCatalog(catalogData.items || {});
-        Object.keys(items).forEach((k: any) => rankings._pool.push(k));
+        const items = stampItemsFromCatalog(catalogData.items);
+        Object.keys(items).forEach((k) => rankings._pool.push(k));
         state.instances[id] = {
             id,
             title: `${meta?.title || catalogData.title || '순위'} · 순위`,
-            category: catalogData.category || '',
+            category: typeof catalogData.category === 'string' ? catalogData.category : '',
             createdAt: now,
             updatedAt: now,
             tiers,
@@ -514,14 +521,14 @@
         return state.instances[id];
     }
 
-    function switchToInstance(instanceId: any) {
+    function switchToInstance(instanceId: string) {
         closePublished();
         if (!state.instances[instanceId]) return;
         state.currentInstanceId = instanceId;
         saveState();
     }
 
-    function createCatalog(title: any, category: any) {
+    function createCatalog(title: string, category: string): string {
         closePublished();
         const id = 'cat-' + uid();
         const now = Date.now();
@@ -536,12 +543,12 @@
         return id;
     }
 
-    function deleteCatalog(catalogId: any) {
+    function deleteCatalog(catalogId: string) {
         closePublished();
         const c = state.catalogs[catalogId];
         if (!c) return;
         try {
-            Object.values(c.items || {}).forEach((it: any) => {
+            Object.values(c.items || {}).forEach((it) => {
                 if (it?.imageKey) TierDB.remove(it.imageKey);
             });
         } catch (_) {}
@@ -551,7 +558,7 @@
         reconcileInstancesWithLinkedCatalogs();
     }
 
-    function addCatalogItem(catalogId: any, name: any, imageKey: any) {
+    function addCatalogItem(catalogId: string, name: string, imageKey: string | null): string | null {
         closePublished();
         const c = state.catalogs[catalogId];
         if (!c) return null;
@@ -563,7 +570,7 @@
         return id;
     }
 
-    function removeCatalogItem(catalogId: any, itemId: any) {
+    function removeCatalogItem(catalogId: string, itemId: string) {
         closePublished();
         const c = state.catalogs[catalogId];
         if (!c?.items?.[itemId]) return;
@@ -574,18 +581,18 @@
         saveState();
     }
 
-    function createInstanceFromLocalCatalog(catalogId: any) {
+    function createInstanceFromLocalCatalog(catalogId: string): string | null {
         closePublished();
         const c = state.catalogs[catalogId];
         if (!c) return null;
         const id = 'tl-' + uid();
         const now = Date.now();
-        const tiers = DEFAULT_TIERS.map((t: any) => ({ ...t }));
-        const rankings: any = {};
-        tiers.forEach((t: any) => { rankings[t.id] = []; });
+        const tiers: TlTierDef[] = DEFAULT_TIERS.map((t) => ({ ...t }));
+        const rankings: TlRankingMap = {};
+        tiers.forEach((t) => { rankings[t.id] = []; });
         rankings._pool = [];
         const items = stampItemsFromCatalog(c.items || {});
-        Object.keys(items).forEach((k: any) => rankings._pool.push(k));
+        Object.keys(items).forEach((k) => rankings._pool.push(k));
         state.instances[id] = {
             id,
             title: `${c.title || '순위'} · 순위`,
@@ -604,13 +611,13 @@
         return id;
     }
 
-    function createList(title: any, category: any) {
+    function createList(title: string, category: string): string {
         closePublished();
         const id = 'tl-' + uid();
         const now = Date.now();
-        const tiers = DEFAULT_TIERS.map((t: any) => ({ ...t }));
-        const rankings: any = {};
-        tiers.forEach((t: any) => { rankings[t.id] = []; });
+        const tiers: TlTierDef[] = DEFAULT_TIERS.map((t) => ({ ...t }));
+        const rankings: TlRankingMap = {};
+        tiers.forEach((t) => { rankings[t.id] = []; });
         rankings._pool = [];
         state.instances[id] = {
             id,
@@ -629,7 +636,7 @@
         return id;
     }
 
-    function addItem(name: any, imageKey: any) {
+    function addItem(name: string, imageKey: string | null): string | null {
         const list = ensureWritableList('addItem') || currentList();
         if (!list) return null;
         const id = 'ti-' + uid();
@@ -641,14 +648,14 @@
         return id;
     }
 
-    function removeItem(itemId: any) {
+    function removeItem(itemId: string): boolean {
         const list = ensureWritableList('removeItem') || currentList();
         if (!list?.items?.[itemId]) return false;
         if (list.items[itemId].tlOrigin !== 'custom') return false;
         const imgKey = list.items[itemId].imageKey;
         if (imgKey) TierDB.remove(imgKey);
         delete list.items[itemId];
-        Object.values(list.rankings || {}).forEach((arr: any) => {
+        Object.values(list.rankings || {}).forEach((arr) => {
             const idx = arr.indexOf(itemId);
             if (idx !== -1) arr.splice(idx, 1);
         });
@@ -658,12 +665,12 @@
     }
 
     /** @returns {boolean} */
-    function moveItem(itemId: any, targetTier: any, insertIdx: any) {
+    function moveItem(itemId: string, targetTier: string, insertIdx: number | undefined): boolean {
         const list = ensureWritableList('moveItem') || currentList();
         if (!list) return false;
         const target = list.rankings[targetTier];
         if (!Array.isArray(target)) return false;
-        Object.values(list.rankings || {}).forEach((arr: any) => {
+        Object.values(list.rankings || {}).forEach((arr) => {
             const idx = arr.indexOf(itemId);
             if (idx !== -1) arr.splice(idx, 1);
         });
@@ -676,34 +683,32 @@
 
     /**
      * 티어 행(라벨·색·순서·개수) 변경. 사라진 티어에 있던 카드는 미배치로 이동.
-     * @param {object} list — ensureWritableList 이후의 순위 인스턴스
-     * @param {{id:string,label:string,color:string}[]} tiersInOrder — 위에서 아래 표시 순
      */
-    function applyTiers(list: any, tiersInOrder: any) {
+    function applyTiers(list: TlListInstance, tiersInOrder: TlTierDef[]): boolean {
         if (!list || !Array.isArray(tiersInOrder) || tiersInOrder.length === 0) return false;
         const maxTiers = 16;
-        const raw = tiersInOrder.slice(0, maxTiers).map((t: any) => ({
+        const raw = tiersInOrder.slice(0, maxTiers).map((t) => ({
             id: String(t.id || '').trim(),
             label: String(t.label || '').trim() || '?',
             color: String(t.color || '#999999').trim() || '#999999',
         }));
-        const used = new Set();
-        const clean = [];
+        const used = new Set<string>();
+        const clean: TlTierDef[] = [];
         for (const t of raw) {
             let id = t.id || ('tr-' + uid());
             while (!id || used.has(id)) id = 'tr-' + uid();
             used.add(id);
             clean.push({ id, label: t.label, color: t.color });
         }
-        const newIdSet = new Set(clean.map((t: any) => t.id));
+        const newIdSet = new Set(clean.map((t) => t.id));
         const oldR = list.rankings || {};
         const pool = [...(oldR._pool || [])];
-        Object.keys(oldR).forEach((tid: any) => {
+        Object.keys(oldR).forEach((tid) => {
             if (tid === '_pool' || newIdSet.has(tid)) return;
             pool.push(...(oldR[tid] || []));
         });
-        const newR: any = { _pool: pool };
-        clean.forEach((t: any) => {
+        const newR: TlRankingMap = { _pool: pool };
+        clean.forEach((t) => {
             newR[t.id] = [...(oldR[t.id] || [])];
         });
         list.tiers = clean;
@@ -716,12 +721,11 @@
     /**
      * 카탈로그 items에 id가 없으면(삭제·동기화 등) 직접 추가(custom)로만 취급.
      * itemOverrides만 있던·tlOrigin 미표기 등도 포함해 catalog 잔존 표시를 걷어냄.
-     * @returns {boolean} 변경 여부
      */
-    function promoteCatalogMissingToCustom(list: any, catalogItemIdSet: any) {
+    function promoteCatalogMissingToCustom(list: TlListInstance, catalogItemIdSet: Set<string>): boolean {
         if (!list?.items || !(catalogItemIdSet instanceof Set)) return false;
         let changed = false;
-        Object.keys(list.items).forEach((id: any) => {
+        Object.keys(list.items).forEach((id) => {
             const it = list.items[id];
             if (!it || it.tlOrigin === 'custom' || catalogItemIdSet.has(id)) return;
             it.tlOrigin = 'custom';
@@ -734,28 +738,27 @@
     /**
      * 카탈로그가 갱신·축소된 뒤: 풀에 없는 id는 후보 풀 출처가 아닌 것으로 보고 제거.
      * tlOrigin === 'custom' 인 항목(직접 추가)만 풀 밖 id를 유지한다.
-     * @returns {boolean} 변경 여부
      */
-    function pruneStaleCatalogBindings(list: any, catalogItems: any) {
+    function pruneStaleCatalogBindings(list: TlListInstance, catalogItems: Record<string, TlItem>): boolean {
         if (!list?.items || !catalogItems || typeof catalogItems !== 'object') return false;
         const catIds = new Set(Object.keys(catalogItems));
         let changed = false;
-        const toDrop: any[] = [];
-        Object.keys(list.items).forEach((id: any) => {
+        const toDrop: string[] = [];
+        Object.keys(list.items).forEach((id) => {
             const it = list.items[id];
             if (!it) return;
             if (it.tlOrigin === 'custom') return;
             if (catIds.has(id)) return;
             toDrop.push(id);
         });
-        toDrop.forEach((id: any) => {
+        toDrop.forEach((id) => {
             const it = list.items[id];
             const imgKey = it?.imageKey;
             if (imgKey) {
                 try { TierDB.remove(imgKey); } catch (_) {}
             }
             delete list.items[id];
-            Object.values(list.rankings || {}).forEach((arr: any) => {
+            Object.values(list.rankings || {}).forEach((arr) => {
                 if (!Array.isArray(arr)) return;
                 for (let i = arr.length - 1; i >= 0; i--) {
                     if (arr[i] === id) {
@@ -767,10 +770,10 @@
             changed = true;
         });
         const valid = new Set(Object.keys(list.items || {}));
-        Object.keys(list.rankings || {}).forEach((tid: any) => {
+        Object.keys(list.rankings || {}).forEach((tid) => {
             const arr = list.rankings[tid];
             if (!Array.isArray(arr)) return;
-            const next = arr.filter((x: any) => valid.has(x));
+            const next = arr.filter((x) => valid.has(x));
             if (next.length !== arr.length) changed = true;
             list.rankings[tid] = next;
         });
@@ -778,20 +781,20 @@
         return changed;
     }
 
-    function persistList(list: any) {
+    function persistList(list: TlListInstance | null) {
         if (!list) return;
         touchInstance(list);
         saveState();
     }
 
-    function repairOrphanRankings() {
+    function repairOrphanRankings(): boolean {
         const list = ensureWritableList('integrityRepair') || currentList();
         if (!list) return false;
         const valid = new Set(Object.keys(list.items || {}));
         let changed = false;
-        Object.keys(list.rankings || {}).forEach((k: any) => {
+        Object.keys(list.rankings || {}).forEach((k) => {
             const arr = list.rankings[k] || [];
-            const next = arr.filter((id: any) => valid.has(id));
+            const next = arr.filter((id) => valid.has(id));
             if (next.length !== arr.length) changed = true;
             list.rankings[k] = next;
         });
@@ -802,22 +805,22 @@
         return changed;
     }
 
-    function repairDeleteItemsByIds(itemIds: any) {
+    function repairDeleteItemsByIds(itemIds: string[]): number {
         if (!itemIds?.length) return 0;
         ensureWritableList('integrityRepair') || currentList();
         let n = 0;
-        itemIds.forEach((id: any) => {
+        itemIds.forEach((id) => {
             if (removeItem(id)) n++;
         });
         return n;
     }
 
-    function repairMarkStaleAsLocalItems(itemIds: any) {
+    function repairMarkStaleAsLocalItems(itemIds: string[]): number {
         if (!itemIds?.length) return 0;
         const list = ensureWritableList('integrityRepair') || currentList();
         if (!list) return 0;
         let n = 0;
-        itemIds.forEach((id: any) => {
+        itemIds.forEach((id) => {
             if (!list.items[id]) return;
             list.items[id].tlOrigin = 'custom';
             list.items[id].tlEdited = true;
@@ -828,22 +831,22 @@
         return n;
     }
 
-    function ensureListUserLabels(list: any) {
+    function ensureListUserLabels(list: TlListInstance | null) {
         if (!list || typeof list !== 'object') return;
         if (!list.userLabels || typeof list.userLabels !== 'object') list.userLabels = {};
     }
 
-    function countCardsUsingUserLabel(labelId: any) {
+    function countCardsUsingUserLabel(labelId: string): number {
         const list = currentList();
         if (!list) return 0;
         let n = 0;
-        Object.values(list.items || {}).forEach((it: any) => {
+        Object.values(list.items || {}).forEach((it) => {
             if (Array.isArray(it.userLabelIds) && it.userLabelIds.includes(labelId)) n++;
         });
         return n;
     }
 
-    function addUserLabelDef(name: any, color: any) {
+    function addUserLabelDef(name: string, color: string): string | null {
         const list = ensureWritableList('addUserLabel') || currentList();
         if (!list) return null;
         ensureListUserLabels(list);
@@ -858,7 +861,7 @@
         return id;
     }
 
-    function updateUserLabelDef(labelId: any, name: any, color: any) {
+    function updateUserLabelDef(labelId: string, name: string, color: string) {
         const list = ensureWritableList('updateUserLabel') || currentList();
         if (!list?.userLabels?.[labelId]) return;
         list.userLabels[labelId].name = String(name || '').trim() || '라벨';
@@ -867,20 +870,20 @@
         saveState();
     }
 
-    function removeUserLabelDef(labelId: any) {
+    function removeUserLabelDef(labelId: string) {
         const list = ensureWritableList('removeUserLabel') || currentList();
         if (!list?.userLabels?.[labelId]) return;
         delete list.userLabels[labelId];
-        Object.values(list.items || {}).forEach((it: any) => {
+        Object.values(list.items || {}).forEach((it) => {
             if (!Array.isArray(it.userLabelIds)) return;
-            it.userLabelIds = it.userLabelIds.filter((x: any) => x !== labelId);
+            it.userLabelIds = it.userLabelIds.filter((x) => x !== labelId);
             if (!it.userLabelIds.length) delete it.userLabelIds;
         });
         touchInstance(list);
         saveState();
     }
 
-    function setItemUserLabelIds(itemId: any, ids: any) {
+    function setItemUserLabelIds(itemId: string, ids: string[]) {
         const list = ensureWritableList('setItemUserLabels') || currentList();
         if (!list?.items?.[itemId]) return;
         const it = list.items[itemId];
@@ -892,13 +895,13 @@
         saveState();
     }
 
-    function duplicateList(listId: any) {
+    function duplicateList(listId: string): string | null {
         closePublished();
         const src = state.instances[listId];
         if (!src) return null;
         const now = Date.now();
         const id = 'tl-' + uid();
-        const copied = JSON.parse(JSON.stringify(src));
+        const copied = JSON.parse(JSON.stringify(src)) as TlListInstance;
         copied.id = id;
         copied.title = (src.title || '티어리스트') + ' (복제)';
         copied.createdAt = now;
@@ -911,34 +914,34 @@
         return id;
     }
 
-    function deleteList(listId: any) {
+    function deleteList(listId: string) {
         closePublished();
         const l = state.instances[listId];
         if (!l) return;
         try {
-            Object.values(l.items || {}).forEach((it: any) => {
+            Object.values(l.items || {}).forEach((it) => {
                 if (it?.imageKey) TierDB.remove(it.imageKey);
             });
         } catch (_) {}
         delete state.instances[listId];
         if (state.currentInstanceId === listId) {
-            const next: any = Object.values(state.instances).sort((a: any, b: any) => (b.updatedAt || 0) - (a.updatedAt || 0))[0];
+            const next = Object.values(state.instances).sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))[0];
             state.currentInstanceId = next?.id || null;
         }
         saveState();
     }
 
-    function fileToDataUrl(file: any) {
-        return new Promise((res: any, rej: any) => {
+    function fileToDataUrl(file: File): Promise<string> {
+        return new Promise<string>((resolve, reject) => {
             const reader = new FileReader();
-            reader.onload = () => res(reader.result);
-            reader.onerror = () => rej(reader.error);
+            reader.onload = () => resolve(String(reader.result ?? ''));
+            reader.onerror = () => reject(reader.error);
             reader.readAsDataURL(file);
         });
     }
 
-    function createThumbnail(dataUrl: any, maxSize: any) {
-        return new Promise((res: any) => {
+    function createThumbnail(dataUrl: string, maxSize: number): Promise<string> {
+        return new Promise<string>((resolve) => {
             const img = new Image();
             img.onload = () => {
                 const canvas = document.createElement('canvas');
@@ -951,14 +954,14 @@
                 canvas.width = w;
                 canvas.height = h;
                 canvas.getContext('2d')!.drawImage(img, 0, 0, w, h);
-                res(canvas.toDataURL('image/webp', 0.85));
+                resolve(canvas.toDataURL('image/webp', 0.85));
             };
-            img.onerror = () => res(dataUrl);
+            img.onerror = () => resolve(dataUrl);
             img.src = dataUrl;
         });
     }
 
-    async function processImageFile(file: any) {
+    async function processImageFile(file: File): Promise<string> {
         const dataUrl = await fileToDataUrl(file);
         const thumb = await createThumbnail(dataUrl, 200);
         const imgKey = 'tl-img-' + uid();
@@ -997,7 +1000,7 @@
         removeItem,
         moveItem,
         applyTiers,
-        getDefaultTiers: () => DEFAULT_TIERS.map((t: any) => ({ ...t })),
+        getDefaultTiers: () => DEFAULT_TIERS.map((t) => ({ ...t })),
         promoteCatalogMissingToCustom,
         pruneStaleCatalogBindings,
         canResetItemFromPool,

--- a/apps/karmolab/src/widgets/tierlist/tierlist-types.ts
+++ b/apps/karmolab/src/widgets/tierlist/tierlist-types.ts
@@ -1,0 +1,250 @@
+/* Tierlist 위젯 공유 타입 정본 — TASK-KL-101 (KL-078 follow-up).
+ * 3 파일(storage / publish / render)이 `const T: any = window.Tierlist` 와 다수 `: any` 파라미터로
+ * 가지고 있던 type 누수를 제거. script-mode IIFE 파일이라 top-level interface 가 카르몰랩 컴파일
+ * 단위 안에서 전역으로 노출된다. */
+
+interface TlMetaBag {
+    source?: string;
+    publishedId?: string;
+    publishedUrl?: string;
+    catalogUrl?: string;
+    dirty?: boolean;
+    dirtyReason?: string;
+    [k: string]: unknown;
+}
+
+interface TlItem {
+    id: string;
+    name?: string;
+    imageKey?: string | null;
+    tlOrigin?: 'catalog' | 'custom';
+    tlEdited?: boolean;
+    userLabelIds?: string[];
+    [k: string]: unknown;
+}
+
+interface TlTierDef {
+    id: string;
+    label: string;
+    color: string;
+}
+
+interface TlUserLabelDef {
+    id: string;
+    name: string;
+    color: string;
+}
+
+/** 티어 id → 카드 id 배열. `_pool` 은 미배치 트레이. */
+type TlRankingMap = Record<string, string[]>;
+
+interface TlListInstance {
+    id: string;
+    title: string;
+    category?: string;
+    catalogId?: string;
+    createdAt: number;
+    updatedAt: number;
+    tiers: TlTierDef[];
+    rankings: TlRankingMap;
+    items: Record<string, TlItem>;
+    userLabels: Record<string, TlUserLabelDef>;
+    meta?: TlMetaBag;
+}
+
+interface TlCatalogInstance {
+    id: string;
+    title: string;
+    category?: string;
+    updatedAt: number;
+    items: Record<string, TlItem>;
+}
+
+interface TlPublishedMeta {
+    id?: string;
+    title?: string;
+    url?: string;
+    tierlistGroup?: string;
+    group?: string;
+    [k: string]: unknown;
+}
+
+/** state.openPublished 에 들어오는 raw data — catalog · slim instance · full list 모두 가능. */
+interface TlPublishedData {
+    kind?: string;
+    version?: number;
+    title?: string;
+    items?: Record<string, TlItem>;
+    images?: Record<string, string>;
+    list?: TlListInstance;
+    catalogRef?: { id?: string; url?: string };
+    itemOverrides?: Record<string, Partial<TlItem>>;
+    [k: string]: unknown;
+}
+
+interface TlPublishedCurrent {
+    meta: TlPublishedMeta;
+    data: TlPublishedData;
+}
+
+interface TlCurrentMetaView {
+    id: string;
+    title: string;
+    source: string;
+    dirty: boolean;
+    url: string;
+    catalogUrl: string;
+    tierlistGroup: string;
+}
+
+interface TlState {
+    catalogs: Record<string, TlCatalogInstance>;
+    instances: Record<string, TlListInstance>;
+    currentInstanceId: string | null;
+    datasets?: Record<string, { lists?: Record<string, TlListInstance> }>;
+    currentDatasetId?: string;
+    lists?: Record<string, TlListInstance>;
+    currentListId?: string;
+}
+
+interface TlPublishedIndexItem {
+    id?: string;
+    title?: string;
+    url?: string;
+    tierlistGroup?: string;
+    group?: string;
+    updatedAt?: string;
+    [k: string]: unknown;
+}
+
+interface TlDbAPI {
+    save: (id: string, dataUrl: string) => Promise<void>;
+    get: (id: string) => Promise<string | null>;
+    remove: (id: string) => Promise<void>;
+    getMany: (ids: string[]) => Promise<Record<string, string>>;
+}
+
+interface TlStateAPI {
+    uid: () => string;
+    loadState: () => void;
+    saveState: () => void;
+    getState: () => TlState;
+    isCatalogPayload: (data: unknown) => boolean;
+    iterAllInstances: () => Array<{ list: TlListInstance; catalogTitle: string | null }>;
+    currentList: () => TlListInstance | null;
+    currentMeta: () => TlCurrentMetaView;
+    isPublishedMode: () => boolean;
+    isPublishedCatalogMode: () => boolean;
+    getPublishedCatalogSnapshot: () => TlPublishedCurrent | null;
+    getPublishedEmbeddedImages: () => Record<string, string>;
+    openPublished: (meta: TlPublishedMeta | null | undefined, data: TlPublishedData) => void;
+    closePublished: () => void;
+    ensureWritableList: (reason: string) => TlListInstance | null;
+    forkInstanceFromCatalogData: (catalogData: TlPublishedData, meta: TlPublishedMeta | undefined) => TlListInstance;
+    switchToInstance: (instanceId: string) => void;
+    createCatalog: (title: string, category: string) => string;
+    deleteCatalog: (catalogId: string) => void;
+    addCatalogItem: (catalogId: string, name: string, imageKey: string | null) => string | null;
+    removeCatalogItem: (catalogId: string, itemId: string) => void;
+    createInstanceFromLocalCatalog: (catalogId: string) => string | null;
+    createList: (title: string, category: string) => string;
+    duplicateList: (listId: string) => string | null;
+    deleteList: (listId: string) => void;
+    addItem: (name: string, imageKey: string | null) => string | null;
+    removeItem: (itemId: string) => boolean;
+    moveItem: (itemId: string, targetTier: string, insertIdx: number | undefined) => boolean;
+    applyTiers: (list: TlListInstance, tiersInOrder: TlTierDef[]) => boolean;
+    getDefaultTiers: () => TlTierDef[];
+    promoteCatalogMissingToCustom: (list: TlListInstance, catalogItemIdSet: Set<string>) => boolean;
+    pruneStaleCatalogBindings: (list: TlListInstance, catalogItems: Record<string, TlItem>) => boolean;
+    canResetItemFromPool: (list: TlListInstance, itemId: string) => boolean;
+    applyCatalogEntryToItem: (list: TlListInstance, itemId: string, catalogEntry: TlItem) => boolean;
+    reconcileListWithCatalogPayload: (list: TlListInstance, catalogItems: Record<string, TlItem>) => boolean;
+    isItemRemovable: (list: TlListInstance, itemId: string) => boolean;
+    persistList: (list: TlListInstance | null) => void;
+    repairOrphanRankings: () => boolean;
+    repairDeleteItemsByIds: (itemIds: string[]) => number;
+    repairMarkStaleAsLocalItems: (itemIds: string[]) => number;
+    ensureListUserLabels: (list: TlListInstance | null) => void;
+    countCardsUsingUserLabel: (labelId: string) => number;
+    addUserLabelDef: (name: string, color: string) => string | null;
+    updateUserLabelDef: (labelId: string, name: string, color: string) => void;
+    removeUserLabelDef: (labelId: string) => void;
+    setItemUserLabelIds: (itemId: string, ids: string[]) => void;
+    processImageFile: (file: File) => Promise<string>;
+}
+
+interface TlPublishAPI {
+    getPublishedIndex: () => Promise<TlPublishedIndexItem[]>;
+    getPublishedJsonByUrl: (relUrl: string) => Promise<TlPublishedData>;
+    getPublishedPreviewCountLine: (relUrl: string) => Promise<string>;
+    openPublishedDirect: (relUrl: string, meta: TlPublishedMeta | null | undefined) => Promise<void>;
+    buildExportPayload: () => Promise<unknown>;
+    exportAsImage: () => Promise<void>;
+    showJsonPreview: () => Promise<void>;
+    forkPublishedCatalogToLocal: () => Promise<TlListInstance | null>;
+    importFromJSONFilePicker: () => Promise<void>;
+    syncInstanceItemOriginsWithCatalogIfNeeded: () => Promise<boolean>;
+    resetItemToCatalogDefault: (itemId: string) => Promise<boolean>;
+}
+
+interface TlRenderAPI {
+    setContainers: (c: {
+        editor?: HTMLElement | null;
+        list?: HTMLElement | null;
+        stats?: HTMLElement | null;
+    }) => void;
+    renderEditor: () => Promise<void>;
+    renderAll: () => Promise<void>;
+    renderListTab: () => void;
+    renderStats: () => void;
+    publishedIndexGroup: (it: TlPublishedIndexItem) => string;
+}
+
+interface TlUiAPI {
+    showContextMenu: (
+        x: number,
+        y: number,
+        actions: Array<{ label: string; danger?: boolean; action: () => void } | 'sep'>
+    ) => void;
+    hideContextMenu: () => void;
+    openDialog: (opts: {
+        title: string;
+        bodyHtml?: string;
+        wide?: boolean;
+        onMount?: (api: { overlay: HTMLDivElement; dialog: HTMLDivElement; close: () => void }) => void;
+    }) => { overlay: HTMLDivElement; dialog: HTMLDivElement; close: () => void };
+}
+
+interface TlDndAPI {
+    initDnD: (
+        root: HTMLElement,
+        opts: {
+            onDrop?: (payload: { itemId: string; tierId: string | undefined; insertIdx: number }) => void;
+            shouldBlockDragStart?: (e: PointerEvent) => boolean;
+        }
+    ) => void;
+}
+
+interface TlDialogsAPI {
+    showAddItemDialog?: () => void;
+    showEditItemDialog?: (itemId: string) => void;
+    showNewListDialog?: () => void;
+    showNewCatalogDialog?: () => void;
+    showAddCatalogItemDialog?: (catalogId: string) => void;
+    showTierSettingsDialog?: () => void;
+    showUserLabelsManagerDialog?: () => void;
+    showAssignUserLabelsDialog?: (itemId: string) => void;
+}
+
+/** namespace.ts 부트스트랩 이후 — index.ts 진입 시점엔 모든 sub-API 가 채워져 있다고 본다. */
+interface TierlistNamespace {
+    injectStyles?: () => void;
+    db: TlDbAPI;
+    state: TlStateAPI;
+    publish: TlPublishAPI;
+    render: TlRenderAPI;
+    ui: TlUiAPI;
+    dnd: TlDndAPI;
+    dialogs: TlDialogsAPI;
+}

--- a/apps/karmolab/types/global.d.ts
+++ b/apps/karmolab/types/global.d.ts
@@ -209,7 +209,9 @@ declare global {
     escapeHtml?: (s: string) => string;
     formatTimestamp?: (ts: number | string | Date) => string;
     getToolMeta?: (id: string) => Record<string, unknown> | undefined;
-    switchPage?: (id: string) => void;
+    switchPage?: (id: string, opts?: { pushHistory?: boolean }) => void;
+    /** btn === 'string' → tabId 로 해석해 selector 로 해당 tab-btn 자동 매칭 (toolbox.ts:948). */
+    switchTab?: (btnOrTabId: HTMLElement | string, tabId?: string) => void;
     getNavLayout?: () => string;
     setNavLayout?: (v: string) => void;
     getTheme?: () => string;


### PR DESCRIPTION
## Summary

KL-078 follow-up. `@ts-nocheck` 일괄 제거(#138) 이후 잔존하던 tierlist 3 파일의 `const T: any = window.Tierlist` IIFE 패턴 + 콜백/state/IDB 파라미터 `: any` (총 ~211 건) 을 단일 `TierlistNamespace` 인터페이스로 정리.

- **신설**: `apps/karmolab/src/widgets/tierlist/tierlist-types.ts` — `TlItem`/`TlListInstance`/`TlCatalogInstance`/`TlState`/`TlPublishedData`/`TlPublishedCurrent`/`TlPublishedIndexItem` 등 데이터 타입 + `TlDbAPI`/`TlStateAPI`/`TlPublishAPI`/`TlRenderAPI`/`TlUiAPI`/`TlDndAPI`/`TlDialogsAPI` 통합 → `TierlistNamespace`. script-mode 컴파일 단위 안에서 전역 노출.
- **storage.ts** (이전 115 any): IDB 콜백 `new Promise<void>((resolve, reject) => …)` 로 타입 파라미터 명시. `IDBOpenDBRequest.result` 직참조로 `onupgradeneeded(e: any)` 제거. cache `Map<string, string>`. state `TlState`.
- **publish.ts** (이전 37 any): `publishedIndexCache: TlPublishedIndexItem[]` / `publishedJsonCache: Map<string, TlPublishedData>`. html2canvas 동적 로드 `(window as any).html2canvas` → 좁은 인터페이스 캐스트.
- **render.ts** (이전 58 any): `editorContainer/listContainer/statsContainer: HTMLElement | null`. event 핸들러 Event/MouseEvent 좁히기. **`(Toolbox.switchTab as any)` 제거** — `toolbox.ts:948` `tabId` 를 optional (`tabId?`) 로 만들어 1-arg 호출 허용 + `global.d.ts` 의 `Toolbox` 타입에 `switchTab` + 2-arg `switchPage` 시그니처 추가.

## 완료 조건 (TASK 스펙 vs 현재)

- [x] `window.Tierlist` 단일 `TierlistNamespace` 인터페이스로 — `tierlist-types.ts` 정본
- [x] 파라미터/변수 `: any` → 인터페이스 정의 후 교체 — 3 파일 0 건
- [x] IDB 콜백 타입: `new Promise<T>((resolve, reject) => ...)` 로 타입 파라미터 활용
- [x] `setContainers({ editor, list, stats }: any)` → `{ editor?: HTMLElement | null; list?: HTMLElement | null; stats?: HTMLElement | null }`
- [x] `Toolbox.switchTab as any` 제거 — toolbox 측 `tabId?` + global.d.ts `switchTab` 시그니처
- [x] `npx tsc --noEmit` (apps/karmolab) — tierlist 영역 0 error
- [x] `npm run verify` — 통과

## Test plan

- [x] `npm run typecheck` (apps/karmolab) — tierlist 영역 0 error. 베이스 25 → 20 (영역 외 pre-existing red 5건은 `packages/karmolab-ai/dist` 빌드 후 자연 해소)
- [x] `npm run verify` (master invariant) — 통과
- [ ] 런타임 스모크 (수동): tierlist 위젯 편집 탭 — 카드 추가/삭제/드래그·드롭, 후보 풀 fork, JSON export/import, 사이트 published 카탈로그 열람
- [ ] 런타임 스모크 (수동): tierlist 위젯 목록 탭 — 로컬·카탈로그·Karmo 카드 컨텍스트 메뉴
- [ ] 런타임 스모크 (수동): tierlist 위젯 통계 탭

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 탭 전환 기능 개선으로 더 유연한 탭 조작 지원
  * 페이지 전환 시 히스토리 관리 옵션 추가

* **Improvements**
  * 퍼블리시드 콘텐츠 관리 및 내보내기/가져오기 안정성 강화
  * 사용자 인터페이스 오류 처리 및 메시지 표시 개선
  * 데이터 동기화 및 복구 기능 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->