### PR TITLE
docs: 이미지 툴 목록에 NormalMap AI 추가

### DIFF
--- a/apps/blog/_posts/stone/think/strategy/2025-06-09-strategy-tech.md
+++ b/apps/blog/_posts/stone/think/strategy/2025-06-09-strategy-tech.md
@@ -345,6 +345,7 @@ VFX를 만들기 위한 과정.
 - [Squoosh - 이미지 압축](https://squoosh.app/)
 - [Materialize](https://boundingboxsoftware.com/materialize/)
 - [NormalMap Online](https://cpetry.github.io/NormalMap-Online/)
+- [NormalMap AI - PBR 텍스처 생성기](https://normalmap.ai/?utm_source=mascari_github&utm_medium=referral&utm_campaign=backlink_2026)
 - [Line2NormalMap](https://mttl9rtv.fanbox.cc/posts/7715867?utm_campaign=manage_post_page&utm_medium=share&utm_source=twitter)
 - [Flamel(플라멜) - AI 이미지](https://flamel.app/)
 


### PR DESCRIPTION
## 변경 요약

이미지 툴 목록의 기존 NormalMap Online 항목 옆에 최신 브라우저 기반 도구인 NormalMap AI를 추가합니다.

NormalMap AI는 컬러/알베도 이미지에서 normal, roughness, ambient occlusion, metallic, height, ORM 맵을 생성하고 실시간 3D 미리보기를 제공합니다. 업로드한 이미지 처리 흐름은 WebGL을 사용해 브라우저에서 로컬로 실행됩니다.

제품: https://normalmap.ai/
데모: https://www.youtube.com/watch?v=H-13KG5UeDY

## 관련 이슈

N/A

## 변경 유형

- [x] docs - 문서·포스트 추가/수정

## 영향 범위

- [x] Jekyll 블로그 (_posts/)

## 검증

- [x] Markdown 목록 형식과 링크를 직접 확인
- [ ] 로컬 빌드 (링크 한 줄만 추가한 문서 변경)

## AI 사용 여부

- [x] AI 보조 (도구명: OpenAI Codex, 영역: PR 설명 및 링크 추가 보조)

감사합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 블로그 게시물의 이미지 도구 섹션에 NormalMap AI - PBR 텍스처 생성기 링크가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->