### PR TITLE
ci: agent-team-graduate.yml workflow_dispatch + batch_graduate (draft·ready 모두 지원)

### DIFF
--- a/.github/workflows/agent-team-graduate.yml
+++ b/.github/workflows/agent-team-graduate.yml
@@ -30,6 +30,9 @@ on:
   workflow_run:
     workflows: ["verify", "Claude Code"]
     types: [completed]
+  workflow_dispatch:
+    # 수동 일괄 졸업 — graduate 비활성화 기간 쌓인 Draft PR 복구용.
+    # 활성화 후 GitHub UI: Actions → Agent Team Graduate → Run workflow
 
 permissions:
   contents: write
@@ -38,7 +41,7 @@ permissions:
 jobs:
   graduate:
     # pull_request 발 run 만 (push 발 verify 는 PR 무관) — 노이즈 축소.
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       # 로컬 composite action 사용 위해 checkout (workflow_run = 기본브랜치 master 체크아웃).
@@ -94,3 +97,55 @@ jobs:
           echo "PR #$num: verify green + 화이트리스트 prefix Draft → 졸업 (ready + squash merge)"
           gh pr ready "$num"
           gh pr merge "$num" --squash --delete-branch
+
+  batch_graduate:
+    # workflow_dispatch 수동 일괄 졸업 — 화이트리스트 prefix Draft PR 중 verify green 전부 처리.
+    # graduate 비활성화 기간 쌓인 PR 복구 등 수동 실행 시 사용.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve merge token (App → PAT fallback)
+        id: tok
+        uses: ./.github/actions/resolve-merge-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          pat: ${{ secrets.PAT_FOR_AUTO_MERGE }}
+
+      - name: Batch graduate all eligible Draft PRs
+        env:
+          GH_TOKEN: ${{ steps.tok.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          gh pr list --state open \
+            --json number,isDraft,headRefName,headRefOid \
+            --jq '[.[] | select(.isDraft==true and (.headRefName | test("^(feature/agent-team-|fix/issue-|feature/issue-)"))))]' \
+            > /tmp/prs.json
+
+          count=$(jq 'length' /tmp/prs.json)
+          echo "화이트리스트 prefix Draft PR ${count}개 검사"
+
+          if [ "$count" -eq 0 ]; then
+            echo "졸업 대상 Draft PR 없음"; exit 0
+          fi
+
+          for i in $(seq 0 $((count - 1))); do
+            num=$(jq -r ".[$i].number" /tmp/prs.json)
+            headRef=$(jq -r ".[$i].headRefName" /tmp/prs.json)
+            headOid=$(jq -r ".[$i].headRefOid" /tmp/prs.json)
+
+            verify_ok=$(gh api "repos/${GH_REPO}/commits/${headOid}/check-runs" --paginate \
+              --jq '[.check_runs[] | select(.name=="verify (master invariant)" and .conclusion=="success")] | length')
+            if [ "${verify_ok:-0}" -lt 1 ]; then
+              echo "PR #$num ($headRef) — verify green 아님, skip"
+              continue
+            fi
+
+            echo "PR #$num ($headRef): verify green → 졸업 (ready + squash merge)"
+            gh pr ready "$num"
+            gh pr merge "$num" --squash --delete-branch
+          done

--- a/.github/workflows/agent-team-graduate.yml
+++ b/.github/workflows/agent-team-graduate.yml
@@ -99,8 +99,9 @@ jobs:
           gh pr merge "$num" --squash --delete-branch
 
   batch_graduate:
-    # workflow_dispatch 수동 일괄 졸업 — 화이트리스트 prefix Draft PR 중 verify green 전부 처리.
+    # workflow_dispatch 수동 일괄 졸업 — 화이트리스트 prefix PR(draft·ready 모두) 중 verify green 전부 처리.
     # graduate 비활성화 기간 쌓인 PR 복구 등 수동 실행 시 사용.
+    # draft=false(ready) PR 도 포함: auto-merge.yml 비활성화 기간 중 ready 전환됐으나 머지 안 된 PR 구제.
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
@@ -114,29 +115,32 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           pat: ${{ secrets.PAT_FOR_AUTO_MERGE }}
 
-      - name: Batch graduate all eligible Draft PRs
+      - name: Batch graduate all eligible PRs (draft + ready)
         env:
           GH_TOKEN: ${{ steps.tok.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
+          # draft·ready 가리지 않고 화이트리스트 prefix 전부 수집.
+          # isDraft==true 만 선택하면 auto-merge 비활성화 기간 중 ready 전환된 PR 을 놓침.
           gh pr list --state open \
             --json number,isDraft,headRefName,headRefOid \
-            --jq '[.[] | select(.isDraft==true and (.headRefName | test("^(feature/agent-team-|fix/issue-|feature/issue-)"))))]' \
+            --jq '[.[] | select(.headRefName | test("^(feature/agent-team-|fix/issue-|feature/issue-)"))]' \
             > /tmp/prs.json
 
           count=$(jq 'length' /tmp/prs.json)
-          echo "화이트리스트 prefix Draft PR ${count}개 검사"
+          echo "화이트리스트 prefix PR ${count}개 검사 (draft+ready 포함)"
 
           if [ "$count" -eq 0 ]; then
-            echo "졸업 대상 Draft PR 없음"; exit 0
+            echo "졸업 대상 PR 없음"; exit 0
           fi
 
           for i in $(seq 0 $((count - 1))); do
             num=$(jq -r ".[$i].number" /tmp/prs.json)
             headRef=$(jq -r ".[$i].headRefName" /tmp/prs.json)
             headOid=$(jq -r ".[$i].headRefOid" /tmp/prs.json)
+            isDraft=$(jq -r ".[$i].isDraft" /tmp/prs.json)
 
             verify_ok=$(gh api "repos/${GH_REPO}/commits/${headOid}/check-runs" --paginate \
               --jq '[.check_runs[] | select(.name=="verify (master invariant)" and .conclusion=="success")] | length')
@@ -146,6 +150,9 @@ jobs:
             fi
 
             echo "PR #$num ($headRef): verify green → 졸업 (ready + squash merge)"
-            gh pr ready "$num"
+            # draft 인 경우만 ready 전환 (ready PR 에 gh pr ready 호출 시 에러 방지).
+            if [ "$isDraft" = "true" ]; then
+              gh pr ready "$num"
+            fi
             gh pr merge "$num" --squash --delete-branch
           done


### PR DESCRIPTION
## 요약

`agent-team-graduate.yml` 에 `workflow_dispatch` 트리거 + `batch_graduate` job 추가 및 버그 수정.

**목적**: graduate 워크플로 비활성화 기간(June 15~) 동안 쌓인 PR 복구 수단.  
재활성화 후 GitHub UI에서 한 번 실행으로 전부 졸업.

## 변경 내용

### Commit 1 (원본)
- `workflow_dispatch` 트리거 추가 (Actions UI → Agent Team Graduate → Run workflow)
- `batch_graduate` job: 화이트리스트 prefix Draft PR + verify green → ready + squash merge
- 기존 `graduate` job: `github.event_name == 'workflow_run'` 조건 명시 (이중 실행 방지)

### Commit 2 (버그 수정 — 2026-06-27)
**버그**: 원본 `batch_graduate`의 jq filter가 `isDraft==true` 만 선택 →  
`auto-merge.yml` 비활성화 기간 중 ready 전환됐으나 머지 안 된 PR(현재 #186~#196 전부 해당)을 누락.

**수정**:
- jq filter: `isDraft==true and ...` → `.headRefName | test(화이트리스트)` (draft·ready 모두 수집)
- draft인 경우만 `gh pr ready` 호출 (이미 ready인 PR에 중복 호출 시 에러 방지)

## 복구 절차 (issue #192)

1. **[PR#193 수동 머지](https://github.com/mascari4615/mascari4615.github.io/pull/193)** — squash merge
2. **[Actions → Agent Team Graduate → Enable workflow](https://github.com/mascari4615/mascari4615.github.io/actions/workflows/agent-team-graduate.yml)**
3. **Actions → Agent Team Graduate → Run workflow** → PR #186~#196 일괄 졸업

## Test plan

- [x] verify CI pass
- [x] `batch_graduate` jq filter: draft·ready 모두 포함 확인
- [x] `gh pr ready` 조건부 호출 (draft 시만)
- [ ] 실제 workflow_dispatch 실행으로 적층 PR 일괄 졸업

---
*autopilot cloud-kl — 2026-06-27 (batch_graduate 버그 수정)*