### PR TITLE
refactor(TASK-KL-105): gemini.ts `: any`/`as any` 74건 제거 — 도메인 인터페이스 + GeminiResponseBody

### DIFF
--- a/apps/karmolab/src/gemini.ts
+++ b/apps/karmolab/src/gemini.ts
@@ -28,7 +28,129 @@ import {
   buildGeminiSafetySettings,
   DOC_URL_AI_STUDIO_API_KEY,
   DOC_URL_VERTEX_API_KEYS,
+  type ModelProvider,
 } from 'karmolab-ai';
+
+/* ===== 내부 타입 (Gemini IIFE 와 ImageDB IIFE 공용) ===== */
+interface ApiKeyProfile {
+    id: string;
+    name: string;
+    key: string;
+}
+
+interface ApiKeyStore {
+    activeId: string;
+    profiles: ApiKeyProfile[];
+}
+
+interface VertexChatContext {
+    projectId: string;
+    location: string;
+}
+
+interface VertexChatContextOptions {
+    projectId?: string | null;
+    location?: string | null;
+}
+
+interface ApiHistoryEntry {
+    type: string;
+    ts?: string;
+    url?: string;
+    method?: string;
+    requestBody?: unknown;
+    responseBody?: unknown;
+    status?: number;
+}
+
+interface GeminiPart {
+    text?: string;
+    inlineData?: { mimeType?: string; data: string };
+    [key: string]: unknown;
+}
+
+interface GeminiContent {
+    role?: string;
+    parts?: GeminiPart[];
+    [key: string]: unknown;
+}
+
+interface GeminiCandidate {
+    content?: GeminiContent;
+    finishReason?: string;
+    [key: string]: unknown;
+}
+
+interface GeminiUsageMetadata {
+    totalTokenCount?: number;
+    [key: string]: unknown;
+}
+
+interface GeminiResponseBody {
+    candidates?: GeminiCandidate[];
+    usageMetadata?: GeminiUsageMetadata;
+    error?: { message?: string; status?: string; [key: string]: unknown };
+    predictions?: Array<Record<string, unknown>>;
+    [key: string]: unknown;
+}
+
+interface GeminiRequestBody {
+    contents?: GeminiContent[];
+    systemInstruction?: { parts?: GeminiPart[] };
+    generationConfig?: Record<string, unknown>;
+    safetySettings?: Array<{ category: string; threshold: string }>;
+    tools?: Array<Record<string, unknown>>;
+    instances?: Array<Record<string, unknown>>;
+    parameters?: Record<string, unknown>;
+    [key: string]: unknown;
+}
+
+interface GeminiChatOptions {
+    temperature?: number;
+    maxTokens?: number;
+    safetyThreshold?: string;
+    webSearch?: boolean;
+    signal?: AbortSignal;
+}
+
+interface VertexChatOptions extends GeminiChatOptions, VertexChatContextOptions {}
+
+interface GeminiImageOptions {
+    signal?: AbortSignal;
+    aspectRatio?: string;
+    safetyThreshold?: string;
+    referenceImage?: string;
+    referenceMimeType?: string;
+}
+
+interface VertexGeminiImageOptions extends GeminiImageOptions {
+    projectId?: string;
+    location?: string;
+}
+
+interface ImagenOptions {
+    signal?: AbortSignal;
+    aspectRatio?: string;
+    safetyFilterLevel?: string;
+    negativePrompt?: string;
+    personGeneration?: string;
+}
+
+interface VertexImagenOptions extends ImagenOptions {
+    projectId?: string;
+    location?: string;
+}
+
+interface ImagenPrediction {
+    bytesBase64Encoded?: string;
+    structValue?: {
+        fields?: {
+            bytesBase64Encoded?: { stringValue?: string };
+            [key: string]: unknown;
+        };
+    };
+    [key: string]: unknown;
+}
 
 const Gemini = (() => {
     const STORAGE_KEY = 'toolbox_gemini_api_key'; // legacy single-key
@@ -37,26 +159,29 @@ const Gemini = (() => {
     const VERTEX_API_KEY_STORAGE = 'toolbox_vertex_api_key';
 
     /* ===== API 키 관리 (다중 프로필) ===== */
-    function getKeyStore() {
+    function getKeyStore(): ApiKeyStore {
         // 1) 최신 구조: { activeId, profiles: [{id,name,key}] }
         try {
-            const parsed = JSON.parse(localStorage.getItem(KEYS_STORE_KEY) || 'null');
+            const parsed: unknown = JSON.parse(localStorage.getItem(KEYS_STORE_KEY) || 'null');
             if (parsed && typeof parsed === 'object') {
-                if (Array.isArray(parsed.profiles)) {
-                    if (!parsed.profiles.length) {
-                        parsed.profiles.push({ id: 'default', name: '기본', key: '' });
+                const obj = parsed as Record<string, unknown>;
+                if (Array.isArray(obj.profiles)) {
+                    const profiles = obj.profiles as ApiKeyProfile[];
+                    if (!profiles.length) {
+                        profiles.push({ id: 'default', name: '기본', key: '' });
                     }
-                    parsed.activeId = parsed.activeId || parsed.profiles[0].id;
-                    return parsed;
+                    const activeId = (typeof obj.activeId === 'string' && obj.activeId) || profiles[0].id;
+                    return { activeId, profiles };
                 }
                 // 2) 구버전 v2: { active: 'free'|'paid', keys: { free, paid } }
-                if (parsed.keys) {
-                    const profiles = [];
-                    if (parsed.keys.free) profiles.push({ id: 'free', name: '무료', key: parsed.keys.free });
-                    if (parsed.keys.paid) profiles.push({ id: 'paid', name: '유료', key: parsed.keys.paid });
+                const keys = obj.keys as { free?: string; paid?: string } | undefined;
+                if (keys) {
+                    const profiles: ApiKeyProfile[] = [];
+                    if (keys.free) profiles.push({ id: 'free', name: '무료', key: keys.free });
+                    if (keys.paid) profiles.push({ id: 'paid', name: '유료', key: keys.paid });
                     if (!profiles.length) profiles.push({ id: 'default', name: '기본', key: '' });
-                    const activeId = profiles.find(p => p.id === parsed.active)?.id || profiles[0].id;
-                    const migrated = { activeId, profiles };
+                    const activeId = profiles.find(p => p.id === obj.active)?.id || profiles[0].id;
+                    const migrated: ApiKeyStore = { activeId, profiles };
                     localStorage.setItem(KEYS_STORE_KEY, JSON.stringify(migrated));
                     return migrated;
                 }
@@ -65,49 +190,49 @@ const Gemini = (() => {
 
         // 3) 더 구버전: STORAGE_KEY 단일 키
         const legacy = localStorage.getItem(STORAGE_KEY) || '';
-        const baseProfile = legacy
+        const baseProfile: ApiKeyProfile = legacy
             ? { id: 'default', name: '기본', key: legacy }
             : { id: 'default', name: '기본', key: '' };
-        const store = { activeId: baseProfile.id, profiles: [baseProfile] };
+        const store: ApiKeyStore = { activeId: baseProfile.id, profiles: [baseProfile] };
         localStorage.setItem(KEYS_STORE_KEY, JSON.stringify(store));
         return store;
     }
 
-    function saveKeyStore(store: any) {
+    function saveKeyStore(store: ApiKeyStore) {
         localStorage.setItem(KEYS_STORE_KEY, JSON.stringify(store));
     }
 
-    function getProfiles() {
+    function getProfiles(): ApiKeyProfile[] {
         const store = getKeyStore();
         return store.profiles || [];
     }
 
-    function getActiveProfileId() {
+    function getActiveProfileId(): string {
         const store = getKeyStore();
         return store.activeId;
     }
 
-    function setActiveProfileId(id: any) {
+    function setActiveProfileId(id: string) {
         const store = getKeyStore();
-        if (!store.profiles?.some((p: any) => p.id === id)) return;
+        if (!store.profiles?.some(p => p.id === id)) return;
         store.activeId = id;
         saveKeyStore(store);
     }
 
-    function getActiveProfileName() {
+    function getActiveProfileName(): string {
         const store = getKeyStore();
-        const p = store.profiles?.find((p: any) => p.id === store.activeId);
+        const p = store.profiles?.find(p => p.id === store.activeId);
         return p ? p.name : '';
     }
 
-    function getApiKey(id: any = null) {
+    function getApiKey(id: string | null = null): string {
         const store = getKeyStore();
         const pid = id || store.activeId;
-        const p = store.profiles?.find((p: any) => p.id === pid);
+        const p = store.profiles?.find(p => p.id === pid);
         return p ? (p.key || '') : '';
     }
 
-    function setApiKey(key: any, id: any = null, nameOverride?: any) {
+    function setApiKey(key: string, id: string | null = null, nameOverride?: string) {
         const store = getKeyStore();
         let pid = id || store.activeId;
         if (!pid) {
@@ -116,7 +241,7 @@ const Gemini = (() => {
             store.profiles.push({ id: pid, name: nameOverride || '프로필', key: '' });
             store.activeId = pid;
         }
-        const idx = (store.profiles || []).findIndex((p: any) => p.id === pid);
+        const idx = (store.profiles || []).findIndex(p => p.id === pid);
         if (idx >= 0) {
             store.profiles[idx].key = key;
             if (nameOverride) store.profiles[idx].name = nameOverride;
@@ -143,7 +268,7 @@ const Gemini = (() => {
         }
     }
 
-    function setVertexApiKey(key: any) {
+    function setVertexApiKey(key: string) {
         try {
             if (key) localStorage.setItem(VERTEX_API_KEY_STORAGE, key);
             else localStorage.removeItem(VERTEX_API_KEY_STORAGE);
@@ -161,7 +286,7 @@ const Gemini = (() => {
     }
 
     /* ===== 기본 모델 (catalog: karmolab-ai) ===== */
-    function getDefaultModel(provider: any = 'gemini') {
+    function getDefaultModel(provider: ModelProvider = 'gemini'): string {
         return getDefaultModelId(provider);
     }
 
@@ -169,7 +294,7 @@ const Gemini = (() => {
     const VERTEX_CHAT_PROJECT_PREF = 'ig_vertex_project_id';
     const VERTEX_CHAT_LOCATION_PREF = 'ig_vertex_location';
 
-    function getVertexChatContext(options: any = {}) {
+    function getVertexChatContext(options: VertexChatContextOptions = {}): VertexChatContext {
         const projectId = String(
             options.projectId != null ? options.projectId : Toolbox.getPref?.(VERTEX_CHAT_PROJECT_PREF, '') || ''
         ).trim();
@@ -180,58 +305,64 @@ const Gemini = (() => {
     }
 
     /* ===== API 요청/응답 히스토리 (디버깅용, 메모리만) ===== */
-    const apiHistory: any[] = [];
+    const apiHistory: ApiHistoryEntry[] = [];
     const API_HISTORY_MAX = 20;
 
-    function recordApiCall(entry: any) {
-        const copy: any = { ...entry, ts: new Date().toISOString() };
+    function recordApiCall(entry: ApiHistoryEntry) {
+        const copy: ApiHistoryEntry = { ...entry, ts: new Date().toISOString() };
         if (copy.requestBody && typeof copy.requestBody === 'object') {
             try {
-                copy.requestBody = JSON.parse(JSON.stringify(copy.requestBody));
-                copy.requestBody.contents?.forEach((c: any) => {
-                    c.parts?.forEach((p: any) => {
+                const reqClone = JSON.parse(JSON.stringify(copy.requestBody)) as GeminiRequestBody;
+                reqClone.contents?.forEach((c) => {
+                    c.parts?.forEach((p) => {
                         if (p.inlineData?.data) {
                             const len = String(p.inlineData.data).length;
                             p.inlineData.data = `[base64 ${len} chars]`;
                         }
                     });
                 });
+                copy.requestBody = reqClone;
             } catch (_) {}
         }
-        if (copy.responseBody && copy.responseBody.candidates) {
-            copy.responseBody = JSON.parse(JSON.stringify(copy.responseBody));
-            copy.responseBody.candidates?.forEach((c: any) => {
-                c.content?.parts?.forEach((p: any) => {
+        const respBody = copy.responseBody as GeminiResponseBody | undefined;
+        if (respBody && respBody.candidates) {
+            const respClone = JSON.parse(JSON.stringify(respBody)) as GeminiResponseBody;
+            respClone.candidates?.forEach((c) => {
+                c.content?.parts?.forEach((p) => {
                     if (p.inlineData?.data) p.inlineData.data = `[base64 ${p.inlineData.data.length} chars]`;
                 });
             });
+            copy.responseBody = respClone;
         }
-        if (copy.responseBody?.predictions) {
-            copy.responseBody = JSON.parse(JSON.stringify(copy.responseBody));
-            copy.responseBody.predictions?.forEach((p: any) => {
-                if (p.bytesBase64Encoded) p.bytesBase64Encoded = `[base64 ${p.bytesBase64Encoded.length} chars]`;
+        const respBody2 = copy.responseBody as GeminiResponseBody | undefined;
+        if (respBody2?.predictions) {
+            const respClone = JSON.parse(JSON.stringify(respBody2)) as GeminiResponseBody;
+            respClone.predictions?.forEach((p) => {
+                const pred = p as ImagenPrediction;
+                if (pred.bytesBase64Encoded) pred.bytesBase64Encoded = `[base64 ${pred.bytesBase64Encoded.length} chars]`;
             });
+            copy.responseBody = respClone;
         }
         if (copy.url) copy.url = maskUrl(copy.url);
         apiHistory.unshift(copy);
         if (apiHistory.length > API_HISTORY_MAX) apiHistory.pop();
     }
 
-    function getApiHistory() { return [...apiHistory]; }
+    function getApiHistory(): ApiHistoryEntry[] { return [...apiHistory]; }
     function clearApiHistory() { apiHistory.length = 0; }
 
-    function applySafetySettings(body, threshold) {
+    function applySafetySettings(body: GeminiRequestBody, threshold: string | undefined) {
         const safetySettings = buildGeminiSafetySettings(threshold);
         if (safetySettings.length > 0) body.safetySettings = safetySettings;
     }
 
     /* ===== HTTP 헬퍼 ===== */
-    function maskKey(key: any) {
+    function maskKey(key: string): string {
         if (!key || key.length < 8) return '••••';
         return key.slice(0, 6) + '...' + key.slice(-4);
     }
 
-    function maskUrl(url: any) {
+    function maskUrl(url: string): string {
         try {
             const u = new URL(url);
             const k = u.searchParams.get('key');
@@ -240,9 +371,9 @@ const Gemini = (() => {
         } catch (_) { return url.replace(/key=[^&]+/, 'key=••••'); }
     }
 
-    async function fetchWithRetry(url: any, body: any, options: any = {}) {
+    async function fetchWithRetry(url: string, body: unknown, options: RequestInit = {}): Promise<Response> {
         try {
-            const fetchOpts: any = {
+            const fetchOpts: RequestInit = {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(body)
@@ -252,10 +383,10 @@ const Gemini = (() => {
 
             if (!response.ok) {
                 let errorDetails = '상세 정보 없음';
-                let fullError = null;
+                let fullError: GeminiResponseBody | null = null;
                 try {
-                    fullError = await response.json();
-                    errorDetails = fullError.error?.message || JSON.stringify(fullError);
+                    fullError = await response.json() as GeminiResponseBody;
+                    errorDetails = fullError?.error?.message || JSON.stringify(fullError);
                 } catch (e) {
                     errorDetails = await response.text();
                 }
@@ -283,49 +414,51 @@ const Gemini = (() => {
             }
 
             return response;
-        } catch (e: any) {
-            if (e.name === 'AbortError') throw new Error('요청이 취소되었습니다.');
-            if (e.message.includes('Failed to fetch') || e.message.includes('NetworkError')) {
-                throw new Error('네트워크 연결 오류. 인터넷 연결을 확인해주세요.');
+        } catch (e: unknown) {
+            if (e instanceof Error) {
+                if (e.name === 'AbortError') throw new Error('요청이 취소되었습니다.');
+                if (e.message.includes('Failed to fetch') || e.message.includes('NetworkError')) {
+                    throw new Error('네트워크 연결 오류. 인터넷 연결을 확인해주세요.');
+                }
             }
             throw e;
         }
     }
 
     /* ===== 텍스트 생성 ===== */
-    async function callText(userText: any, systemPrompt: any, modelId: any) {
+    async function callText(userText: string, systemPrompt: string, modelId: string | undefined) {
         const key = requireApiKey();
         if (!key) return null;
 
         const model = modelId || getDefaultModel('gemini');
         const url = buildAiStudioGenerateContentUrl(model, key);
-        const body = {
+        const body: GeminiRequestBody = {
             contents: [{ parts: [{ text: userText }] }],
             systemInstruction: { parts: [{ text: systemPrompt }] },
             generationConfig: { maxOutputTokens: 8192 }
         };
 
         const res = await fetchWithRetry(url, body);
-        const data = await res.json();
+        const data = await res.json() as GeminiResponseBody;
 
         if (!data.candidates || !data.candidates[0]) {
             throw new Error('응답에 결과가 없습니다: ' + JSON.stringify(data));
         }
 
         return {
-            text: data.candidates[0].content.parts[0].text,
+            text: data.candidates[0].content?.parts?.[0]?.text ?? '',
             usage: data.usageMetadata
         };
     }
 
     /* ===== 챗 (멀티턴) ===== */
-    async function callChat(history: any, systemPrompt: any, modelId: any, options: any = {}) {
+    async function callChat(history: GeminiContent[], systemPrompt: string, modelId: string | undefined, options: GeminiChatOptions = {}) {
         const key = requireApiKey();
         if (!key) return null;
 
         const model = modelId || getDefaultModel('gemini');
         const url = buildAiStudioGenerateContentUrl(model, key);
-        const body: any = {
+        const body: GeminiRequestBody = {
             contents: history,
             systemInstruction: { parts: [{ text: systemPrompt }] },
             generationConfig: {
@@ -340,26 +473,26 @@ const Gemini = (() => {
         }
 
         const res = await fetchWithRetry(url, body);
-        const data = await res.json();
+        const data = await res.json() as GeminiResponseBody;
 
         if (!data.candidates || !data.candidates[0]?.content) {
             throw new Error('응답에 결과가 없습니다.');
         }
 
         return {
-            text: data.candidates[0].content.parts[0].text,
+            text: data.candidates[0].content?.parts?.[0]?.text ?? '',
             usage: data.usageMetadata
         };
     }
 
     /* ===== 챗 스트리밍 ===== */
-    async function callChatStream(history: any, systemPrompt: any, modelId: any, options: any = {}) {
+    async function callChatStream(history: GeminiContent[], systemPrompt: string, modelId: string | undefined, options: GeminiChatOptions = {}) {
         const key = requireApiKey();
         if (!key) return null;
 
         const model = modelId || getDefaultModel('gemini');
         const url = buildAiStudioStreamGenerateContentUrl(model, key);
-        const body: any = {
+        const body: GeminiRequestBody = {
             contents: history,
             systemInstruction: { parts: [{ text: systemPrompt }] },
             generationConfig: {
@@ -370,7 +503,7 @@ const Gemini = (() => {
         applySafetySettings(body, options.safetyThreshold);
         if (options.webSearch) body.tools = [{ googleSearch: {} }];
 
-        const fetchOpts: any = {
+        const fetchOpts: RequestInit = {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body)
@@ -380,13 +513,14 @@ const Gemini = (() => {
         const response = await fetch(url, fetchOpts);
         if (!response.ok) {
             let msg = `[HTTP ${response.status}]`;
-            try { const e: any = await response.json(); msg += ' ' + (e.error?.message || JSON.stringify(e)); } catch (_) {}
+            try { const e = await response.json() as GeminiResponseBody; msg += ' ' + (e.error?.message || JSON.stringify(e)); } catch (_) {}
             throw new Error(msg);
         }
 
         return {
             async *chunks() {
-                const reader = (response.body as any).getReader();
+                const reader = response.body?.getReader();
+                if (!reader) return;
                 const decoder = new TextDecoder();
                 let buffer = '';
                 while (true) {
@@ -400,7 +534,7 @@ const Gemini = (() => {
                         const jsonStr = line.slice(6).trim();
                         if (!jsonStr || jsonStr === '[DONE]') continue;
                         try {
-                            const parsed = JSON.parse(jsonStr);
+                            const parsed = JSON.parse(jsonStr) as GeminiResponseBody;
                             const text = parsed.candidates?.[0]?.content?.parts?.[0]?.text;
                             if (text) yield { text, usage: parsed.usageMetadata || null };
                         } catch (_) {}
@@ -411,7 +545,7 @@ const Gemini = (() => {
     }
 
     /* ===== Vertex — 텍스트 / 채팅 / 스트리밍 (generateContent·streamGenerateContent) ===== */
-    async function callVertexText(userText: any, systemPrompt: any, modelId: any, options: any = {}) {
+    async function callVertexText(userText: string, systemPrompt: string, modelId: string | undefined, options: VertexChatOptions = {}) {
         const key = requireVertexApiKey();
         if (!key) return null;
 
@@ -428,14 +562,14 @@ const Gemini = (() => {
             method: 'generateContent',
             apiKey: key,
         });
-        const body = {
+        const body: GeminiRequestBody = {
             contents: [{ parts: [{ text: userText }] }],
             systemInstruction: { parts: [{ text: systemPrompt }] },
             generationConfig: { maxOutputTokens: 8192 },
         };
 
         const res = await fetchWithRetry(url, body, { signal: options.signal });
-        const data = await res.json();
+        const data = await res.json() as GeminiResponseBody;
 
         if (data.error) {
             throw new Error(data.error.message || data.error.status || 'Vertex API 오류');
@@ -445,12 +579,12 @@ const Gemini = (() => {
         }
 
         return {
-            text: data.candidates[0].content.parts[0].text,
+            text: data.candidates[0].content?.parts?.[0]?.text ?? '',
             usage: data.usageMetadata,
         };
     }
 
-    async function callVertexChat(history: any, systemPrompt: any, modelId: any, options: any = {}) {
+    async function callVertexChat(history: GeminiContent[], systemPrompt: string, modelId: string | undefined, options: VertexChatOptions = {}) {
         const key = requireVertexApiKey();
         if (!key) return null;
 
@@ -467,7 +601,7 @@ const Gemini = (() => {
             method: 'generateContent',
             apiKey: key,
         });
-        const body = {
+        const body: GeminiRequestBody = {
             contents: history,
             systemInstruction: { parts: [{ text: systemPrompt }] },
             generationConfig: {
@@ -478,7 +612,7 @@ const Gemini = (() => {
         applySafetySettings(body, options.safetyThreshold);
 
         const res = await fetchWithRetry(url, body, { signal: options.signal });
-        const data = await res.json();
+        const data = await res.json() as GeminiResponseBody;
 
         if (data.error) {
             throw new Error(data.error.message || data.error.status || 'Vertex API 오류');
@@ -488,12 +622,12 @@ const Gemini = (() => {
         }
 
         return {
-            text: data.candidates[0].content.parts[0].text,
+            text: data.candidates[0].content?.parts?.[0]?.text ?? '',
             usage: data.usageMetadata,
         };
     }
 
-    async function callVertexChatStream(history: any, systemPrompt: any, modelId: any, options: any = {}) {
+    async function callVertexChatStream(history: GeminiContent[], systemPrompt: string, modelId: string | undefined, options: VertexChatOptions = {}) {
         const key = requireVertexApiKey();
         if (!key) return null;
 
@@ -510,7 +644,7 @@ const Gemini = (() => {
             method: 'streamGenerateContent',
             apiKey: key,
         });
-        const body: any = {
+        const body: GeminiRequestBody = {
             contents: history,
             systemInstruction: { parts: [{ text: systemPrompt }] },
             generationConfig: {
@@ -520,7 +654,7 @@ const Gemini = (() => {
         };
         applySafetySettings(body, options.safetyThreshold);
 
-        const fetchOpts: any = {
+        const fetchOpts: RequestInit = {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body),
@@ -531,7 +665,7 @@ const Gemini = (() => {
         if (!response.ok) {
             let msg = `[HTTP ${response.status}]`;
             try {
-                const e: any = await response.json();
+                const e = await response.json() as GeminiResponseBody;
                 msg += ' ' + (e.error?.message || JSON.stringify(e));
             } catch (_) {}
             throw new Error(msg);
@@ -539,7 +673,8 @@ const Gemini = (() => {
 
         return {
             async *chunks() {
-                const reader = (response.body as any).getReader();
+                const reader = response.body?.getReader();
+                if (!reader) return;
                 const decoder = new TextDecoder();
                 let buffer = '';
                 while (true) {
@@ -553,7 +688,7 @@ const Gemini = (() => {
                         const jsonStr = line.slice(6).trim();
                         if (!jsonStr || jsonStr === '[DONE]') continue;
                         try {
-                            const parsed = JSON.parse(jsonStr);
+                            const parsed = JSON.parse(jsonStr) as GeminiResponseBody;
                             const text = parsed.candidates?.[0]?.content?.parts?.[0]?.text;
                             if (text) yield { text, usage: parsed.usageMetadata || null };
                         } catch (_) {}
@@ -571,14 +706,14 @@ const Gemini = (() => {
      * - referenceImage: data URL 또는 순수 base64(편집·업스케일 등 입력 이미지)
      * - referenceMimeType: 기본 image/png
      */
-    async function callGeminiImage(prompt: any, modelId: any, options: any = {}) {
+    async function callGeminiImage(prompt: string, modelId: string | undefined, options: GeminiImageOptions = {}) {
         const key = requireApiKey();
         if (!key) throw new Error('API 키가 설정되지 않았습니다.');
 
         const model = modelId || getDefaultModel('geminiImage');
         const url = buildAiStudioGenerateContentUrl(model, key);
 
-        const genConfig: any = {
+        const genConfig: Record<string, unknown> = {
             maxOutputTokens: 8192,
             responseModalities: ['TEXT', 'IMAGE']
         };
@@ -586,7 +721,7 @@ const Gemini = (() => {
             genConfig.imageConfig = { aspectRatio: options.aspectRatio };
         }
 
-        const parts: any[] = [{ text: prompt }];
+        const parts: GeminiPart[] = [{ text: prompt }];
         if (options.referenceImage) {
             let b64 = options.referenceImage;
             if (typeof b64 === 'string' && b64.includes(',')) b64 = b64.split(',')[1];
@@ -600,7 +735,7 @@ const Gemini = (() => {
         }
 
         const threshold = options.safetyThreshold || 'BLOCK_ONLY_HIGH';
-        const body = {
+        const body: GeminiRequestBody = {
             contents: [{ parts }],
             generationConfig: genConfig,
             safetySettings: [
@@ -613,7 +748,7 @@ const Gemini = (() => {
         };
 
         const res = await fetchWithRetry(url, body, { signal: options.signal });
-        const data = await res.json();
+        const data = await res.json() as GeminiResponseBody;
 
         recordApiCall({
             type: 'geminiImage',
@@ -640,9 +775,9 @@ const Gemini = (() => {
             throw new Error(`이미지 데이터가 없습니다. (finishReason: ${reason})`);
         }
 
-        const imageData = cand.content.parts.find((p: any) => p.inlineData);
-        if (!imageData) {
-            const hasText = cand.content.parts.some((p: any) => p.text);
+        const imageData = cand.content.parts.find(p => p.inlineData);
+        if (!imageData?.inlineData) {
+            const hasText = cand.content.parts.some(p => p.text);
             throw new Error(hasText
                 ? '이미지 대신 텍스트만 반환되었습니다. 이 모델은 이미지 생성이 제한되거나, 프롬프트/안전 필터로 인해 이미지가 생성되지 않았을 수 있습니다.'
                 : '이미지를 찾을 수 없습니다.');
@@ -661,7 +796,7 @@ const Gemini = (() => {
      * - 엔드포인트: https://aiplatform.googleapis.com/v1/publishers/google/models/${model}:generateContent?key=...
      * - Imagen 이미지는 callVertexImagen(:predict) 사용.
      */
-    async function callVertexGeminiImage(prompt: any, modelId: any, options: any = {}) {
+    async function callVertexGeminiImage(prompt: string, modelId: string | undefined, options: VertexGeminiImageOptions = {}) {
         const key = requireVertexApiKey();
         if (!key) throw new Error('Vertex API 키가 설정되지 않았습니다.');
 
@@ -680,7 +815,7 @@ const Gemini = (() => {
             apiKey: key,
         });
 
-        const genConfig: any = {
+        const genConfig: Record<string, unknown> = {
             maxOutputTokens: 8192,
             responseModalities: ['TEXT', 'IMAGE']
         };
@@ -688,7 +823,7 @@ const Gemini = (() => {
             genConfig.imageConfig = { aspectRatio: options.aspectRatio };
         }
 
-        const parts: any[] = [{ text: prompt }];
+        const parts: GeminiPart[] = [{ text: prompt }];
         if (options.referenceImage) {
             let b64 = options.referenceImage;
             if (typeof b64 === 'string' && b64.includes(',')) b64 = b64.split(',')[1];
@@ -702,7 +837,7 @@ const Gemini = (() => {
         }
 
         const threshold = options.safetyThreshold || 'BLOCK_ONLY_HIGH';
-        const body = {
+        const body: GeminiRequestBody = {
             contents: [{ parts }],
             generationConfig: genConfig,
             safetySettings: [
@@ -715,7 +850,7 @@ const Gemini = (() => {
         };
 
         const res = await fetchWithRetry(url, body, { signal: options.signal });
-        const data = await res.json();
+        const data = await res.json() as GeminiResponseBody;
 
         recordApiCall({
             type: 'vertexGeminiImage',
@@ -742,9 +877,9 @@ const Gemini = (() => {
             throw new Error(`이미지 데이터가 없습니다. (finishReason: ${reason})`);
         }
 
-        const imageData = cand.content.parts.find((p: any) => p.inlineData);
-        if (!imageData) {
-            const hasText = cand.content.parts.some((p: any) => p.text);
+        const imageData = cand.content.parts.find(p => p.inlineData);
+        if (!imageData?.inlineData) {
+            const hasText = cand.content.parts.some(p => p.text);
             throw new Error(hasText
                 ? '이미지 대신 텍스트만 반환되었습니다. 이 모델은 이미지 생성이 제한되거나, 프롬프트/안전 필터로 인해 이미지가 생성되지 않았을 수 있습니다.'
                 : '이미지를 찾을 수 없습니다.');
@@ -764,25 +899,25 @@ const Gemini = (() => {
      * - negativePrompt: 제외할 요소 텍스트
      * - personGeneration: 'allow_adult'(기본) | 'allow_all' | 'dont_allow'
      */
-    async function callImagen(prompt: any, modelId: any, count: any = 1, options: any = {}) {
+    async function callImagen(prompt: string, modelId: string | undefined, count: number = 1, options: ImagenOptions = {}): Promise<string[]> {
         const key = requireApiKey();
         if (!key) throw new Error('API 키가 설정되지 않았습니다.');
 
         const model = modelId || getDefaultModel('imagen');
         const url = buildAiStudioPredictUrl(model, key);
 
-        const params: any = { sampleCount: count };
+        const params: Record<string, unknown> = { sampleCount: count };
         if (options.aspectRatio) params.aspectRatio = options.aspectRatio;
         if (options.safetyFilterLevel) params.safetyFilterLevel = options.safetyFilterLevel;
         if (options.personGeneration) params.personGeneration = options.personGeneration;
 
-        const instance: any = { prompt };
+        const instance: Record<string, unknown> = { prompt };
         if (options.negativePrompt) instance.negativePrompt = options.negativePrompt;
 
-        const body = { instances: [instance], parameters: params };
+        const body: GeminiRequestBody = { instances: [instance], parameters: params };
 
         const res = await fetchWithRetry(url, body, { signal: options.signal });
-        const data = await res.json();
+        const data = await res.json() as GeminiResponseBody;
 
         recordApiCall({
             type: 'imagen',
@@ -797,14 +932,15 @@ const Gemini = (() => {
             throw new Error('이미지 생성 결과가 없습니다.');
         }
 
-        return data.predictions.map((p: any) => {
-            if (!p.bytesBase64Encoded) throw new Error('base64 이미지 데이터 없음');
-            return `data:image/png;base64,${p.bytesBase64Encoded}`;
+        return data.predictions.map((p) => {
+            const pred = p as ImagenPrediction;
+            if (!pred.bytesBase64Encoded) throw new Error('base64 이미지 데이터 없음');
+            return `data:image/png;base64,${pred.bytesBase64Encoded}`;
         });
     }
 
     /** Vertex predict 응답의 이미지 base64 추출 (JSON 또는 protobuf Struct JSON) */
-    function extractImagenPredictionBase64(p: any) {
+    function extractImagenPredictionBase64(p: ImagenPrediction | null | undefined): string | null {
         if (!p) return null;
         if (p.bytesBase64Encoded) return p.bytesBase64Encoded;
         const fields = p.structValue?.fields;
@@ -818,7 +954,7 @@ const Gemini = (() => {
      * - 엔드포인트: https://{location}-aiplatform.googleapis.com/v1/projects/.../models/...:predict?key=...
      * options: { signal, projectId, location, aspectRatio, safetyFilterLevel, negativePrompt, personGeneration }
      */
-    async function callVertexImagen(prompt: any, modelId: any, count: any = 1, options: any = {}) {
+    async function callVertexImagen(prompt: string, modelId: string | undefined, count: number = 1, options: VertexImagenOptions = {}): Promise<string[]> {
         const key = requireVertexApiKey();
         if (!key) throw new Error('Vertex API 키가 설정되지 않았습니다.');
 
@@ -838,18 +974,18 @@ const Gemini = (() => {
             apiKey: key,
         });
 
-        const params: any = { sampleCount: count };
+        const params: Record<string, unknown> = { sampleCount: count };
         if (options.aspectRatio) params.aspectRatio = options.aspectRatio;
         if (options.safetyFilterLevel) params.safetyFilterLevel = options.safetyFilterLevel;
         if (options.personGeneration) params.personGeneration = options.personGeneration;
 
-        const instance: any = { prompt };
+        const instance: Record<string, unknown> = { prompt };
         if (options.negativePrompt) instance.negativePrompt = options.negativePrompt;
 
-        const body = { instances: [instance], parameters: params };
+        const body: GeminiRequestBody = { instances: [instance], parameters: params };
 
         const res = await fetchWithRetry(url, body, { signal: options.signal });
-        const data = await res.json();
+        const data = await res.json() as GeminiResponseBody;
 
         recordApiCall({
             type: 'vertexImagen',
@@ -868,15 +1004,15 @@ const Gemini = (() => {
             throw new Error('이미지 생성 결과가 없습니다.');
         }
 
-        return data.predictions.map((p: any) => {
-            const b64 = extractImagenPredictionBase64(p);
+        return data.predictions.map((p) => {
+            const b64 = extractImagenPredictionBase64(p as ImagenPrediction);
             if (!b64) throw new Error('base64 이미지 데이터 없음 (필터 차단 또는 응답 형식 불일치)');
             return `data:image/png;base64,${b64}`;
         });
     }
 
     /* ===== 공통 API 키 UI 빌더 (프로필 리스트) ===== */
-    function buildApiKeyUI(idPrefix: any) {
+    function buildApiKeyUI(idPrefix: string) {
         const store = getKeyStore();
         const profiles = store.profiles || [];
         const activeId = store.activeId;
@@ -924,12 +1060,12 @@ const Gemini = (() => {
             </div>`;
         return {
             html,
-            init(container: any) {
-                const root = container || document;
-                const listEl = root.querySelector ? root.querySelector(`#${idPrefix}ApiProfileList`) : document.getElementById(`${idPrefix}ApiProfileList`);
-                const addBtn = root.querySelector ? root.querySelector(`#${idPrefix}ApiAdd`) : document.getElementById(`${idPrefix}ApiAdd`);
+            init(container?: HTMLElement | Document | null) {
+                const root: HTMLElement | Document = container || document;
+                const listEl = root.querySelector(`#${idPrefix}ApiProfileList`);
+                const addBtn = root.querySelector(`#${idPrefix}ApiAdd`);
 
-                const vertexStatusEl = root.querySelector(`#${idPrefix}VertexKeyStatus`);
+                const vertexStatusEl = root.querySelector(`#${idPrefix}VertexKeyStatus`) as HTMLElement | null;
                 const vertexEditBtn = root.querySelector(`#${idPrefix}VertexKeyEdit`);
                 const vertexClearBtn = root.querySelector(`#${idPrefix}VertexKeyClear`);
                 const vertexProjectEl = root.querySelector(`#${idPrefix}VertexProjectId`);
@@ -961,7 +1097,7 @@ const Gemini = (() => {
                     const profiles = store.profiles || [];
                     const activeId = store.activeId;
                     if (!listEl) return;
-                    listEl.innerHTML = profiles.map((p: any) => {
+                    listEl.innerHTML = profiles.map((p) => {
                         const hasKey = !!p.key;
                         return `
                             <div class="api-prof-row" data-id="${p.id}" style="display:flex;align-items:center;gap:6px;padding:4px 6px;border:1px solid var(--border);border-radius:6px;background:${p.id === activeId ? 'var(--accent-subtle)' : 'transparent'};">
@@ -1039,22 +1175,24 @@ const Gemini = (() => {
                 }
 
                 if (listEl) {
-                    listEl.addEventListener('input', (e: any) => {
+                    listEl.addEventListener('input', (e: Event) => {
                         const target = e.target;
                         if (!(target instanceof HTMLInputElement) || !target.classList.contains('api-prof-name')) return;
                         const row = target.closest('.api-prof-row');
                         const id = row?.getAttribute('data-id');
                         if (!id) return;
                         const store = getKeyStore();
-                        const idx = (store.profiles || []).findIndex((p: any) => p.id === id);
+                        const idx = (store.profiles || []).findIndex(p => p.id === id);
                         if (idx >= 0) {
                             store.profiles[idx].name = target.value.trim() || '프로필';
                             saveKeyStore(store);
                         }
                     });
 
-                    listEl.addEventListener('click', (e: any) => {
-                        const btn = e.target.closest('button');
+                    listEl.addEventListener('click', (e: Event) => {
+                        const target = e.target;
+                        if (!(target instanceof Element)) return;
+                        const btn = target.closest('button');
                         if (!btn) return;
                         const role = btn.getAttribute('data-role');
                         const row = btn.closest('.api-prof-row');
@@ -1062,7 +1200,7 @@ const Gemini = (() => {
                         if (!id) return;
                         const store = getKeyStore();
                         const profiles = store.profiles || [];
-                        const idx = profiles.findIndex((p: any) => p.id === id);
+                        const idx = profiles.findIndex(p => p.id === id);
                         if (idx < 0) return;
 
                         if (role === 'active') {
@@ -1114,7 +1252,7 @@ const Gemini = (() => {
     }
 
     /* ===== 프롬프트 향상 ===== */
-    async function enhancePrompt(originalPrompt: any) {
+    async function enhancePrompt(originalPrompt: string) {
         const systemPrompt = `You are a prompt enhancement expert for AI image generation.
 Improve the given prompt to produce higher quality, more detailed, and more visually striking images.
 Keep the same subject and intent, but add details about lighting, composition, art style, colors, and atmosphere.
@@ -1150,11 +1288,11 @@ const ImageDB = (() => {
     const STORE_NAME = 'images';
     const DB_VERSION = 1;
 
-    function open() {
+    function open(): Promise<IDBDatabase> {
         return new Promise((resolve, reject) => {
             const req = indexedDB.open(DB_NAME, DB_VERSION);
-            req.onupgradeneeded = (e: any) => {
-                const db = e.target.result;
+            req.onupgradeneeded = (e: IDBVersionChangeEvent) => {
+                const db = (e.target as IDBOpenDBRequest).result;
                 if (!db.objectStoreNames.contains(STORE_NAME)) {
                     const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
                     store.createIndex('timestamp', 'timestamp', { unique: false });
@@ -1165,12 +1303,12 @@ const ImageDB = (() => {
         });
     }
 
-    function notify(action: any, detail?: any) {
+    function notify(action: string, detail?: Record<string, unknown>) {
         window.dispatchEvent(new CustomEvent('imagedb-change', { detail: { action, ...detail } }));
     }
 
-    async function save(item: any) {
-        const db: any = await open();
+    async function save(item: ImageDBItem) {
+        const db = await open();
         try {
             await new Promise<void>((resolve, reject) => {
                 const tx = db.transaction(STORE_NAME, 'readwrite');
@@ -1182,20 +1320,20 @@ const ImageDB = (() => {
         } finally { db.close(); }
     }
 
-    async function getAll() {
-        const db: any = await open();
+    async function getAll(): Promise<ImageDBItem[]> {
+        const db = await open();
         try {
-            return await new Promise((resolve, reject) => {
+            return await new Promise<ImageDBItem[]>((resolve, reject) => {
                 const tx = db.transaction(STORE_NAME, 'readonly');
                 const req = tx.objectStore(STORE_NAME).index('timestamp').getAll();
-                req.onsuccess = () => resolve(req.result.reverse());
+                req.onsuccess = () => resolve((req.result as ImageDBItem[]).reverse());
                 req.onerror = () => reject(req.error);
             });
         } finally { db.close(); }
     }
 
-    async function remove(id: any) {
-        const db: any = await open();
+    async function remove(id: string) {
+        const db = await open();
         try {
             await new Promise<void>((resolve, reject) => {
                 const tx = db.transaction(STORE_NAME, 'readwrite');
@@ -1208,7 +1346,7 @@ const ImageDB = (() => {
     }
 
     async function clear() {
-        const db: any = await open();
+        const db = await open();
         try {
             await new Promise<void>((resolve, reject) => {
                 const tx = db.transaction(STORE_NAME, 'readwrite');


### PR DESCRIPTION
- ApiKeyProfile / ApiKeyStore / VertexChatContext / ApiHistoryEntry / GeminiContent / GeminiResponseBody / GeminiRequestBody / *Options 인터페이스 IIFE 외부 정의
- fetchWithRetry 시그니처: (url: string, body: unknown, options?: RequestInit) => Promise<Response> (스펙)
- catch (e: any) → catch (e: unknown) + instanceof Error 가드
- 키 관리 함수 파라미터 (getApiKey/setApiKey/setActiveProfileId 등) string 타입화
- callText/callChat/callChatStream/callVertex* 파라미터 string + GeminiContent[] + GeminiChatOptions/VertexChatOptions
- callGeminiImage/callImagen/callVertex* — GeminiImageOptions/ImagenOptions/Vertex*
- recordApiCall 내부 구조체 — GeminiRequestBody/GeminiResponseBody 좁히기
- ImageDB IIFE — IDBDatabase/IDBOpenDBRequest 표준 타입, ImageDBItem 사용
- getDefaultModel(provider: ModelProvider = 'gemini') — karmolab-ai 의 ModelProvider type 재사용

apps/karmolab tsc --noEmit: gemini.ts 오류 0건 (baseline 2건 제거: applySafetySettings 암시적 any).
잔존 18건은 모두 사전존재(imageedit.ts Gemini.getApiKey 등 — global.d.ts 면 누락 / 별건 TASK).
npm run verify (master invariant) 통과 — karmolab build + acl audit + servermonitor + app origin 정상.

KL-104 (chatbot.ts) 동일 패턴.

Co-authored-by: Claude Agent <claude@anthropic.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  - 다중 프로필 API 키 관리 기능 추가로 여러 계정 전환 가능

* **개선 사항**
  - 네트워크 오류 및 재시도 로직 개선
  - API 요청/응답 히스토리 추적 강화
  - 이미지 생성 안정성 및 오류 처리 향상
  - 민감 정보(키, 토큰, URL) 로그 마스킹으로 보안 강화
  - 전체 시스템 안정성 및 신뢰성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->