### PR TITLE
fix(TASK-KL-102): Gemini global 선언에 getApiKey·requireApiKey·fetchWithRetry 추가

### DIFF
--- a/apps/karmolab/types/global.d.ts
+++ b/apps/karmolab/types/global.d.ts
@@ -140,8 +140,11 @@ declare global {
           count: number,
           options?: Record<string, unknown>
         ) => Promise<string[]>;
+        getApiKey: (id?: string | null) => string;
+        requireApiKey: () => string | null;
+        fetchWithRetry: (url: string, body: unknown, options?: RequestInit) => Promise<Response>;
         /** `packages/karmolab-ai` MODEL_CATALOG 재노출 — `Gemini.MODELS.gemini` 등으로 위젯이 사용 */
-        MODELS?: GeminiModelsCatalog;
+        MODELS: GeminiModelsCatalog;
         GEMINI_SAFETY_LEVELS?: Array<{ value: string; label: string }>;
         DEFAULT_GEMINI_SAFETY_THRESHOLD?: string;
       };


### PR DESCRIPTION
## 요약

- `apps/karmolab/types/global.d.ts` 의 `var Gemini` 선언에 누락 메서드 3개 추가
- `MODELS?` → `MODELS` 필수화 (gemini.ts 가 항상 내보내므로 안전)

## 변경 내용

| 추가 항목 | 타입 |
|---|---|
| `getApiKey` | `(id?: string \| null) => string` |
| `requireApiKey` | `() => string \| null` |
| `fetchWithRetry` | `(url: string, body: unknown, options?: RequestInit) => Promise<Response>` |
| `MODELS` | `GeminiModelsCatalog` (optional 제거) |

## 배경

TASK-KL-102 — `imageedit.ts` 에서 `Gemini!.getApiKey`, `Gemini!.requireApiKey`, `Gemini!.fetchWithRetry`, `Gemini!.MODELS.geminiImage` 를 사용하나 `global.d.ts` 미선언으로 `tsc --noEmit` 12건 오류 발생. KL-102 는 `done` 마킹됐지만 실제 fix 가 누락된 status drift.

## 검증

- [x] `npm run typecheck` (apps/karmolab) 0 오류
- [x] `npm run verify` 통과 (cargo check + ACL audit + SM audit 포함)

TASK-KL-102

---
_Generated by [Claude Code](https://claude.ai/code/session_01AecQ5gtxu8HMPuY1qWUqEN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Gemini API 키 관리 메서드 추가
  * 재시도 로직이 포함된 데이터 조회 기능 추가

* **개선 사항**
  * Gemini 모델 카탈로그 필수 구성 요소로 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->