### PR TITLE
fix(TASK-KL-115): imageedit.ts (globalThis as any).ImageDB → ImageDB! 직접 접근

### DIFF
--- a/apps/karmolab/src/widgets/imageedit.ts
+++ b/apps/karmolab/src/widgets/imageedit.ts
@@ -3410,7 +3410,7 @@
         if (!requireImage()) return;
         try {
             const dataUrl = canvas.toDataURL('image/png');
-            await (globalThis as any).ImageDB.save({
+            await ImageDB!.save({
                 id: 'edit_' + Date.now() + '_' + Math.random().toString(36).slice(2, 6),
                 url: dataUrl,
                 prompt: '(이미지 편집)',
@@ -4160,7 +4160,7 @@
         d.classList.add('open');
         const grid = document.getElementById('ieLibGrid');
         grid!.innerHTML = '<div class="ie-lib-empty">로딩 중...</div>';
-        (globalThis as any).ImageDB.getAll().then((items: any) => {
+        ImageDB!.getAll().then((items: any) => {
             if (items.length === 0) {
                 grid!.innerHTML = '<div class="ie-lib-empty">라이브러리가 비어 있습니다.</div>';
                 return;


### PR DESCRIPTION
## 변경 내용

TASK-KL-106 sub-task D — `imageedit.ts` GlobalThis ImageDB `as any` 제거.

### 수정 내용

- `(globalThis as any).ImageDB.save({...})` → `ImageDB!.save({...})` (line ~3414)
- `(globalThis as any).ImageDB.getAll().then(...)` → `ImageDB!.getAll().then(...)` (line ~4164)

### 이미 완료된 부분

- `global.d.ts`: `var ImageDB: ImageDBAPI | undefined` — 이미 선언됨 (기존재)
- EXIF 태그 딕셔너리 `(tags as any)[0x...]` ~20건 — TASK-KL-113 에서 완료

## 검증

- `apps/karmolab && npm run build` ✅

TASK-ID: TASK-KL-115

---
_Generated by [Claude Code](https://claude.ai/code/session_015iDwy8LevLs7saTqxw9PpQ)_