### PR TITLE
fix(TASK-KL-103): chatbot.ts tsc 오류 5건 정리

### DIFF
--- a/apps/karmolab/src/widgets/chatbot/chatbot.ts
+++ b/apps/karmolab/src/widgets/chatbot/chatbot.ts
@@ -509,7 +509,7 @@ import {
                 safetySel.innerHTML = levels
                     .map(level => `<option value="${level.value}">${Toolbox.escapeHtml(level.label)}</option>`)
                     .join('');
-                const savedSafety = Toolbox.getPref('cb_safety_threshold') || defaultThreshold;
+                const savedSafety = Toolbox.getPref('cb_safety_threshold', '') || defaultThreshold;
                 safetySel.value = savedSafety;
                 if (!safetySel.value && levels.length > 0) safetySel.value = defaultThreshold;
                 safetySel.addEventListener('change', () => {
@@ -950,8 +950,8 @@ import {
             const modelId = modelSel?.value || (Gemini as any).getDefaultModel('gemini');
             const tempInput = (document.getElementById('cbTemperature') as any);
             const temperature = tempInput ? parseFloat(tempInput.value) : 0.8;
-            const safetyInput = document.getElementById('cbSafetyThreshold');
-            const safetyThreshold = safetyInput?.value || Gemini.DEFAULT_GEMINI_SAFETY_THRESHOLD;
+            const safetyInput = document.getElementById('cbSafetyThreshold') as HTMLInputElement | null;
+            const safetyThreshold = safetyInput?.value || Gemini?.DEFAULT_GEMINI_SAFETY_THRESHOLD;
 
             const streamEl = appendStreamMsg() as any;
             currentStreamAbort = new AbortController();
@@ -1071,8 +1071,8 @@ import {
             const modelId = modelSel?.value || (Gemini as any).getDefaultModel('gemini');
             const tempInput = (document.getElementById('cbTemperature') as any);
             const temperature = tempInput ? parseFloat(tempInput.value) : 0.8;
-            const safetyInput = document.getElementById('cbSafetyThreshold');
-            const safetyThreshold = safetyInput?.value || Gemini.DEFAULT_GEMINI_SAFETY_THRESHOLD;
+            const safetyInput = document.getElementById('cbSafetyThreshold') as HTMLInputElement | null;
+            const safetyThreshold = safetyInput?.value || Gemini?.DEFAULT_GEMINI_SAFETY_THRESHOLD;
 
             const streamEl = appendStreamMsg() as any;
             currentStreamAbort = new AbortController();


### PR DESCRIPTION
## Summary

`apps/karmolab/src/widgets/chatbot/chatbot.ts` 의 `tsc --noEmit` 오류 5건 (quality-loop 자동 감지, 2026-06-08) 정리.

- **line 512** TS2554 — `Toolbox.getPref('cb_safety_threshold')` → `Toolbox.getPref('cb_safety_threshold', '')`. `global.d.ts` 의 `Toolbox.getPref?: (key, fallback?) => string` 는 fallback 을 optional 로 선언했으나, `src/toolbox.ts` 의 IIFE return 이 같은 전역 식별자를 가리는 동시에 내부 `function getPref(key, fallback)` 의 두 인자가 implicit-any 필수 파라미터로 추론되어 2-arg 강제. 다른 callsite (line 435/456/470/499/926/1058) 가 이미 `(key, '')` 형식이라 동일 패턴으로 정렬.
- **line 953, 1074** TS2339 — `document.getElementById('cbSafetyThreshold')` 반환값을 `HTMLInputElement | null` 로 캐스트해 `.value` 접근 narrow.
- **line 954, 1075** TS18048 — `Gemini.DEFAULT_GEMINI_SAFETY_THRESHOLD` → `Gemini?.DEFAULT_GEMINI_SAFETY_THRESHOLD`. `global.d.ts` 의 `var Gemini: undefined | {...}` 가드 누락 — line 506 의 `typeof Gemini !== 'undefined'` 좁힘은 다른 callback scope 라 940/1060 함수 영역까지 전파되지 않음.

## Test plan

- [x] `cd apps/karmolab && npx tsc --noEmit` 에서 `chatbot.ts` 관련 오류 0건 (나머지 오류는 `karmolab-ai` 모듈 미해결 등 본 TASK 범위 밖)
- [x] `node scripts/verify.mjs` (= `npm run verify`) 통과 — `packages/karmolab-ai` build / Tauri ACL audit / Server Monitor audit / typos 모두 통과 (Rust toolchain·blog node_modules·yawnbot 은 환경 부재 skip — CI 가 정본 게이트)
- [ ] 런타임 검증 (브라우저에서 chatbot 위젯의 cbSafetyThreshold select 동작) — 본 PR 의 변경은 타입 좁히기·optional chaining 한정으로 런타임 동작 변화 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 채팅봇의 안전 필터 기본값 처리 개선으로 일관성 강화
  * 메시지 전송 및 재생성 시 안전 임계값 적용 로직 개선
  * 안전 필터 초기화 시 기본값 폴백 메커니즘 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->